### PR TITLE
Fix/correct result indexing plotting

### DIFF
--- a/openscvx/plotting.py
+++ b/openscvx/plotting.py
@@ -9,7 +9,7 @@ from openscvx.config import Config
 
 def full_subject_traj_time(results, params):
     x_full = results["x_full"]
-    x_nodes = results["x_history"][-1]
+    x_nodes = results["x"]
     t_nodes = x_nodes[:,params.veh.t_inds]
     t_full = results['t_full']
     subs_traj = []

--- a/openscvx/plotting.py
+++ b/openscvx/plotting.py
@@ -8,8 +8,8 @@ from openscvx.utils import qdcm
 from openscvx.config import Config
 
 def full_subject_traj_time(results, params):
-    x_full = results['state']
-    x_nodes = results['scp_trajs'][-1]
+    x_full = results["x_full"]
+    x_nodes = results["x_history"][-1]
     t_nodes = x_nodes[:,params.veh.t_inds]
     t_full = results['t_full']
     subs_traj = []


### PR DESCRIPTION
- `full_subject_traj_time` had not had the result dict keys updated after the refactor from #31 
- Directly access latest nodes in `result["x"]` instead of final element of `result["x_history"]`