### PR TITLE
Feature/more consistent constraint definition

### DIFF
--- a/examples/params/dr_vp.py
+++ b/examples/params/dr_vp.py
@@ -25,7 +25,7 @@ final_state = bc(jnp.array([10.0, 0.0, 20.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 
 final_state.type[3:13] = "Free"
 final_state.type[13] = "Minimize"
 
-initial_control = np.array([0, 0, 10, 0, 0, 0, 1])
+initial_control = np.array([0, 0, 10, 0, 0, 0])
 max_control = np.array(
     [0, 0, 4.179446268 * 9.81, 18.665, 18.665, 0.55562, 3.0 * total_time]
 )  # Upper Bound on the controls
@@ -132,8 +132,6 @@ def dynamics(x, u):
 
 
 u_bar = np.repeat(np.expand_dims(initial_control, axis=0), n, axis=0)
-s = total_time
-u_bar[:, -1] = np.repeat(s, n)
 
 x_bar = np.repeat(np.expand_dims(np.zeros_like(max_state), axis=0), n, axis=0)
 x_bar[:, :] = np.linspace(initial_state.value, final_state.value, n)

--- a/examples/params/dr_vp.py
+++ b/examples/params/dr_vp.py
@@ -27,9 +27,9 @@ final_state.type[13] = "Minimize"
 
 initial_control = np.array([0, 0, 10, 0, 0, 0])
 max_control = np.array(
-    [0, 0, 4.179446268 * 9.81, 18.665, 18.665, 0.55562, 3.0 * total_time]
+    [0, 0, 4.179446268 * 9.81, 18.665, 18.665, 0.55562]
 )  # Upper Bound on the controls
-min_control = np.array([0, 0, 0, -18.665, -18.665, -0.55562, 0.3 * total_time])
+min_control = np.array([0, 0, 0, -18.665, -18.665, -0.55562])
 
 
 ### Sensor Params ###

--- a/examples/params/dr_vp.py
+++ b/examples/params/dr_vp.py
@@ -12,16 +12,16 @@ n = 33  # Number of Nodes
 total_time = 40.0  # Total time for the simulation
 
 max_state = np.array(
-    [200.0, 100.0, 50.0, 100.0, 100.0, 100.0, 1.0, 1.0, 1.0, 1.0, 10.0, 10.0, 10.0, 100.0]
+    [200.0, 100, 50, 100, 100, 100, 1, 1, 1, 1, 10, 10, 10, 100]
 )  # Upper Bound on the states
 min_state = np.array(
-    [-200.0, -100.0, 15.0, -100.0, -100.0, -100.0, -1.0, -1.0, -1.0, -1.0, -10.0, -10.0, -10.0, 0.0]
+    [-200.0, -100, 15, -100, -100, -100, -1, -1, -1, -1, -10, -10, -10, 0]
 )  # Lower Bound on the states
 
-initial_state = bc(jnp.array([10.0, 0.0, 20.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+initial_state = bc(jnp.array([10.0, 0, 20, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]))
 initial_state.type[6:13] = "Free"
 
-final_state = bc(jnp.array([10.0, 0.0, 20.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, total_time]))
+final_state = bc(jnp.array([10.0, 0, 20, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, total_time]))
 final_state.type[3:13] = "Free"
 final_state.type[13] = "Minimize"
 
@@ -133,8 +133,7 @@ def dynamics(x, u):
 
 u_bar = np.repeat(np.expand_dims(initial_control, axis=0), n, axis=0)
 
-x_bar = np.repeat(np.expand_dims(np.zeros_like(max_state), axis=0), n, axis=0)
-x_bar[:, :] = np.linspace(initial_state.value, final_state.value, n)
+x_bar = np.linspace(initial_state.value, final_state.value, n)
 
 i = 0
 origins = [initial_state.value[:3]]

--- a/examples/params/dr_vp.py
+++ b/examples/params/dr_vp.py
@@ -12,10 +12,10 @@ n = 33  # Number of Nodes
 total_time = 40.0  # Total time for the simulation
 
 max_state = np.array(
-    [200, 100, 50, 100, 100, 100, 1, 1, 1, 1, 10, 10, 10, 100, 1e-4]
+    [200, 100, 50, 100, 100, 100, 1, 1, 1, 1, 10, 10, 10, 100]
 )  # Upper Bound on the states
 min_state = np.array(
-    [-200, -100, 15, -100, -100, -100, -1, -1, -1, -1, -10, -10, -10, 0, 0]
+    [-200, -100, 15, -100, -100, -100, -1, -1, -1, -1, -10, -10, -10, 0]
 )  # Lower Bound on the states
 
 initial_state = bc(jnp.array([10, 0, 20, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]))
@@ -94,8 +94,8 @@ def g_vp(p_s_I, x):
 
 
 constraints = []
-constraints.append(ctcs(lambda x, u: x[:-1] - max_state[:-1]))
-constraints.append(ctcs(lambda x, u: min_state[:-1] - x[:-1]))
+constraints.append(ctcs(lambda x, u: x[:-1] - max_state))
+constraints.append(ctcs(lambda x, u: min_state - x[:-1]))
 for pose in init_poses:
     constraints.append(ctcs(lambda x, u, p=pose: g_vp(p, x)))
 for node, cen in zip(gate_nodes, A_gate_cen):
@@ -136,7 +136,7 @@ s = total_time
 u_bar[:, -1] = np.repeat(s, n)
 
 x_bar = np.repeat(np.expand_dims(np.zeros_like(max_state), axis=0), n, axis=0)
-x_bar[:, :-1] = np.linspace(initial_state.value, final_state.value, n)
+x_bar[:, :] = np.linspace(initial_state.value, final_state.value, n)
 
 i = 0
 origins = [initial_state.value[:3]]

--- a/examples/params/dr_vp.py
+++ b/examples/params/dr_vp.py
@@ -12,16 +12,16 @@ n = 33  # Number of Nodes
 total_time = 40.0  # Total time for the simulation
 
 max_state = np.array(
-    [200, 100, 50, 100, 100, 100, 1, 1, 1, 1, 10, 10, 10, 100]
+    [200.0, 100.0, 50.0, 100.0, 100.0, 100.0, 1.0, 1.0, 1.0, 1.0, 10.0, 10.0, 10.0, 100.0]
 )  # Upper Bound on the states
 min_state = np.array(
-    [-200, -100, 15, -100, -100, -100, -1, -1, -1, -1, -10, -10, -10, 0]
+    [-200.0, -100.0, 15.0, -100.0, -100.0, -100.0, -1.0, -1.0, -1.0, -1.0, -10.0, -10.0, -10.0, 0.0]
 )  # Lower Bound on the states
 
-initial_state = bc(jnp.array([10, 0, 20, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]))
+initial_state = bc(jnp.array([10.0, 0.0, 20.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
 initial_state.type[6:13] = "Free"
 
-final_state = bc(jnp.array([10, 0, 20, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, total_time]))
+final_state = bc(jnp.array([10.0, 0.0, 20.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, total_time]))
 final_state.type[3:13] = "Free"
 final_state.type[13] = "Minimize"
 

--- a/examples/params/dr_vp_nodal.py
+++ b/examples/params/dr_vp_nodal.py
@@ -12,24 +12,24 @@ n = 33  # Number of Nodes
 total_time = 30.0  # Total time for the simulation
 
 max_state = np.array(
-    [200, 100, 50, 100, 100, 100, 1, 1, 1, 1, 10, 10, 10, 100, 1e-4]
+    [200.0, 100, 50, 100, 100, 100, 1, 1, 1, 1, 10, 10, 10, 100]
 )  # Upper Bound on the states
 min_state = np.array(
-    [-200, -100, 15, -100, -100, -100, -1, -1, -1, -1, -10, -10, -10, 0, 0]
+    [-200.0, -100, 15, -100, -100, -100, -1, -1, -1, -1, -10, -10, -10, 0]
 )  # Lower Bound on the states
 
-initial_state = bc(jnp.array([10, 0, 20, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]))
+initial_state = bc(jnp.array([10.0, 0, 20, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]))
 initial_state.type[6:13] = "Free"
 
-final_state = bc(jnp.array([10, 0, 20, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, total_time]))
+final_state = bc(jnp.array([10.0, 0, 20, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, total_time]))
 final_state.type[3:13] = "Free"
 final_state.type[13] = "Minimize"
 
-initial_control = np.array([0., 0., 10., 0., 0., 0., 1.])
+initial_control = np.array([0., 0., 10., 0., 0., 0.])
 max_control = np.array(
-    [0, 0, 4.179446268 * 9.81, 18.665, 18.665, 0.55562, 3.0 * total_time]
+    [0, 0, 4.179446268 * 9.81, 18.665, 18.665, 0.55562]
 )  # Upper Bound on the controls
-min_control = np.array([0, 0, 0, -18.665, -18.665, -0.55562, 0.3 * total_time])
+min_control = np.array([0, 0, 0, -18.665, -18.665, -0.55562])
 
 
 ### Sensor Params ###
@@ -136,11 +136,7 @@ def dynamics(x, u):
 
 
 u_bar = np.repeat(np.expand_dims(initial_control, axis=0), n, axis=0)
-s = total_time
-u_bar[:, -1] = np.repeat(s, n)
-
-x_bar = np.repeat(np.expand_dims(np.zeros_like(max_state), axis=0), n, axis=0)
-x_bar[:, :-1] = np.linspace(initial_state.value, final_state.value, n)
+x_bar = np.linspace(initial_state.value, final_state.value, n)
 
 i = 0
 origins = [initial_state.value[:3]]

--- a/examples/params/dr_vp_polytope.py
+++ b/examples/params/dr_vp_polytope.py
@@ -14,25 +14,25 @@ total_time = 30.0  # Total time for the simulation
 s_inds = -1  # Time dilation index in Control
 
 max_state = np.array(
-    [200, 100, 50, 100, 100, 100, 1, 1, 1, 1, 10, 10, 10, 100, 1e-4]
+    [200.0, 100, 50, 100, 100, 100, 1, 1, 1, 1, 10, 10, 10, 100]
 )  # Upper Bound on the states
 min_state = np.array(
-    [-200, -100, 15, -100, -100, -100, -1, -1, -1, -1, -10, -10, -10, 0, 0]
+    [-200.0, -100, 15, -100, -100, -100, -1, -1, -1, -1, -10, -10, -10, 0]
 )  # Lower Bound on the states
 
-initial_state = bc(jnp.array([10, 0, 20, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]))
+initial_state = bc(jnp.array([10.0, 0, 20, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]))
 initial_state.type[6:13] = "Free"
 
-final_state = bc(jnp.array([10, 0, 20, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, total_time]))
+final_state = bc(jnp.array([10.0, 0, 20, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, total_time]))
 final_state.type[3:13] = "Free"
 final_state.type[13] = "Minimize"
 
-initial_control = np.array([0, 0, 10, 0, 0, 0, 1])
+initial_control = np.array([0.0, 0, 10, 0, 0, 0])
 max_control = np.array(
-    [0, 0, 4.179446268 * 9.81, 18.665, 18.665, 0.55562, 3.0 * total_time]
+    [0.0, 0, 4.179446268 * 9.81, 18.665, 18.665, 0.55562]
 )  # Upper Bound on the controls
 min_control = np.array(
-    [0, 0, 0, -18.665, -18.665, -0.55562, 0.3 * total_time]
+    [0.0, 0, 0, -18.665, -18.665, -0.55562]
 )  # Lower Bound on the controls
 
 
@@ -118,8 +118,8 @@ def g_vp(p_s_I, x):
 
 
 constraints = []
-constraints.append(ctcs(lambda x, u: x[:-1] - max_state[:-1]))
-constraints.append(ctcs(lambda x, u: min_state[:-1] - x[:-1]))
+constraints.append(ctcs(lambda x, u: x[:-1] - max_state))
+constraints.append(ctcs(lambda x, u: min_state - x[:-1]))
 for pose in init_poses:
     constraints.append(ctcs(lambda x, u, p=pose: g_vp(p, x)))
 for node, cen in zip(gate_nodes, A_gate_cen):
@@ -157,11 +157,7 @@ def dynamics(x, u):
 
 
 u_bar = np.repeat(np.expand_dims(initial_control, axis=0), n, axis=0)
-s = total_time
-u_bar[:, -1] = np.repeat(s, n)
-
-x_bar = np.repeat(np.expand_dims(np.zeros_like(max_state), axis=0), n, axis=0)
-x_bar[:, :-1] = np.linspace(initial_state.value, final_state.value, n)
+x_bar = np.linspace(initial_state.value, final_state.value, n)
 
 i = 0
 origins = [initial_state.value[:3]]

--- a/examples/params/drone_racing.py
+++ b/examples/params/drone_racing.py
@@ -11,25 +11,25 @@ n = 22  # Number of Nodes
 total_time = 24.0  # Total time for the simulation
 
 max_state = np.array(
-    [200, 100, 50, 100, 100, 100, 1, 1, 1, 1, 10, 10, 10, 100, 1e-4]
+    [200.0, 100, 50, 100, 100, 100, 1, 1, 1, 1, 10, 10, 10, 100]
 )  # Upper Bound on the states
 min_state = np.array(
-    [-200, -100, 15, -100, -100, -100, -1, -1, -1, -1, -10, -10, -10, 0, 0]
+    [-200.0, -100, 15, -100, -100, -100, -1, -1, -1, -1, -10, -10, -10, 0]
 )  # Lower Bound on the states
 
-initial_state = bc(jnp.array([10, 0, 20, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]))
+initial_state = bc(jnp.array([10.0, 0, 20, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]))
 initial_state.type[6:13] = "Free"
 
-final_state = bc(jnp.array([10, 0, 20, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, total_time]))
+final_state = bc(jnp.array([10.0, 0, 20, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, total_time]))
 final_state.type[3:13] = "Free"
 final_state.type[13] = "Minimize"
 
-initial_control = np.array([0, 0, 10, 0, 0, 0, 1])
+initial_control = np.array([0.0, 0, 10, 0, 0, 0])
 max_control = np.array(
-    [0, 0, 4.179446268 * 9.81, 18.665, 18.665, 0.55562, 3.0 * total_time]
+    [0, 0, 4.179446268 * 9.81, 18.665, 18.665, 0.55562]
 )  # Upper Bound on the controls
 min_control = np.array(
-    [0, 0, 0, -18.665, -18.665, -0.55562, 0.3 * total_time]
+    [0, 0, 0, -18.665, -18.665, -0.55562]
 )  # Lower Bound on the controls
 
 m = 1.0  # Mass of the drone
@@ -68,8 +68,8 @@ for center in gate_centers:
 
 
 constraints = [
-    ctcs(lambda x, u: (x[:-1] - max_state[:-1])),
-    ctcs(lambda x, u: (min_state[:-1] - x[:-1])),
+    ctcs(lambda x, u: (x[:-1] - max_state)),
+    ctcs(lambda x, u: (min_state - x[:-1])),
 ]
 for node, cen in zip(gate_nodes, A_gate_cen):
     constraints.append(
@@ -102,11 +102,7 @@ def dynamics(x, u):
 
 
 u_bar = np.repeat(np.expand_dims(initial_control, axis=0), n, axis=0)
-s = total_time
-u_bar[:, -1] = np.repeat(s, n)
-
-x_bar = np.repeat(np.expand_dims(np.zeros_like(max_state), axis=0), n, axis=0)
-x_bar[:, :-1] = np.linspace(initial_state.value, final_state.value, n)
+x_bar = np.linspace(initial_state.value, final_state.value, n)
 
 i = 0
 origins = [initial_state.value[:3]]

--- a/examples/params/obstacle_avoidance.py
+++ b/examples/params/obstacle_avoidance.py
@@ -9,19 +9,19 @@ from openscvx.utils import qdcm, SSMP, SSM, generate_orthogonal_unit_vectors
 n = 6
 total_time = 4.0  # Total time for the simulation
 
-max_state = np.array([200, 10, 20, 100, 100, 100, 1, 1, 1, 1, 10, 10, 10, 100, 1e-4])
+max_state = np.array([200., 10, 20, 100, 100, 100, 1, 1, 1, 1, 10, 10, 10, 100])
 min_state = np.array(
-    [-200, -100, 0, -100, -100, -100, -1, -1, -1, -1, -10, -10, -10, 0, 0]
+    [-200., -100, 0, -100, -100, -100, -1, -1, -1, -1, -10, -10, -10, 0]
 )
 
-initial_state = bc(jnp.array([10, 0, 2, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]))
+initial_state = bc(jnp.array([10.0, 0, 2, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]))
 initial_state.type[6:13] = "Free"
 
-final_state = bc(jnp.array([-10, 0, 2, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, total_time]))
+final_state = bc(jnp.array([-10.0, 0, 2, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, total_time]))
 final_state.type[3:13] = "Free"
 final_state.type[13] = "Minimize"
 
-initial_control = np.array([0, 0, 50, 0, 0, 0, 1])
+initial_control = np.array([0.0, 0, 50, 0, 0, 0])
 
 
 def dynamics(x, u):
@@ -74,16 +74,12 @@ for _ in obstacle_centers:
 constraints = []
 for center, A in zip(obstacle_centers, A_obs):
     constraints.append(ctcs(lambda x, u: g_obs(center, A, x)))
-constraints.append(ctcs(lambda x, u: x[:-1] - max_state[:-1]))
-constraints.append(ctcs(lambda x, u: min_state[:-1] - x[:-1]))
+constraints.append(ctcs(lambda x, u: x[:-1] - max_state))
+constraints.append(ctcs(lambda x, u: min_state - x[:-1]))
 
 
 u_bar = np.repeat(np.expand_dims(initial_control, axis=0), n, axis=0)
-s = total_time
-u_bar[:, -1] = np.repeat(s, n)
-
-x_bar = np.repeat(np.expand_dims(np.zeros_like(max_state), axis=0), n, axis=0)
-x_bar[:, :-1] = np.linspace(initial_state.value, final_state.value, n)
+x_bar = np.linspace(initial_state.value, final_state.value, n)
 
 problem = TrajOptProblem(
     dynamics=dynamics,
@@ -98,10 +94,10 @@ problem = TrajOptProblem(
     x_max=max_state,
     x_min=min_state,
     u_max=np.array(
-        [0, 0, 4.179446268 * 9.81, 18.665, 18.665, 0.55562, 3.0 * total_time]
+        [0, 0, 4.179446268 * 9.81, 18.665, 18.665, 0.55562]
     ),  # Upper Bound on the controls
     u_min=np.array(
-        [0, 0, 0, -18.665, -18.665, -0.55562, 0.3 * total_time]
+        [0, 0, 0, -18.665, -18.665, -0.55562]
     ),  # Lower Bound on the controls
 )
 

--- a/examples/params/obstacle_avoidance_nodal.py
+++ b/examples/params/obstacle_avoidance_nodal.py
@@ -9,19 +9,19 @@ from openscvx.utils import qdcm, SSMP, SSM, generate_orthogonal_unit_vectors
 n = 6
 total_time = 4.0  # Total time for the simulation
 
-max_state = np.array([200, 10, 20, 100, 100, 100, 1, 1, 1, 1, 10, 10, 10, 100, 1e-4])
+max_state = np.array([200., 10, 20, 100, 100, 100, 1, 1, 1, 1, 10, 10, 10, 100])
 min_state = np.array(
-    [-200, -100, 0, -100, -100, -100, -1, -1, -1, -1, -10, -10, -10, 0, 0]
+    [-200., -100, 0, -100, -100, -100, -1, -1, -1, -1, -10, -10, -10, 0]
 )
 
-initial_state = bc(jnp.array([10, 0, 2, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]))
+initial_state = bc(jnp.array([10., 0, 2, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]))
 initial_state.type[6:13] = "Free"
 
-final_state = bc(jnp.array([-10, 0, 2, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, total_time]))
+final_state = bc(jnp.array([-10., 0, 2, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, total_time]))
 final_state.type[3:13] = "Free"
 final_state.type[13] = "Minimize"
 
-initial_control = np.array([0., 0., 50., 0., 0., 0., 1.])
+initial_control = np.array([0., 0., 50., 0., 0., 0.])
 
 
 def dynamics(x, u):
@@ -73,16 +73,12 @@ constraints = []
 for center, A_obs_s in zip(obstacle_centers, A_obs):
     # constraints.append(ctcs(lambda x, u: g_obs(center, A, x)))
     constraints.append(nodal(lambda x, u, c=center, A=A_obs_s: g_obs(x, u, c, A), convex=False))
-constraints.append(ctcs(lambda x, u: x[:-1] - max_state[:-1]))
-constraints.append(ctcs(lambda x, u: min_state[:-1] - x[:-1]))
+constraints.append(ctcs(lambda x, u: x[:-1] - max_state))
+constraints.append(ctcs(lambda x, u: min_state - x[:-1]))
 
 
 u_bar = np.repeat(np.expand_dims(initial_control, axis=0), n, axis=0)
-s = total_time
-u_bar[:, -1] = np.repeat(s, n)
-
-x_bar = np.repeat(np.expand_dims(np.zeros_like(max_state), axis=0), n, axis=0)
-x_bar[:, :-1] = np.linspace(initial_state.value, final_state.value, n)
+x_bar = np.linspace(initial_state.value, final_state.value, n)
 
 problem = TrajOptProblem(
     dynamics=dynamics,
@@ -97,10 +93,10 @@ problem = TrajOptProblem(
     x_max=max_state,
     x_min=min_state,
     u_max=np.array(
-        [0, 0, 4.179446268 * 9.81, 18.665, 18.665, 0.55562, 3.0 * total_time]
+        [0, 0, 4.179446268 * 9.81, 18.665, 18.665, 0.55562]
     ),  # Upper Bound on the controls
     u_min=np.array(
-        [0, 0, 0, -18.665, -18.665, -0.55562, 0.3 * total_time]
+        [0, 0, 0, -18.665, -18.665, -0.55562]
     ),  # Lower Bound on the controls
 )
 

--- a/openscvx/config.py
+++ b/openscvx/config.py
@@ -107,7 +107,7 @@ class SimConfig:
     x_bar: np.ndarray
     u_bar: np.ndarray
     initial_state: np.ndarray
-    initial_control: np.ndarray
+    initial_control: np.ndarray # TODO: (norrisg) remove, not used anywhere
     final_state: np.ndarray
     max_state: np.ndarray
     min_state: np.ndarray
@@ -148,9 +148,6 @@ class SimConfig:
         assert (
             self.min_state.shape[0] == self.n_states
         ), f"Min state must have {self.n_states} elements"
-        assert (
-            self.initial_control.shape[0] == self.n_controls
-        ), f"Initial control must have {self.n_controls} elements"
         assert (
             self.max_control.shape[0] == self.n_controls
         ), f"Max control must have {self.n_controls} elements"

--- a/openscvx/trajoptproblem.py
+++ b/openscvx/trajoptproblem.py
@@ -36,6 +36,9 @@ class TrajOptProblem:
         x_min_augmented = np.hstack([x_min, 0])
         x_max_augmented = np.hstack([x_max, 1e-4])
 
+        u_min_augmented = np.hstack([u_min, 0.3*time_init])
+        u_max_augmented = np.hstack([u_max, 3.0*time_init])
+
         x_bar_augmented = np.hstack([x_guess, np.full((x_guess.shape[0], 1), 0)])
         u_bar_augmented = np.hstack([u_guess, np.full((u_guess.shape[0], 1), time_init)])
 
@@ -48,8 +51,8 @@ class TrajOptProblem:
                 max_state=x_max_augmented,
                 min_state=x_min_augmented,
                 initial_control=initial_control,
-                max_control=u_max,
-                min_control=u_min,
+                max_control=u_max_augmented,
+                min_control=u_min_augmented,
                 total_time=time_init,
                 n_states=len(x_max),
                 dt=0.1,

--- a/openscvx/trajoptproblem.py
+++ b/openscvx/trajoptproblem.py
@@ -32,6 +32,9 @@ class TrajOptProblem:
         scp: ScpConfig = None,
         sim: SimConfig = None,
     ):
+        
+        x_min_augmented = np.hstack([x_min, 0])
+        x_max_augmented = np.hstack([x_max, 1e-4])
 
         if sim is None:
             sim = SimConfig(
@@ -39,8 +42,8 @@ class TrajOptProblem:
                 u_bar=u_guess,
                 initial_state=initial_state,
                 final_state=final_state,
-                max_state=x_max,
-                min_state=x_min,
+                max_state=x_max_augmented,
+                min_state=x_min_augmented,
                 initial_control=initial_control,
                 max_control=u_max,
                 min_control=u_min,

--- a/openscvx/trajoptproblem.py
+++ b/openscvx/trajoptproblem.py
@@ -36,9 +36,11 @@ class TrajOptProblem:
         x_min_augmented = np.hstack([x_min, 0])
         x_max_augmented = np.hstack([x_max, 1e-4])
 
+        x_bar_augmented = np.hstack([x_guess, np.full((x_guess.shape[0], 1), 0)])
+
         if sim is None:
             sim = SimConfig(
-                x_bar=x_guess,
+                x_bar=x_bar_augmented,
                 u_bar=u_guess,
                 initial_state=initial_state,
                 final_state=final_state,

--- a/openscvx/trajoptproblem.py
+++ b/openscvx/trajoptproblem.py
@@ -31,15 +31,19 @@ class TrajOptProblem:
         u_min: jnp.ndarray,
         scp: ScpConfig = None,
         sim: SimConfig = None,
+        ctcs_augmentation_min=0.0,
+        ctcs_augmentation_max=1e-4,
+        time_dilation_factor_min=0.3,
+        time_dilation_factor_max=3.0,
     ):
 
         # TODO (norrisg) move this into some augmentation function, if we want to make this be executed after the init (i.e. within problem.initialize) need to rethink how problem is defined
 
-        x_min_augmented = np.hstack([x_min, 0])
-        x_max_augmented = np.hstack([x_max, 1e-4])
+        x_min_augmented = np.hstack([x_min, ctcs_augmentation_min])
+        x_max_augmented = np.hstack([x_max, ctcs_augmentation_max])
 
-        u_min_augmented = np.hstack([u_min, 0.3 * time_init])
-        u_max_augmented = np.hstack([u_max, 3.0 * time_init])
+        u_min_augmented = np.hstack([u_min, time_dilation_factor_min * time_init])
+        u_max_augmented = np.hstack([u_max, time_dilation_factor_max * time_init])
 
         x_bar_augmented = np.hstack([x_guess, np.full((x_guess.shape[0], 1), 0)])
         u_bar_augmented = np.hstack(

--- a/openscvx/trajoptproblem.py
+++ b/openscvx/trajoptproblem.py
@@ -37,11 +37,12 @@ class TrajOptProblem:
         x_max_augmented = np.hstack([x_max, 1e-4])
 
         x_bar_augmented = np.hstack([x_guess, np.full((x_guess.shape[0], 1), 0)])
+        u_bar_augmented = np.hstack([u_guess, np.full((u_guess.shape[0], 1), time_init)])
 
         if sim is None:
             sim = SimConfig(
                 x_bar=x_bar_augmented,
-                u_bar=u_guess,
+                u_bar=u_bar_augmented,
                 initial_state=initial_state,
                 final_state=final_state,
                 max_state=x_max_augmented,


### PR DESCRIPTION
Fixes #30 

- Don't force user to define the CTCS state augmentation state constraints
- Don't force user to define the time dilation control constraints
- Both can be provided as args to `TrajOptProblem` to override the default behavior

TODO:
- Move into dedicated `augmentation` functions
- Might involve moving where / how the problem is initialized s.t. the problem is only setup in `problem.initialize`
- Should remove some of the assertions regarding dimensions in `SimConfig`
- **Should refactor the member variables of `Config` since many are deprecated!**