### PR TITLE
Refactor/cleanup unused params

### DIFF
--- a/examples/params/cinema_vp.py
+++ b/examples/params/cinema_vp.py
@@ -16,6 +16,7 @@ class Dynamics:
         self.t_inds = -3          # Time Index in State
         self.fuel_inds = -2       # Fuel Index in State
         self.y_inds = -1          # Constraint Violation Index in State
+        self.s_inds = -1          # Time dilation index in Control
 
         self.max_state = np.array([ 200,  100,  50,  100,  100,  100,  1,  1,  1,  1,  10,  10,  10,  40, 2000, 1E-8])  # Upper Bound on the states
         self.min_state = np.array([-100, -100, -10, -100, -100, -100, -1, -1, -1, -1, -10, -10, -10,   0,   0,     0])  # Lower Bound on the states

--- a/examples/params/dr_vp.py
+++ b/examples/params/dr_vp.py
@@ -16,6 +16,7 @@ class Dynamics:
     def __init__(self):
         self.t_inds = -2          # Time Index in State
         self.y_inds = -1          # Constraint Violation Index in State
+        self.s_inds = -1          # Time dilation index in Control
 
         self.max_state=np.array([200, 100, 50, 100, 100, 100, 1, 1, 1, 1, 10, 10, 10, 100, 1e-4])  # Upper Bound on the states
         self.min_state=np.array([-200, -100, 15, -100, -100, -100, -1, -1, -1, -1, -10, -10, -10, 0, 0])  # Lower Bound on the states

--- a/examples/params/dr_vp_polytope.py
+++ b/examples/params/dr_vp_polytope.py
@@ -17,6 +17,7 @@ class Dynamics:
     def __init__(self):
         self.t_inds = -2          # Time Index in State
         self.y_inds = -1          # Constraint Violation Index in State
+        self.s_inds = -1          # Time dilation index in Control
         
         self.max_state=np.array([200, 100, 50, 100, 100, 100, 1, 1, 1, 1, 10, 10, 10, 100, 1e-4])  # Upper Bound on the states
         self.min_state=np.array([-200, -100, 15, -100, -100, -100, -1, -1, -1, -1, -10, -10, -10, 0, 0])  # Lower Bound on the states

--- a/examples/params/drone_racing.py
+++ b/examples/params/drone_racing.py
@@ -15,6 +15,7 @@ class Dynamics:
     def __init__(self):
         self.t_inds = -2          # Time Index in State
         self.y_inds = -1          # Constraint Violation Index in State
+        self.s_inds = -1          # Time dilation index in Control
 
         self.max_state=np.array([200, 100, 50, 100, 100, 100, 1, 1, 1, 1, 10, 10, 10, 100, 1e-4])  # Upper Bound on the states
         self.min_state=np.array([-200, -100, 15, -100, -100, -100, -1, -1, -1, -1, -10, -10, -10, 0, 0])  # Lower Bound on the states

--- a/examples/params/obstacle_avoidance.py
+++ b/examples/params/obstacle_avoidance.py
@@ -15,6 +15,7 @@ class Dynamics:
     def __init__(self):
         self.t_inds = -2          # Time Index in State
         self.y_inds = -1          # Constraint Violation Index in State
+        self.s_inds = -1          # Time dilation index in Control
 
         self.max_state = np.array([200, 10, 20, 100, 100, 100, 1, 1, 1, 1, 10, 10, 10, 100, 1E-4])
         self.min_state = np.array([-200, -100, 0, -100, -100, -100, -1, -1, -1, -1, -10, -10, -10, 0, 0])

--- a/openscvx/config.py
+++ b/openscvx/config.py
@@ -106,9 +106,6 @@ class SimConfig:
     max_control: np.ndarray
     min_control: np.ndarray
     total_time: float
-    g: float = -9.81
-    m: float = 1.0
-    J_b: np.ndarray = field(default_factory=lambda: np.array([1.0, 1.0, 1.0]))
     n_states: int = None
     n_controls: int = None
     max_dt: float = 1e2

--- a/openscvx/discretization.py
+++ b/openscvx/discretization.py
@@ -176,7 +176,8 @@ class AugmentedDynamics:
                     x: np.ndarray,
                     u_current: np.ndarray,
                     u_next: np.ndarray,
-                    tau_init: float) -> np.ndarray:
+                    tau_init: float,
+                    idx_s: int) -> np.ndarray:
         x = x[None, :]
         
         if self.params.scp.dis_type == "ZOH":
@@ -185,4 +186,4 @@ class AugmentedDynamics:
             beta = (tau - tau_init) * self.params.scp.n
         u = u_current + beta * (u_next - u_current)
         
-        return  u[:, 6] * self.params.veh.state_dot(x, u[:,:-1]).squeeze()
+        return  u[:, idx_s] * self.params.veh.state_dot(x, u[:,:-1]).squeeze()

--- a/openscvx/ocp.py
+++ b/openscvx/ocp.py
@@ -115,6 +115,4 @@ def OCP(params):
     # PROBLEM
     #########
     prob = cp.Problem(cp.Minimize(cost), constr)
-    # if params.scp.gen_code:
-    #     cpg.generate_code(prob, solver = 'QOCO', code_dir='solver', wrapper = True)
     return prob

--- a/openscvx/propagation.py
+++ b/openscvx/propagation.py
@@ -39,7 +39,7 @@ def simulate_nonlinear_time(x_0, u_lam, tau_vals, t, aug_dy, params):
         # Obtain those values from tau_vals
         tau_cur = tau_vals[(tau_inds >= k) & (tau_inds < k+1)]
 
-        sol = itg.solve_ivp(aug_dy.prop_aug_dy, (tau[k], tau[k+1]), x_0, args=(np.array(controls_current), np.array(controls_next), np.array([[tau[k]]])), method='DOP853', dense_output=True)
+        sol = itg.solve_ivp(aug_dy.prop_aug_dy, (tau[k], tau[k+1]), x_0, args=(np.array(controls_current), np.array(controls_next), np.array([[tau[k]]]), params.veh.s_inds), method='DOP853', dense_output=True)
         x = sol.y
         x_time = sol.sol(tau_cur)
         for i in range(x_time.shape[1]):


### PR DESCRIPTION
- remove some unused physics params from `SimConfig`
- remove deprecated `gen_code` flag usage from `ocp`
- remove hardcoded indexing into `u[-1]`, instead look for `u[inds_s]`