### PR TITLE
Feature/better index tracking initial

### DIFF
--- a/examples/params/cinema_vp.py
+++ b/examples/params/cinema_vp.py
@@ -11,10 +11,9 @@ n = 12  # Number of Nodes
 total_time = 40.0  # Total time for the simulation
 
 
-fuel_inds = -3  # Fuel Index in State
-t_inds = -2  # Time Index in State
-y_inds = -1  # Constraint Violation Index in State
-s_inds = -1  # Time dilation index in Control
+fuel_inds = 13  # Fuel Index in State
+t_inds = 14
+s_inds = 6  # Time dilation index in Control
 
 
 max_state = np.array(
@@ -101,8 +100,8 @@ def g_max(x):
 
 constraints = [
     ctcs(lambda x, u: np.sqrt(2e1) * g_vp(x)),
-    ctcs(lambda x, u: x[:-1] - max_state),
-    ctcs(lambda x, u: min_state - x[:-1]),
+    ctcs(lambda x, u: x - max_state),
+    ctcs(lambda x, u: min_state - x),
     ctcs(lambda x, u: g_min(x)),
     ctcs(lambda x, u: g_max(x)),
 ]

--- a/examples/params/cinema_vp.py
+++ b/examples/params/cinema_vp.py
@@ -25,11 +25,12 @@ min_state = np.array(
 )  # Lower Bound on the states
 
 initial_state = bc(jnp.array([8.0, -0.2, 2.2, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0]))
-initial_state.type[6:13] = "Free"
+initial_state.type[6:14] = "Free"
 
 final_state = bc(jnp.array([-10.0, 0, 2, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 40]))
 final_state.type[0:13] = "Free"
-final_state.type[13] = "Minimize"
+final_state.type[13] = "Minimize" # Minimize fuel usage
+final_state.type[14] = "Minimize" # Minimize time
 
 max_control = np.array(
     [0, 0, 4.179446268 * 9.81, 18.665, 18.665, 0.55562]

--- a/examples/params/cinema_vp.py
+++ b/examples/params/cinema_vp.py
@@ -78,7 +78,8 @@ def dynamics(x, u):
     q_dot = 0.5 * SSMP(w) @ q
     w_dot = jnp.diag(1 / J_b) @ (tau - SSM(w) @ jnp.diag(J_b) @ w)
     fuel_dot = jnp.linalg.norm(u)[None]
-    return jnp.hstack([r_dot, v_dot, q_dot, w_dot, fuel_dot])
+    t_dot = 1
+    return jnp.hstack([r_dot, v_dot, q_dot, w_dot, fuel_dot, t_dot])
 
 
 def g_vp(x):

--- a/examples/params/cinema_vp.py
+++ b/examples/params/cinema_vp.py
@@ -127,6 +127,7 @@ for k in range(n):
 problem = TrajOptProblem(
     dynamics=dynamics,
     constraints=constraints,
+    idx_time=t_inds,
     N=n,
     time_init=total_time,
     x_guess=x_bar,

--- a/examples/params/dr_vp.py
+++ b/examples/params/dr_vp.py
@@ -128,7 +128,8 @@ def dynamics(x, u):
     v_dot = (1 / m) * qdcm(q) @ f + jnp.array([0, 0, g_const])
     q_dot = 0.5 * SSMP(w) @ q
     w_dot = jnp.diag(1 / J_b) @ (tau - SSM(w) @ jnp.diag(J_b) @ w)
-    return jnp.hstack([r_dot, v_dot, q_dot, w_dot])
+    t_dot = 1
+    return jnp.hstack([r_dot, v_dot, q_dot, w_dot, t_dot])
 
 
 u_bar = np.repeat(np.expand_dims(initial_control, axis=0), n, axis=0)

--- a/examples/params/dr_vp.py
+++ b/examples/params/dr_vp.py
@@ -94,8 +94,8 @@ def g_vp(p_s_I, x):
 
 
 constraints = []
-constraints.append(ctcs(lambda x, u: x[:-1] - max_state))
-constraints.append(ctcs(lambda x, u: min_state - x[:-1]))
+constraints.append(ctcs(lambda x, u: x - max_state))
+constraints.append(ctcs(lambda x, u: min_state - x))
 for pose in init_poses:
     constraints.append(ctcs(lambda x, u, p=pose: g_vp(p, x)))
 for node, cen in zip(gate_nodes, A_gate_cen):

--- a/examples/params/dr_vp.py
+++ b/examples/params/dr_vp.py
@@ -170,6 +170,7 @@ for k in range(n):
 problem = TrajOptProblem(
     dynamics=dynamics,
     constraints=constraints,
+    idx_time=len(max_state)-1,
     N=n,
     time_init=total_time,
     x_guess=x_bar,

--- a/examples/params/dr_vp_nodal.py
+++ b/examples/params/dr_vp_nodal.py
@@ -173,6 +173,7 @@ for k in range(n):
 problem = TrajOptProblem(
     dynamics=dynamics,
     constraints=constraints,
+    idx_time=len(max_state)-1,
     N=n,
     time_init=total_time,
     x_guess=x_bar,

--- a/examples/params/dr_vp_nodal.py
+++ b/examples/params/dr_vp_nodal.py
@@ -132,7 +132,8 @@ def dynamics(x, u):
     v_dot = (1 / m) * qdcm(q) @ f + jnp.array([0, 0, g_const])
     q_dot = 0.5 * SSMP(w) @ q
     w_dot = jnp.diag(1 / J_b) @ (tau - SSM(w) @ jnp.diag(J_b) @ w)
-    return jnp.hstack([r_dot, v_dot, q_dot, w_dot])
+    t_dot = 1
+    return jnp.hstack([r_dot, v_dot, q_dot, w_dot, t_dot])
 
 
 u_bar = np.repeat(np.expand_dims(initial_control, axis=0), n, axis=0)

--- a/examples/params/dr_vp_polytope.py
+++ b/examples/params/dr_vp_polytope.py
@@ -118,8 +118,8 @@ def g_vp(p_s_I, x):
 
 
 constraints = []
-constraints.append(ctcs(lambda x, u: x[:-1] - max_state))
-constraints.append(ctcs(lambda x, u: min_state - x[:-1]))
+constraints.append(ctcs(lambda x, u: x - max_state))
+constraints.append(ctcs(lambda x, u: min_state - x))
 for pose in init_poses:
     constraints.append(ctcs(lambda x, u, p=pose: g_vp(p, x)))
 for node, cen in zip(gate_nodes, A_gate_cen):

--- a/examples/params/dr_vp_polytope.py
+++ b/examples/params/dr_vp_polytope.py
@@ -153,7 +153,8 @@ def dynamics(x, u):
     v_dot = (1 / m) * qdcm(q) @ f + jnp.array([0, 0, g_const])
     q_dot = 0.5 * SSMP(w) @ q
     w_dot = jnp.diag(1 / J_b) @ (tau - SSM(w) @ jnp.diag(J_b) @ w)
-    return jnp.hstack([r_dot, v_dot, q_dot, w_dot])
+    t_dot = 1
+    return jnp.hstack([r_dot, v_dot, q_dot, w_dot, t_dot])
 
 
 u_bar = np.repeat(np.expand_dims(initial_control, axis=0), n, axis=0)

--- a/examples/params/dr_vp_polytope.py
+++ b/examples/params/dr_vp_polytope.py
@@ -194,6 +194,7 @@ for k in range(n):
 problem = TrajOptProblem(
     dynamics=dynamics,
     constraints=constraints,
+    idx_time=len(max_state)-1,
     N=n,
     time_init=total_time,
     x_guess=x_bar,

--- a/examples/params/drone_racing.py
+++ b/examples/params/drone_racing.py
@@ -124,6 +124,7 @@ for _ in range(n_gates + 1):
 problem = TrajOptProblem(
     dynamics=dynamics,
     constraints=constraints,
+    idx_time=len(max_state)-1,
     N=n,
     time_init=total_time,
     x_guess=x_bar,

--- a/examples/params/drone_racing.py
+++ b/examples/params/drone_racing.py
@@ -68,8 +68,8 @@ for center in gate_centers:
 
 
 constraints = [
-    ctcs(lambda x, u: (x[:-1] - max_state)),
-    ctcs(lambda x, u: (min_state - x[:-1])),
+    ctcs(lambda x, u: (x - max_state)),
+    ctcs(lambda x, u: (min_state - x)),
 ]
 for node, cen in zip(gate_nodes, A_gate_cen):
     constraints.append(

--- a/examples/params/drone_racing.py
+++ b/examples/params/drone_racing.py
@@ -98,7 +98,8 @@ def dynamics(x, u):
     v_dot = (1 / m) * qdcm(q) @ f + jnp.array([0, 0, g_const])
     q_dot = 0.5 * SSMP(w) @ q
     w_dot = jnp.diag(1 / J_b) @ (tau - SSM(w) @ jnp.diag(J_b) @ w)
-    return jnp.hstack([r_dot, v_dot, q_dot, w_dot])
+    t_dot = 1
+    return jnp.hstack([r_dot, v_dot, q_dot, w_dot, t_dot])
 
 
 u_bar = np.repeat(np.expand_dims(initial_control, axis=0), n, axis=0)

--- a/examples/params/obstacle_avoidance.py
+++ b/examples/params/obstacle_avoidance.py
@@ -85,6 +85,7 @@ x_bar = np.linspace(initial_state.value, final_state.value, n)
 problem = TrajOptProblem(
     dynamics=dynamics,
     constraints=constraints,
+    idx_time=len(max_state)-1,
     N=n,
     time_init=total_time,
     x_guess=x_bar,

--- a/examples/params/obstacle_avoidance.py
+++ b/examples/params/obstacle_avoidance.py
@@ -44,7 +44,8 @@ def dynamics(x, u):
     v_dot = (1 / m) * qdcm(q) @ f + jnp.array([0, 0, g_const])
     q_dot = 0.5 * SSMP(w) @ q
     w_dot = jnp.diag(1 / J_b) @ (tau - SSM(w) @ jnp.diag(J_b) @ w)
-    return jnp.hstack([r_dot, v_dot, q_dot, w_dot])
+    t_dot = 1
+    return jnp.hstack([r_dot, v_dot, q_dot, w_dot, t_dot])
 
 
 def g_obs(center, A, x):

--- a/examples/params/obstacle_avoidance.py
+++ b/examples/params/obstacle_avoidance.py
@@ -75,8 +75,8 @@ for _ in obstacle_centers:
 constraints = []
 for center, A in zip(obstacle_centers, A_obs):
     constraints.append(ctcs(lambda x, u: g_obs(center, A, x)))
-constraints.append(ctcs(lambda x, u: x[:-1] - max_state))
-constraints.append(ctcs(lambda x, u: min_state - x[:-1]))
+constraints.append(ctcs(lambda x, u: x - max_state))
+constraints.append(ctcs(lambda x, u: min_state - x))
 
 
 u_bar = np.repeat(np.expand_dims(initial_control, axis=0), n, axis=0)

--- a/examples/params/obstacle_avoidance_nodal.py
+++ b/examples/params/obstacle_avoidance_nodal.py
@@ -74,8 +74,8 @@ constraints = []
 for center, A_obs_s in zip(obstacle_centers, A_obs):
     # constraints.append(ctcs(lambda x, u: g_obs(center, A, x)))
     constraints.append(nodal(lambda x, u, c=center, A=A_obs_s: g_obs(x, u, c, A), convex=False))
-constraints.append(ctcs(lambda x, u: x[:-1] - max_state))
-constraints.append(ctcs(lambda x, u: min_state - x[:-1]))
+constraints.append(ctcs(lambda x, u: x - max_state))
+constraints.append(ctcs(lambda x, u: min_state - x))
 
 
 u_bar = np.repeat(np.expand_dims(initial_control, axis=0), n, axis=0)

--- a/examples/params/obstacle_avoidance_nodal.py
+++ b/examples/params/obstacle_avoidance_nodal.py
@@ -44,7 +44,8 @@ def dynamics(x, u):
     v_dot = (1 / m) * qdcm(q) @ f + jnp.array([0, 0, g_const])
     q_dot = 0.5 * SSMP(w) @ q
     w_dot = jnp.diag(1 / J_b) @ (tau - SSM(w) @ jnp.diag(J_b) @ w)
-    return jnp.hstack([r_dot, v_dot, q_dot, w_dot])
+    t_dot = 1
+    return jnp.hstack([r_dot, v_dot, q_dot, w_dot, t_dot])
 
 def g_obs(x, u, center, A):
     value = 1 - (x[:3] - center).T @ A @ (x[:3] - center)

--- a/examples/params/obstacle_avoidance_nodal.py
+++ b/examples/params/obstacle_avoidance_nodal.py
@@ -84,6 +84,7 @@ x_bar = np.linspace(initial_state.value, final_state.value, n)
 problem = TrajOptProblem(
     dynamics=dynamics,
     constraints=constraints,
+    idx_time=len(max_state)-1,
     N=n,
     time_init=total_time,
     x_guess=x_bar,

--- a/openscvx/config.py
+++ b/openscvx/config.py
@@ -54,15 +54,13 @@ class SimConfig:
     max_control: np.ndarray
     min_control: np.ndarray
     total_time: float
+    t_inds: int
+    y_inds: int
+    s_inds: int
     constraints_ctcs: List[callable] = field(
         default_factory=list
     )  # TODO (norrisg): clean this up, consider moving to dedicated `constraints` dataclass
     constraints_nodal: List[callable] = field(default_factory=list)
-    t_inds: int = (
-        -2
-    )  # TODO (norrisg): clean this up, should be generated and tracked more elegantly
-    y_inds: int = -1
-    s_inds: int = -1
     n_states: int = None
     n_controls: int = None
     S_x: np.ndarray = None

--- a/openscvx/config.py
+++ b/openscvx/config.py
@@ -54,9 +54,9 @@ class SimConfig:
     max_control: np.ndarray
     min_control: np.ndarray
     total_time: float
-    t_inds: int
-    y_inds: int
-    s_inds: int
+    idx_t: int
+    idx_y: int
+    idx_s: int
     constraints_ctcs: List[callable] = field(
         default_factory=list
     )  # TODO (norrisg): clean this up, consider moving to dedicated `constraints` dataclass

--- a/openscvx/config.py
+++ b/openscvx/config.py
@@ -54,9 +54,11 @@ class SimConfig:
     max_control: np.ndarray
     min_control: np.ndarray
     total_time: float
-    idx_t: int
-    idx_y: int
-    idx_s: int
+    idx_x_true: slice
+    idx_u_true: slice
+    idx_t: slice
+    idx_y: slice
+    idx_s: slice
     constraints_ctcs: List[callable] = field(
         default_factory=list
     )  # TODO (norrisg): clean this up, consider moving to dedicated `constraints` dataclass

--- a/openscvx/discretization.py
+++ b/openscvx/discretization.py
@@ -338,7 +338,7 @@ class ExactDis:
             # Use count to grab the first count number of elements
             tau_cur = tau_vals[prev_count:prev_count + count]
 
-            sol = self.params.prp.integrator(x_0, (tau[k], tau[k + 1]), controls_current, controls_next, np.array([[tau[k]]]), params.sim.s_inds)
+            sol = self.params.prp.integrator(x_0, (tau[k], tau[k + 1]), controls_current, controls_next, np.array([[tau[k]]]), params.sim.idx_s)
 
             x = sol.ys
             for tau_i in tau_cur:

--- a/openscvx/dynamics.py
+++ b/openscvx/dynamics.py
@@ -6,9 +6,8 @@ def get_augmented_dynamics(dynamics: callable, g_func: callable):
     def dynamics_augmented(x: jnp.array, u: jnp.array) -> jnp.array:
         # TODO: (norrisg) handle varying lengths of x and u due to augmentation more elegantly
         x_dot = dynamics(x[:-1], u)
-        t_dot = 1
         y_dot = g_func(x, u)
-        return jnp.hstack([x_dot, t_dot, y_dot])
+        return jnp.hstack([x_dot, y_dot])
 
     return dynamics_augmented
 

--- a/openscvx/dynamics.py
+++ b/openscvx/dynamics.py
@@ -4,8 +4,8 @@ import jax.numpy as jnp
 
 def get_augmented_dynamics(dynamics: callable, g_func: callable):
     def dynamics_augmented(x: jnp.array, u: jnp.array) -> jnp.array:
-        # TODO: (norrisg) handle varying lengths of x and u due to augmentation more elegantly
-        x_dot = dynamics(x[:-1], u)
+        # TODO: (norrisg) only pass user-defined portion of x to dynamics in case user has `-1` or similar indexing in function
+        x_dot = dynamics(x, u)
         y_dot = g_func(x, u)
         return jnp.hstack([x_dot, y_dot])
 

--- a/openscvx/ocp.py
+++ b/openscvx/ocp.py
@@ -111,8 +111,8 @@ def OCP(params: Config):
     constr += [u_nonscaled[i] <= params.sim.max_control for i in range(params.scp.n)]
     constr += [u_nonscaled[i] >= params.sim.min_control for i in range(params.scp.n)] # Control Constraints
 
-    constr += [x_nonscaled[i][:-1] <= params.sim.max_state[:-1] for i in range(params.scp.n)]
-    constr += [x_nonscaled[i][:-1] >= params.sim.min_state[:-1] for i in range(params.scp.n)] # State Constraints (Also implemented in CTCS but included for numerical stability)
+    constr += [x_nonscaled[i][params.sim.idx_x_true] <= params.sim.max_state[params.sim.idx_x_true] for i in range(params.scp.n)]
+    constr += [x_nonscaled[i][params.sim.idx_x_true] >= params.sim.min_state[params.sim.idx_x_true] for i in range(params.scp.n)] # State Constraints (Also implemented in CTCS but included for numerical stability)
 
     ########
     # COSTS
@@ -129,8 +129,8 @@ def OCP(params: Config):
                 cost += params.scp.lam_vb * cp.sum(cp.pos(nu_vb[idx_ncvx]))
                 idx_ncvx += 1
 
-    constr += [cp.abs(x_nonscaled[i][-1] - x_nonscaled[i-1][-1]) <= params.sim.max_state[-1] for i in range(1, params.scp.n)] # LICQ Constraint
-    constr += [x_nonscaled[0][-1] == 0]
+    constr += [cp.abs(x_nonscaled[i][params.sim.idx_y] - x_nonscaled[i-1][params.sim.idx_y]) <= params.sim.max_state[params.sim.idx_y] for i in range(1, params.scp.n)] # LICQ Constraint
+    constr += [x_nonscaled[0][params.sim.idx_y] == 0]
     
     #########
     # PROBLEM

--- a/openscvx/ocp.py
+++ b/openscvx/ocp.py
@@ -96,7 +96,7 @@ def OCP(params: Config):
             cost += lam_cost * x_nonscaled[-1][i]
 
     if params.scp.uniform_time_grid:
-        constr += [x_nonscaled[i][params.sim.t_inds] - x_nonscaled[i-1][params.sim.t_inds] == x_nonscaled[i-1][params.sim.t_inds] - x_nonscaled[i-2][params.sim.t_inds] for i in range(2, params.scp.n)] # Uniform Time Step
+        constr += [x_nonscaled[i][params.sim.idx_t] - x_nonscaled[i-1][params.sim.idx_t] == x_nonscaled[i-1][params.sim.idx_t] - x_nonscaled[i-2][params.sim.idx_t] for i in range(2, params.scp.n)] # Uniform Time Step
 
     constr += [0 == la.inv(S_x) @ (x_nonscaled[i] - x_bar[i] - dx[i]) for i in range(params.scp.n)] # State Error
     constr += [0 == la.inv(S_u) @ (u_nonscaled[i] - u_bar[i] - du[i]) for i in range(params.scp.n)] # Control Error

--- a/openscvx/ptr.py
+++ b/openscvx/ptr.py
@@ -169,7 +169,7 @@ def PTR_main(params: Config, prob: cp.Problem, aug_dy: ExactDis, cpg_solve) -> d
 
     result = dict(
         converged = k <= params.scp.k_max,
-        t_final = x[:,-2][-1],
+        t_final = x[:,params.sim.idx_t][-1],
         u = u,
         x = x,
         x_history = scp_trajs,

--- a/openscvx/ptr.py
+++ b/openscvx/ptr.py
@@ -194,7 +194,7 @@ def PTR_post(params: Config, result: dict, aug_dy: ExactDis) -> dict:
 
     x_full = aug_dy.simulate_nonlinear_time(x[0], u, tau_vals, t)
 
-    print("Total CTCS Constraint Violation:", x_full[-1, params.sim.y_inds])
+    print("Total CTCS Constraint Violation:", x_full[-1, params.sim.idx_y])
     i = 0
     cost = np.zeros_like(x[-1, i])
     for type in params.sim.initial_state.type:

--- a/openscvx/trajoptproblem.py
+++ b/openscvx/trajoptproblem.py
@@ -51,6 +51,9 @@ class TrajOptProblem:
 
         # TODO (norrisg) move this into some augmentation function, if we want to make this be executed after the init (i.e. within problem.initialize) need to rethink how problem is defined
 
+        len_x_true = len(x_max)
+        len_u_true = len(u_max)
+
         x_min_augmented = np.hstack([x_min, ctcs_augmentation_min])
         x_max_augmented = np.hstack([x_max, ctcs_augmentation_max])
 
@@ -110,7 +113,7 @@ class TrajOptProblem:
         for constraint in constraints:
             if constraint.constraint_type == "ctcs":
                 sim.constraints_ctcs.append(
-                    lambda x, u, func=constraint: jnp.sum(func.penalty(func(x, u)))
+                    lambda x, u, func=constraint: jnp.sum(func.penalty(func(x[:len_x_true], u[:len_u_true])))
                 )
             elif constraint.constraint_type == "nodal":
                 sim.constraints_nodal.append(constraint)

--- a/openscvx/trajoptproblem.py
+++ b/openscvx/trajoptproblem.py
@@ -27,6 +27,7 @@ class TrajOptProblem:
         self,
         dynamics: callable,
         constraints: List[callable],
+        idx_time: int,
         N: int,
         time_init: float,
         x_guess: jnp.ndarray,
@@ -51,8 +52,14 @@ class TrajOptProblem:
 
         # TODO (norrisg) move this into some augmentation function, if we want to make this be executed after the init (i.e. within problem.initialize) need to rethink how problem is defined
 
+        # Index tracking
         len_x_true = len(x_max)
         len_u_true = len(u_max)
+        idx_constraint_violation = len_x_true
+        idx_time_dilation = len_u_true
+
+        # check that idx_time is in the correct range
+        assert(idx_time >= 0 and idx_time < len_x_true), "idx_time must be in the range of the state vector and non-negative"
 
         x_min_augmented = np.hstack([x_min, ctcs_augmentation_min])
         x_max_augmented = np.hstack([x_max, ctcs_augmentation_max])
@@ -80,6 +87,9 @@ class TrajOptProblem:
                 min_control=u_min_augmented,
                 total_time=time_init,
                 n_states=len(x_max),
+                t_inds=idx_time,
+                y_inds=idx_constraint_violation,
+                s_inds=idx_time_dilation,
             )
 
         if scp is None:

--- a/openscvx/trajoptproblem.py
+++ b/openscvx/trajoptproblem.py
@@ -53,13 +53,14 @@ class TrajOptProblem:
         # TODO (norrisg) move this into some augmentation function, if we want to make this be executed after the init (i.e. within problem.initialize) need to rethink how problem is defined
 
         # Index tracking
-        len_x_true = len(x_max)
-        len_u_true = len(u_max)
-        idx_constraint_violation = len_x_true
-        idx_time_dilation = len_u_true
+        idx_x_true = slice(0, len(x_max))
+        idx_u_true = slice(0, len(u_max))
+        idx_constraint_violation = slice(idx_x_true.stop, idx_x_true.stop + 1)
+        idx_time_dilation = slice(idx_u_true.stop, idx_u_true.stop + 1)
 
         # check that idx_time is in the correct range
-        assert(idx_time >= 0 and idx_time < len_x_true), "idx_time must be in the range of the state vector and non-negative"
+        assert(idx_time >= 0 and idx_time < len(x_max)), "idx_time must be in the range of the state vector and non-negative"
+        idx_time = slice(idx_time, idx_time + 1)
 
         x_min_augmented = np.hstack([x_min, ctcs_augmentation_min])
         x_max_augmented = np.hstack([x_max, ctcs_augmentation_max])
@@ -87,6 +88,8 @@ class TrajOptProblem:
                 min_control=u_min_augmented,
                 total_time=time_init,
                 n_states=len(x_max),
+                idx_x_true=idx_x_true,
+                idx_u_true=idx_u_true,
                 idx_t=idx_time,
                 idx_y=idx_constraint_violation,
                 idx_s=idx_time_dilation,
@@ -123,7 +126,7 @@ class TrajOptProblem:
         for constraint in constraints:
             if constraint.constraint_type == "ctcs":
                 sim.constraints_ctcs.append(
-                    lambda x, u, func=constraint: jnp.sum(func.penalty(func(x[:len_x_true], u[:len_u_true])))
+                    lambda x, u, func=constraint: jnp.sum(func.penalty(func(x[idx_x_true], u[idx_u_true])))
                 )
             elif constraint.constraint_type == "nodal":
                 sim.constraints_nodal.append(constraint)

--- a/openscvx/trajoptproblem.py
+++ b/openscvx/trajoptproblem.py
@@ -87,9 +87,9 @@ class TrajOptProblem:
                 min_control=u_min_augmented,
                 total_time=time_init,
                 n_states=len(x_max),
-                t_inds=idx_time,
-                y_inds=idx_constraint_violation,
-                s_inds=idx_time_dilation,
+                idx_t=idx_time,
+                idx_y=idx_constraint_violation,
+                idx_s=idx_time_dilation,
             )
 
         if scp is None:


### PR DESCRIPTION
- Fixes #53, although in a roundabout way
- Time dynamics (usually `t_dot=1`) is now the users responsibility, this resolves the weirdness of having to define state constraints for time even when time dynamics are added under the hood, it is now all the users responsibility
- Initially tried to fully automate the time augmentation but this breaks use cases like `cinema_vp` where the user may want time dependent dynamics or constraints. In the future this can be resolved if/when we add custom symbolic variables. Then we can simply have a special `TimeVariable` type which allows the user to reference it without having to explicitly define the dynamics
- Resolved issue where user needed to know to only index `x[:-1]` for CTCS state bounds, which does not make sense for the user since the state and bounds are defined as the same size, this only arises since the CTCS constraint violation will be appended to the state later. This indexing is now handled under the hood
- User must now specify the time index, which must be part of the state
- Indices are now tracked as slices for use within the repo, currently not super elegant but it works

TODO:
- Should move index tracking and augmentation in general into other functions or maybe files? @griffin-norris 
- Especially to implement #27 should make the index slicing and tracking more robust, i.e to help track where in the large `A_qp` which vector is
```python
blocks = [
    ("x_true",               len(x_max)),
    ("u_true",               len(u_max)),
    ("constraint_violation", 1),
    ("time_dilation",        1),
]

offset = 0
idx = {}
for name, size in blocks:
    idx[name] = slice(offset, offset + size)
    offset += size

# use:
#   idx["x_true"], idx["u_true"], idx["constraint_violation"], idx["time_dilation"]
```
- Could move index stuff to own higher-level member of `Config` @griffin-norris 