### PR TITLE
Fix/better nodal constraint iterator name

### DIFF
--- a/examples/main.py
+++ b/examples/main.py
@@ -35,7 +35,7 @@ with open('results/results.pickle', 'wb') as f:
 with open('results/results.pickle', 'rb') as f:
     results = pickle.load(f) 
 
-results = problem.post_process(results)
-results.update(plotting_dict)
+# results = problem.post_process(results)
+# results.update(plotting_dict)
 # plot_animation(results, problem.params)
-plot_camera_animation(results, problem.params)
+# plot_camera_animation(results, problem.params)

--- a/examples/main.py
+++ b/examples/main.py
@@ -7,7 +7,7 @@ current_dir = os.path.dirname(os.path.abspath(__file__))
 parent_dir = os.path.dirname(current_dir)
 sys.path.append(parent_dir)
 
-from examples.params.dr_vp_nodal import problem, plotting_dict
+from examples.params.dr_vp import problem, plotting_dict
 
 from openscvx.ptr import PTR_main
 from openscvx.plotting import plot_camera_polytope_animation, plot_camera_animation, plot_animation, plot_scp_animation, plot_constraint_violation, plot_control, plot_state, plot_losses, plot_conic_view_animation, plot_camera_view


### PR DESCRIPTION
- change name of iterator for nonconvex nodal constraints from `g_id` to `idx_ncvx` to distinguish the two, the ID applied is within all nodal constraints, the index needs to be in the list of `g_*`
- comment out post processing in `main.py` for convenience
- swap default example problem to `dr_vp