### PR TITLE
Refactor/clean up ptr

### DIFF
--- a/examples/main.py
+++ b/examples/main.py
@@ -7,7 +7,7 @@ current_dir = os.path.dirname(os.path.abspath(__file__))
 parent_dir = os.path.dirname(current_dir)
 sys.path.append(parent_dir)
 
-from examples.params.dr_vp_nodal import problem, plotting_dict
+from examples.params.obstacle_avoidance import problem, plotting_dict
 
 from openscvx.ptr import PTR_main
 from examples.plotting import plot_camera_animation, plot_animation, plot_scp_animation
@@ -37,5 +37,7 @@ with open('results/results.pickle', 'rb') as f:
 
 results = problem.post_process(results)
 results.update(plotting_dict)
-plot_animation(results, problem.params)
-# plot_camera_animation(results, problem.params)
+animation_plot = plot_animation(results, problem.params)
+# animation_plot.show()
+# camera_plot = plot_camera_animation(results, problem.params)
+# camera_plot.show()

--- a/examples/params/obstacle_avoidance.py
+++ b/examples/params/obstacle_avoidance.py
@@ -104,7 +104,7 @@ problem = TrajOptProblem(
 
 problem.params.scp.w_tr_adapt = 1.8
 
-problem.params.dev.debug_printing = True
+problem.params.dev.printing = True
 
 problem.params.prp.dt = 0.01
 problem.params.dis.custom_integrator = True

--- a/examples/plotting.py
+++ b/examples/plotting.py
@@ -148,7 +148,7 @@ def plot_camera_view(result: dict, params: Config) -> None:
     # Save figure as svg
     fig.write_image("figures/camera_view.svg")
 
-    fig.show()
+    return fig
 
 def plot_camera_animation(result: dict, params:Config, path="") -> None:
     title = r'$\text{Camera Animation}$'
@@ -313,7 +313,7 @@ def plot_camera_animation(result: dict, params:Config, path="") -> None:
     # # Remove the paper background
     # fig.update_layout(paper_bgcolor='rgba(0,0,0,0)')
 
-    fig.show()  
+    return fig  
 
 def plot_camera_polytope_animation(result: dict, params: Config, path="") -> None:
     title = r'$\text{Camera Animation}$'
@@ -572,7 +572,7 @@ def plot_camera_polytope_animation(result: dict, params: Config, path="") -> Non
 
     # # Remove the paper background
     # fig.update_layout(paper_bgcolor='rgba(0,0,0,0)')
-    fig.show()  
+    return fig  
 
 def plot_conic_view_animation(result: dict, params: Config, path="") -> None:
     title = r'$\text{Conic Constraint}$'
@@ -766,7 +766,7 @@ def plot_conic_view_animation(result: dict, params: Config, path="") -> None:
     # # Remove the paper background
     # fig.update_layout(paper_bgcolor='rgba(0,0,0,0)')
 
-    fig.show()
+    return fig
 
 def plot_conic_view_polytope_animation(result: dict, params: Config, path="") -> None:
     title = r'$\text{Conic Constraint}$'
@@ -1061,7 +1061,7 @@ def plot_conic_view_polytope_animation(result: dict, params: Config, path="") ->
     # with open(f'{path}results/conic_animation.html', 'w') as f:
     #     f.write(html_str)
 
-    fig.show()
+    return fig
 
 def plot_animation(result: dict,
                    params: Config,
@@ -1395,7 +1395,7 @@ def plot_animation(result: dict,
         dtick=1.0
     )
 
-    fig.show()
+    return fig
 
 
 def plot_scp_animation(result: dict,
@@ -1632,7 +1632,7 @@ def plot_scp_animation(result: dict,
     if not "moving_subject" in result:
         fig.update_layout(scene_camera=dict(up=dict(x=0, y=0, z=90), center=dict(x=1, y=0.3, z=1), eye=dict(x=-1, y=2, z=1)))
 
-    fig.show()
+    return fig
 
 def scp_traj_interp(scp_trajs, params: Config):
     scp_prop_trajs = []

--- a/openscvx/config.py
+++ b/openscvx/config.py
@@ -23,7 +23,7 @@ class DiscretizationConfig:
 class DevConfig:
     profiling: bool = False
     debug: bool = False
-    debug_printing: bool = True
+    printing: bool = True
 
 
 @dataclass

--- a/openscvx/io.py
+++ b/openscvx/io.py
@@ -1,7 +1,13 @@
+import sys
 import warnings
 warnings.filterwarnings("ignore")
 
 from termcolor import colored
+
+# Define colors for printing
+col_main = "blue"
+col_pos = "green"
+col_neg = "red"
 
 def intro():
     # Silence syntax warnings
@@ -28,6 +34,32 @@ def header():
     print("{:^4} | {:^7} | {:^7} | {:^7} | {:^7} | {:^7} | {:^7} |  {:^7} | {:^14}".format(
         "Iter", "Dis Time (ms)", "Solve Time (ms)", "J_total", "J_tr", "J_vb", "J_vc", "Cost", "Solver Status"))
     print(colored("---------------------------------------------------------------------------------------------------------"))
+
+def intermediate(print_queue: list, params):
+
+    while print_queue:
+        data = print_queue.pop(0)
+        # remove bottom labels and line
+        if not data["iter"] == 1:
+            sys.stdout.write('\x1b[1A\x1b[2K\x1b[1A\x1b[2K')
+        if data["prob_stat"][3] == 'f':
+            # Only show the first element of the string
+            data["prob_stat"] = data["prob_stat"][0]
+
+        iter_colored = colored("{:4d}".format(data["iter"]))
+        J_tot_colored = colored("{:.1e}".format(data["J_total"]))
+        J_tr_colored = colored("{:.1e}".format(data["J_tr"]), col_pos if data["J_tr"] <= params.scp.ep_tr else col_neg)
+        J_vb_colored = colored("{:.1e}".format(data["J_vb"]), col_pos if data["J_vb"] <= params.scp.ep_vb else col_neg)
+        J_vc_colored = colored("{:.1e}".format(data["J_vc"]), col_pos if data["J_vc"] <= params.scp.ep_vc else col_neg)
+        cost_colored = colored("{:.1e}".format(data["cost"]))
+        prob_stat_colored = colored(data["prob_stat"], col_pos if data["prob_stat"] == 'optimal' else col_neg)
+
+        print("{:^4} |     {:^6.2f}    |      {:^6.2F}     | {:^7} | {:^7} | {:^7} | {:^7} |  {:^7} | {:^14}".format(
+            iter_colored, data["dis_time"], data["subprop_time"], J_tot_colored, J_tr_colored, J_vb_colored, J_vc_colored, cost_colored, prob_stat_colored))
+
+    print(colored("---------------------------------------------------------------------------------------------------------"))
+    print("{:^4} | {:^7} | {:^7} | {:^7} | {:^7} | {:^7} | {:^7} |  {:^7} | {:^14}".format(
+        "Iter", "Dis Time (ms)", "Solve Time (ms)", "J_total", "J_tr", "J_vb", "J_vc", "Cost", "Solver Status"))
 
 def footer(computation_time):
     print(colored("---------------------------------------------------------------------------------------------------------"))

--- a/openscvx/io.py
+++ b/openscvx/io.py
@@ -1,0 +1,40 @@
+import warnings
+warnings.filterwarnings("ignore")
+
+from termcolor import colored
+
+def intro():
+    # Silence syntax warnings
+    warnings.filterwarnings("ignore")
+    ascii_art = '''
+                             
+                            ____                    _____  _____           
+                           / __ \                  / ____|/ ____|          
+                          | |  | |_ __   ___ _ __ | (___ | |  __   ____  __
+                          | |  | | '_ \ / _ \ '_ \ \___ \| |  \ \ / /\ \/ /
+                          | |__| | |_) |  __/ | | |____) | |___\ V /  >  < 
+                           \____/| .__/ \___|_| |_|_____/ \_____\_/  /_/\_\ 
+                                 | |                                       
+                                 |_|                                       
+---------------------------------------------------------------------------------------------------------
+                                Author: Chris Hayner and Griffin Norris
+                                    Autonomous Controls Laboratory
+                                       University of Washington
+---------------------------------------------------------------------------------------------------------
+'''
+    print(ascii_art)
+
+def header():
+    print("{:^4} | {:^7} | {:^7} | {:^7} | {:^7} | {:^7} | {:^7} |  {:^7} | {:^14}".format(
+        "Iter", "Dis Time (ms)", "Solve Time (ms)", "J_total", "J_tr", "J_vb", "J_vc", "Cost", "Solver Status"))
+    print(colored("---------------------------------------------------------------------------------------------------------"))
+
+def footer(computation_time):
+    print(colored("---------------------------------------------------------------------------------------------------------"))
+    # Define ANSI color codes
+    BOLD = "\033[1m"
+    RESET = "\033[0m"
+
+    # Print with bold text
+    print("------------------------------------------------ " + BOLD + "RESULTS" + RESET + " ------------------------------------------------")
+    print("Total Computation Time: ", computation_time)

--- a/openscvx/io.py
+++ b/openscvx/io.py
@@ -1,6 +1,8 @@
 import sys
 import warnings
 warnings.filterwarnings("ignore")
+import queue
+import time
 
 from termcolor import colored
 
@@ -12,6 +14,7 @@ col_neg = "red"
 def intro():
     # Silence syntax warnings
     warnings.filterwarnings("ignore")
+    # fmt: off
     ascii_art = '''
                              
                             ____                    _____  _____           
@@ -28,6 +31,7 @@ def intro():
                                        University of Washington
 ---------------------------------------------------------------------------------------------------------
 '''
+    # fmt: on
     print(ascii_art)
 
 def header():
@@ -35,31 +39,36 @@ def header():
         "Iter", "Dis Time (ms)", "Solve Time (ms)", "J_total", "J_tr", "J_vb", "J_vc", "Cost", "Solver Status"))
     print(colored("---------------------------------------------------------------------------------------------------------"))
 
-def intermediate(print_queue: list, params):
+def intermediate(print_queue, params):
+    hz = 30.0
+    while True:
+        t_start = time.time()
+        try:
+            data = print_queue.get(timeout=1.0/hz)
+            # remove bottom labels and line
+            if not data["iter"] == 1:
+                sys.stdout.write('\x1b[1A\x1b[2K\x1b[1A\x1b[2K')
+            if data["prob_stat"][3] == 'f':
+                # Only show the first element of the string
+                data["prob_stat"] = data["prob_stat"][0]
 
-    while print_queue:
-        data = print_queue.pop(0)
-        # remove bottom labels and line
-        if not data["iter"] == 1:
-            sys.stdout.write('\x1b[1A\x1b[2K\x1b[1A\x1b[2K')
-        if data["prob_stat"][3] == 'f':
-            # Only show the first element of the string
-            data["prob_stat"] = data["prob_stat"][0]
+            iter_colored = colored("{:4d}".format(data["iter"]))
+            J_tot_colored = colored("{:.1e}".format(data["J_total"]))
+            J_tr_colored = colored("{:.1e}".format(data["J_tr"]), col_pos if data["J_tr"] <= params.scp.ep_tr else col_neg)
+            J_vb_colored = colored("{:.1e}".format(data["J_vb"]), col_pos if data["J_vb"] <= params.scp.ep_vb else col_neg)
+            J_vc_colored = colored("{:.1e}".format(data["J_vc"]), col_pos if data["J_vc"] <= params.scp.ep_vc else col_neg)
+            cost_colored = colored("{:.1e}".format(data["cost"]))
+            prob_stat_colored = colored(data["prob_stat"], col_pos if data["prob_stat"] == 'optimal' else col_neg)
 
-        iter_colored = colored("{:4d}".format(data["iter"]))
-        J_tot_colored = colored("{:.1e}".format(data["J_total"]))
-        J_tr_colored = colored("{:.1e}".format(data["J_tr"]), col_pos if data["J_tr"] <= params.scp.ep_tr else col_neg)
-        J_vb_colored = colored("{:.1e}".format(data["J_vb"]), col_pos if data["J_vb"] <= params.scp.ep_vb else col_neg)
-        J_vc_colored = colored("{:.1e}".format(data["J_vc"]), col_pos if data["J_vc"] <= params.scp.ep_vc else col_neg)
-        cost_colored = colored("{:.1e}".format(data["cost"]))
-        prob_stat_colored = colored(data["prob_stat"], col_pos if data["prob_stat"] == 'optimal' else col_neg)
+            print("{:^4} |     {:^6.2f}    |      {:^6.2F}     | {:^7} | {:^7} | {:^7} | {:^7} |  {:^7} | {:^14}".format(
+                iter_colored, data["dis_time"], data["subprop_time"], J_tot_colored, J_tr_colored, J_vb_colored, J_vc_colored, cost_colored, prob_stat_colored))
 
-        print("{:^4} |     {:^6.2f}    |      {:^6.2F}     | {:^7} | {:^7} | {:^7} | {:^7} |  {:^7} | {:^14}".format(
-            iter_colored, data["dis_time"], data["subprop_time"], J_tot_colored, J_tr_colored, J_vb_colored, J_vc_colored, cost_colored, prob_stat_colored))
-
-        print(colored("---------------------------------------------------------------------------------------------------------"))
-        print("{:^4} | {:^7} | {:^7} | {:^7} | {:^7} | {:^7} | {:^7} |  {:^7} | {:^14}".format(
-            "Iter", "Dis Time (ms)", "Solve Time (ms)", "J_total", "J_tr", "J_vb", "J_vc", "Cost", "Solver Status"))
+            print(colored("---------------------------------------------------------------------------------------------------------"))
+            print("{:^4} | {:^7} | {:^7} | {:^7} | {:^7} | {:^7} | {:^7} |  {:^7} | {:^14}".format(
+                "Iter", "Dis Time (ms)", "Solve Time (ms)", "J_total", "J_tr", "J_vb", "J_vc", "Cost", "Solver Status"))
+        except queue.Empty:
+            pass
+        time.sleep(max(0.0, 1.0/hz - (time.time() - t_start)))
 
 def footer(computation_time):
     print(colored("---------------------------------------------------------------------------------------------------------"))

--- a/openscvx/io.py
+++ b/openscvx/io.py
@@ -57,9 +57,9 @@ def intermediate(print_queue: list, params):
         print("{:^4} |     {:^6.2f}    |      {:^6.2F}     | {:^7} | {:^7} | {:^7} | {:^7} |  {:^7} | {:^14}".format(
             iter_colored, data["dis_time"], data["subprop_time"], J_tot_colored, J_tr_colored, J_vb_colored, J_vc_colored, cost_colored, prob_stat_colored))
 
-    print(colored("---------------------------------------------------------------------------------------------------------"))
-    print("{:^4} | {:^7} | {:^7} | {:^7} | {:^7} | {:^7} | {:^7} |  {:^7} | {:^14}".format(
-        "Iter", "Dis Time (ms)", "Solve Time (ms)", "J_total", "J_tr", "J_vb", "J_vc", "Cost", "Solver Status"))
+        print(colored("---------------------------------------------------------------------------------------------------------"))
+        print("{:^4} | {:^7} | {:^7} | {:^7} | {:^7} | {:^7} | {:^7} |  {:^7} | {:^14}".format(
+            "Iter", "Dis Time (ms)", "Solve Time (ms)", "J_total", "J_tr", "J_vb", "J_vc", "Cost", "Solver Status"))
 
 def footer(computation_time):
     print(colored("---------------------------------------------------------------------------------------------------------"))

--- a/openscvx/post_processing.py
+++ b/openscvx/post_processing.py
@@ -1,0 +1,36 @@
+import numpy as np
+
+from openscvx.propagation import s_to_t, t_to_tau, simulate_nonlinear_time
+from openscvx.config import Config
+
+
+def propagate_trajectory_results(params: Config, result: dict, propagation_solver: callable) -> dict:
+    x = result["x"]
+    u = result["u"]
+
+    t = np.array(s_to_t(u, params))
+
+    t_full = np.arange(0, t[-1], params.prp.dt)
+
+    tau_vals, u_full = t_to_tau(u, t_full, u, t, params)
+
+    x_full = simulate_nonlinear_time(x[0], u, tau_vals, t, params, propagation_solver)
+
+    print("Total CTCS Constraint Violation:", x_full[-1, params.sim.idx_y])
+    i = 0
+    cost = np.zeros_like(x[-1, i])
+    for type in params.sim.initial_state.type:
+        if type == "Minimize":
+            cost += x[0, i]
+        i += 1
+    i = 0
+    for type in params.sim.final_state.type:
+        if type == "Minimize":
+            cost += x[-1, i]
+        i += 1
+    print("Cost: ", cost)
+
+    more_result = dict(t_full=t_full, x_full=x_full, u_full=u_full)
+
+    result.update(more_result)
+    return result

--- a/openscvx/ptr.py
+++ b/openscvx/ptr.py
@@ -35,11 +35,10 @@ def PTR_main(params: Config, prob: cp.Problem, aug_dy: callable, cpg_solve, emit
     V_multi_shoot_traj = []
 
     k = 1
-    log_data = []
 
     while k <= params.scp.k_max and ((J_tr >= params.scp.ep_tr) or (J_vb >= params.scp.ep_vb) or (J_vc >= params.scp.ep_vc)):
         x, u, t, J_total, J_vb_vec, J_vc_vec, J_tr_vec, prob_stat, V_multi_shoot, subprop_time, dis_time = PTR_subproblem(cpg_solve, x_bar, u_bar, aug_dy, prob, params)
-        
+
         V_multi_shoot_traj.append(V_multi_shoot)
 
         x_bar = x
@@ -55,7 +54,8 @@ def PTR_main(params: Config, prob: cp.Problem, aug_dy: callable, cpg_solve, emit
         if k > params.scp.cost_drop:
             params.scp.lam_cost = params.scp.lam_cost * params.scp.cost_relax
 
-        log_data.append({
+        emitter_function(
+            {
                 "iter": k,
                 "dis_time": dis_time * 1000.0,
                 "subprop_time": subprop_time * 1000.0,
@@ -64,10 +64,10 @@ def PTR_main(params: Config, prob: cp.Problem, aug_dy: callable, cpg_solve, emit
                 "J_vb": J_vb,
                 "J_vc": J_vc,
                 "cost": t[-1],
-                "prob_stat": prob_stat
-            })
-        emitter_function(log_data[-1])
-            
+                "prob_stat": prob_stat,
+            }
+        )
+
         k += 1
 
     result = dict(

--- a/openscvx/ptr.py
+++ b/openscvx/ptr.py
@@ -10,12 +10,13 @@ from termcolor import colored
 from openscvx.propagation import s_to_t, t_to_tau, simulate_nonlinear_time
 from openscvx.config import Config
 from openscvx.ocp import OptimalControlProblem
+from openscvx import io
 
 import warnings
 warnings.filterwarnings("ignore")
 
 def PTR_init(ocp: cp.Problem, discretization_solver: callable, params: Config, ) -> tuple[cp.Problem, callable]:
-    intro()
+    io.intro()
 
     t_0_while = time.time()
 
@@ -50,9 +51,7 @@ def PTR_main(params: Config, prob: cp.Problem, aug_dy: callable, cpg_solve) -> d
     col_pos = "green"
     col_neg = "red"
 
-    print("{:^4} | {:^7} | {:^7} | {:^7} | {:^7} | {:^7} | {:^7} |  {:^7} | {:^14}".format(
-            "Iter", "Dis Time (ms)", "Solve Time (ms)", "J_total", "J_tr", "J_vb", "J_vc", "Cost", "Solver Status"))
-    print(colored("---------------------------------------------------------------------------------------------------------"))
+    io.header()
 
     k = 1
 
@@ -83,8 +82,6 @@ def PTR_main(params: Config, prob: cp.Problem, aug_dy: callable, cpg_solve) -> d
         params.scp.w_tr = min(params.scp.w_tr * params.scp.w_tr_adapt, params.scp.w_tr_max)
         if k > params.scp.cost_drop:
             params.scp.lam_cost = params.scp.lam_cost * params.scp.cost_relax
-        
-
 
         log_data.append({
                 "iter": k,
@@ -154,14 +151,7 @@ def PTR_main(params: Config, prob: cp.Problem, aug_dy: callable, cpg_solve) -> d
                 iter_colored, data["dis_time"], data["subprop_time"], J_tot_colored, J_tr_colored, J_vb_colored, J_vc_colored, cost_colored, prob_stat_colored))
 
 
-    print(colored("---------------------------------------------------------------------------------------------------------"))
-    # Define ANSI color codes
-    BOLD = "\033[1m"
-    RESET = "\033[0m"
-
-    # Print with bold text
-    print("------------------------------------------------ " + BOLD + "RESULTS" + RESET + " ------------------------------------------------")
-    print("Total Computation Time: ", t_f_while - t_0_while)
+    io.footer(t_f_while - t_0_while)
 
     result = dict(
         converged = k <= params.scp.k_max,
@@ -277,24 +267,3 @@ def PTR_subproblem(cpg_solve, x_bar, u_bar, aug_dy, prob, params: Config):
             J_vb_vec += np.maximum(0, prob.var_dict['nu_vb_' + str(id_ncvx)].value)
             id_ncvx += 1
     return x, u, costs, prob.value, J_vb_vec, J_vc_vec, J_tr_vec, prob.status, V_multi_shoot, subprop_time, dis_time
-
-def intro():
-    # Silence syntax warnings
-    warnings.filterwarnings("ignore")
-    ascii_art = '''
-                             
-                            ____                    _____  _____           
-                           / __ \                  / ____|/ ____|          
-                          | |  | |_ __   ___ _ __ | (___ | |  __   ____  __
-                          | |  | | '_ \ / _ \ '_ \ \___ \| |  \ \ / /\ \/ /
-                          | |__| | |_) |  __/ | | |____) | |___\ V /  >  < 
-                           \____/| .__/ \___|_| |_|_____/ \_____\_/  /_/\_\ 
-                                 | |                                       
-                                 |_|                                       
----------------------------------------------------------------------------------------------------------
-                                Author: Chris Hayner and Griffin Norris
-                                    Autonomous Controls Laboratory
-                                       University of Washington
----------------------------------------------------------------------------------------------------------
-'''
-    print(ascii_art)

--- a/openscvx/ptr.py
+++ b/openscvx/ptr.py
@@ -4,7 +4,6 @@ import cvxpy as cp
 import pickle
 import time
 
-from openscvx.propagation import s_to_t, t_to_tau, simulate_nonlinear_time
 from openscvx.config import Config
 
 import warnings
@@ -83,41 +82,6 @@ def PTR_main(params: Config, prob: cp.Problem, aug_dy: callable, cpg_solve, emit
         J_vb_history = J_vb_vec,
         J_vc_history = J_vc_vec,
     )
-    return result
-
-def PTR_post(params: Config, result: dict, propagation_solver: callable) -> dict:
-    x = result["x"]
-    u = result["u"]
-
-    t = np.array(s_to_t(u, params))
-
-    t_full = np.arange(0, t[-1], params.prp.dt)
-
-    tau_vals, u_full = t_to_tau(u, t_full, u, t, params)
-
-    x_full = simulate_nonlinear_time(x[0], u, tau_vals, t, params, propagation_solver)
-
-    print("Total CTCS Constraint Violation:", x_full[-1, params.sim.idx_y])
-    i = 0
-    cost = np.zeros_like(x[-1, i])
-    for type in params.sim.initial_state.type:
-        if type == 'Minimize':
-            cost += x[0, i]
-        i +=1
-    i = 0
-    for type in params.sim.final_state.type:
-        if type == 'Minimize':
-            cost += x[-1, i]
-        i +=1
-    print("Cost: ", cost)
-
-    more_result = dict(
-        t_full = t_full,
-        x_full = x_full,
-        u_full = u_full
-    )
-
-    result.update(more_result)
     return result
 
 

--- a/openscvx/ptr.py
+++ b/openscvx/ptr.py
@@ -50,13 +50,6 @@ def PTR_main(params: Config, prob: cp.Problem, aug_dy: callable, cpg_solve, emit
 
     k = 1
 
-    if params.dev.profiling:
-        import cProfile
-        pr = cProfile.Profile()
-        
-        # Enable the profiler
-        pr.enable()
-
     log_data = []
 
     t_0_while = time.time()
@@ -94,12 +87,6 @@ def PTR_main(params: Config, prob: cp.Problem, aug_dy: callable, cpg_solve, emit
         k += 1
 
     t_f_while = time.time()
-    # Disable the profiler
-    if params.dev.profiling:
-        pr.disable()
-        
-        # Save results so it can be viusualized with snakeviz
-        pr.dump_stats('profiling_results.prof')
     
     # Allow emitter function to finish
     time.sleep(0.5)

--- a/openscvx/ptr.py
+++ b/openscvx/ptr.py
@@ -71,9 +71,6 @@ def PTR_main(params: Config, prob: cp.Problem, aug_dy: callable, cpg_solve, emit
             
         k += 1
 
-    # Allow emitter function to finish
-    time.sleep(0.5)
-
     result = dict(
         converged = k <= params.scp.k_max,
         t_final = x[:,params.sim.idx_t][-1],

--- a/openscvx/ptr.py
+++ b/openscvx/ptr.py
@@ -4,13 +4,8 @@ import cvxpy as cp
 import pickle
 import time
 
-import sys
-from termcolor import colored
-
 from openscvx.propagation import s_to_t, t_to_tau, simulate_nonlinear_time
 from openscvx.config import Config
-from openscvx.ocp import OptimalControlProblem
-from openscvx import io
 
 import warnings
 warnings.filterwarnings("ignore")

--- a/openscvx/trajoptproblem.py
+++ b/openscvx/trajoptproblem.py
@@ -163,14 +163,20 @@ class TrajOptProblem:
         self.discretization_solver: callable = None
         self.cpg_solve = None
 
-        self.print_queue = queue.Queue()
-        self.emitter_function = lambda intermediate_result: self.print_queue.put(
-            intermediate_result
-        )
-        self.print_thread = threading.Thread(
-            target=io.intermediate, args=(self.print_queue, self.params), daemon=True
-        )
-        self.print_thread.start()
+        # set up emitter & thread only if printing is enabled
+        if self.params.dev.printing:
+            self.print_queue      = queue.Queue()
+            self.emitter_function = lambda data: self.print_queue.put(data)
+            self.print_thread     = threading.Thread(
+                target=io.intermediate,
+                args=(self.print_queue, self.params),
+                daemon=True,
+            )
+            self.print_thread.start()
+        else:
+            # no-op emitter; nothing ever gets queued or printed
+            self.emitter_function = lambda data: None
+
 
         self.timing_init = None
         self.timing_solve = None

--- a/openscvx/trajoptproblem.py
+++ b/openscvx/trajoptproblem.py
@@ -22,7 +22,8 @@ from openscvx.constraints.ctcs import get_g_func
 from openscvx.discretization import get_discretization_solver
 from openscvx.propagation import get_propagation_solver
 from openscvx.constraints.boundary import BoundaryConstraint
-from openscvx.ptr import PTR_init, PTR_main, PTR_post
+from openscvx.ptr import PTR_init, PTR_main
+from openscvx.post_processing import propagate_trajectory_results
 from openscvx.ocp import OptimalControlProblem
 from openscvx import io
 
@@ -300,7 +301,7 @@ class TrajOptProblem:
             pr.enable()
 
         t_0_post = time.time()
-        result = PTR_post(self.params, result, self.propagation_solver)
+        result = propagate_trajectory_results(self.params, result, self.propagation_solver)
         t_f_post = time.time()
 
         self.timing_post = t_f_post - t_0_post

--- a/openscvx/trajoptproblem.py
+++ b/openscvx/trajoptproblem.py
@@ -225,9 +225,24 @@ class TrajOptProblem:
                 "Problem has not been initialized. Call initialize() before solve()"
             )
 
-        return PTR_main(
+
+        # Enable the profiler
+        if self.params.dev.profiling:
+            import cProfile
+            pr = cProfile.Profile()
+            pr.enable()
+
+        result =  PTR_main(
             self.params, self.optimal_control_problem, self.discretization_solver, self.cpg_solve, self.emitter_function
         )
+    
+        # Disable the profiler
+        if self.params.dev.profiling:
+            pr.disable()
+            # Save results so it can be viusualized with snakeviz
+            pr.dump_stats('profiling_results.prof')
+        
+        return result
 
     def post_process(self, result):
         return PTR_post(self.params, result, self.propagation_solver)

--- a/openscvx/trajoptproblem.py
+++ b/openscvx/trajoptproblem.py
@@ -269,6 +269,8 @@ class TrajOptProblem:
         )
 
         t_f_while = time.time()
+        while self.print_queue.qsize() > 0:
+            time.sleep(0.1)
         # Print bottom footer for solver results as well as total computation time
         io.footer(t_f_while - t_0_while)
         # Disable the profiler

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -22,7 +22,7 @@ TEST_CASES = {
         "max_cost": 2.0,
         "max_vio": 1e-3,
         "max_iters": 10,
-        "timing": {"init": 12.0, "solve": 0.5, "post": 0.5},
+        "timing": {"init": 15.0, "solve": 0.5, "post": 0.5},
         # no custom integrator flag
     },
     "dr_vp_nodal": {
@@ -33,7 +33,7 @@ TEST_CASES = {
         "vio_idx": -1,
         "max_cost": 30.0,
         "max_vio": 1e-3,
-        "timing": {"init": 30.0, "solve": 3.0, "post": 1.0},
+        "timing": {"init": 35.0, "solve": 3.0, "post": 1.0},
         "pre_init": [lambda p: setattr(p.params.dis, "custom_integrator", False), lambda p: setattr(p.params.dev, "printing", False)],
     },
     "dr_vp": {
@@ -44,7 +44,7 @@ TEST_CASES = {
         "vio_idx": -1,
         "max_cost": 45.0,
         "max_vio": 1.0,
-        "timing": {"init": 30.0, "solve": 3.0, "post": 1.0},
+        "timing": {"init": 35.0, "solve": 3.0, "post": 1.0},
         "pre_init": [lambda p: setattr(p.params.dis, "custom_integrator", False), lambda p: setattr(p.params.dev, "printing", False)],
     },
     "cinema_vp": {

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -34,12 +34,12 @@ def test_obstacle_avoidance():
     prop_cost = result['x_full'][:,-2][-1]
     sol_cost = result['x'][:,-2][-1]
 
-    assert sol_cost < 2.0, "Obstacle Avoidance Process failed with solution cost"
-    assert prop_cost < 2.0, "Obstacle Avoidance Process failed with propagated cost"
-    assert sol_constr_vio < 1e-3, "Obstacle Avoidance Process failed with solution constraint violation"
-    assert prop_constr_vio < 1e-3, "Obstacle Avoidance Process failed with propagated constraint violation"
-    assert scp_iters < 10, "Obstacle Avoidance Process took more then expected iterations"
-    assert output_dict['converged'], "Obstacle Avoidance Process failed with output"
+    assert sol_cost < 2.0, "Problem failed with solution cost"
+    assert prop_cost < 2.0, "Problem failed with propagated cost"
+    assert sol_constr_vio < 1e-3, "Problem failed with solution constraint violation"
+    assert prop_constr_vio < 1e-3, "Problem failed with propagated constraint violation"
+    assert scp_iters < 10, "Problem took more then expected iterations"
+    assert output_dict['converged'], "Problem failed with output"
 
     assert problem.timing_init < 6.0, "Problem took more then expected initialization time"
     assert problem.timing_solve < 0.2, "Problem took more then expected solve time"
@@ -69,10 +69,10 @@ def test_dr_vp_nodal():
     prop_cost = result['x_full'][:,-2][-1]
     sol_cost = result['x'][:,-2][-1]
 
-    assert sol_cost < 30.0, "Obstacle Avoidance Process failed with solution cost"
-    assert prop_cost < 30.0, "Obstacle Avoidance Process failed with propagated cost"
-    assert sol_constr_vio < 1e-3, "Obstacle Avoidance Process failed with solution constraint violation"
-    assert prop_constr_vio < 1e-3, "Obstacle Avoidance Process failed with propagated constraint violation"
+    assert sol_cost < 30.0, "Problem failed with solution cost"
+    assert prop_cost < 30.0, "Problem failed with propagated cost"
+    assert sol_constr_vio < 1e-3, "Problem failed with solution constraint violation"
+    assert prop_constr_vio < 1e-3, "Problem failed with propagated constraint violation"
     assert output_dict['converged'], "DR VP Nodal Process failed with output"
 
     assert problem.timing_init < 20.0, "Problem took more then expected initialization time"
@@ -103,10 +103,10 @@ def test_dr_vp():
     prop_cost = result['x_full'][:,-2][-1]
     sol_cost = result['x'][:,-2][-1]
     
-    assert sol_cost < 45.0, "Obstacle Avoidance Process failed with solution cost"
-    assert prop_cost < 45.0, "Obstacle Avoidance Process failed with propagated cost"
-    assert sol_constr_vio < 1e0, "Obstacle Avoidance Process failed with solution constraint violation"
-    assert prop_constr_vio < 1e0, "Obstacle Avoidance Process failed with propagated constraint violation"
+    assert sol_cost < 45.0, "Problem failed with solution cost"
+    assert prop_cost < 45.0, "Problem failed with propagated cost"
+    assert sol_constr_vio < 1e0, "Problem failed with solution constraint violation"
+    assert prop_constr_vio < 1e0, "Problem failed with propagated constraint violation"
     assert output_dict['converged'], "DR VP Process failed with output"
 
     assert problem.timing_init < 25.0, "Problem took more then expected initialization time"
@@ -137,10 +137,10 @@ def test_cinema_vp():
     prop_cost = result['x_full'][:,-3][-1]
     sol_cost = result['x'][:,-3][-1]
     
-    assert sol_cost < 400.0, "Obstacle Avoidance Process failed with solution cost"
-    assert prop_cost < 400.0, "Obstacle Avoidance Process failed with propagated cost"
-    assert sol_constr_vio < 1E0, "Obstacle Avoidance Process failed with solution constraint violation"
-    assert prop_constr_vio < 1e0, "Obstacle Avoidance Process failed with propagated constraint violation"
+    assert sol_cost < 400.0, "Problem failed with solution cost"
+    assert prop_cost < 400.0, "Problem failed with propagated cost"
+    assert sol_constr_vio < 1E0, "Problem failed with solution constraint violation"
+    assert prop_constr_vio < 1e0, "Problem failed with propagated constraint violation"
     assert output_dict['converged'], "Cinema VP Process failed with output"
 
     assert problem.timing_init < 8.0, "Problem took more then expected initialization time"

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -40,6 +40,10 @@ def test_obstacle_avoidance():
     assert prop_constr_vio < 1e-3, "Obstacle Avoidance Process failed with propagated constraint violation"
     assert scp_iters < 10, "Obstacle Avoidance Process took more then expected iterations"
     assert output_dict['converged'], "Obstacle Avoidance Process failed with output"
+
+    assert problem.timing_init < 6.0, "Problem took more then expected initialization time"
+    assert problem.timing_solve < 0.2, "Problem took more then expected solve time"
+    assert problem.timing_post < 0.2, "Problem took more then expected post process time"
     
     # Clean up jax memory usage
     jax.clear_caches()
@@ -70,6 +74,10 @@ def test_dr_vp_nodal():
     assert sol_constr_vio < 1e-3, "Obstacle Avoidance Process failed with solution constraint violation"
     assert prop_constr_vio < 1e-3, "Obstacle Avoidance Process failed with propagated constraint violation"
     assert output_dict['converged'], "DR VP Nodal Process failed with output"
+
+    assert problem.timing_init < 20.0, "Problem took more then expected initialization time"
+    assert problem.timing_solve < 2.0, "Problem took more then expected solve time"
+    assert problem.timing_post < 0.5, "Problem took more then expected post process time"
     
     # Clean up jax memory usage
     jax.clear_caches()
@@ -100,6 +108,10 @@ def test_dr_vp():
     assert sol_constr_vio < 1e0, "Obstacle Avoidance Process failed with solution constraint violation"
     assert prop_constr_vio < 1e0, "Obstacle Avoidance Process failed with propagated constraint violation"
     assert output_dict['converged'], "DR VP Process failed with output"
+
+    assert problem.timing_init < 25.0, "Problem took more then expected initialization time"
+    assert problem.timing_solve < 2.0, "Problem took more then expected solve time"
+    assert problem.timing_post < 0.5, "Problem took more then expected post process time"
     
     # Clean up jax memory usage
     jax.clear_caches()
@@ -130,6 +142,10 @@ def test_cinema_vp():
     assert sol_constr_vio < 1E0, "Obstacle Avoidance Process failed with solution constraint violation"
     assert prop_constr_vio < 1e0, "Obstacle Avoidance Process failed with propagated constraint violation"
     assert output_dict['converged'], "Cinema VP Process failed with output"
+
+    assert problem.timing_init < 8.0, "Problem took more then expected initialization time"
+    assert problem.timing_solve < 0.5, "Problem took more then expected solve time"
+    assert problem.timing_post < 0.5, "Problem took more then expected post process time"
     
     # Clean up jax memory usage
     jax.clear_caches()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -55,7 +55,7 @@ TEST_CASES = {
         "vio_idx": -1,
         "max_cost": 400.0,
         "max_vio": 1.0,
-        "timing": {"init": 8.0, "solve": 0.5, "post": 0.5},
+        "timing": {"init": 8.0, "solve": 0.8, "post": 0.5},
         "pre_init": [lambda p: setattr(p.params.dis, "custom_integrator", False), lambda p: setattr(p.params.dev, "printing", False)],
     },
 }

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -34,7 +34,7 @@ TEST_CASES = {
         "max_cost": 30.0,
         "max_vio": 1e-3,
         "timing": {"init": 20.0, "solve": 2.0, "post": 0.5},
-        "pre_init": lambda p: setattr(p.params.dis, "custom_integrator", False),
+        "pre_init": [lambda p: setattr(p.params.dis, "custom_integrator", False), lambda p: setattr(p.params.dev, "printing", False)],
     },
     "dr_vp": {
         "problem": dr_vp_problem,
@@ -45,7 +45,7 @@ TEST_CASES = {
         "max_cost": 45.0,
         "max_vio": 1.0,
         "timing": {"init": 25.0, "solve": 2.0, "post": 0.5},
-        "pre_init": lambda p: setattr(p.params.dis, "custom_integrator", False),
+        "pre_init": [lambda p: setattr(p.params.dis, "custom_integrator", False), lambda p: setattr(p.params.dev, "printing", False)],
     },
     "cinema_vp": {
         "problem": cinema_vp_problem,
@@ -56,16 +56,21 @@ TEST_CASES = {
         "max_cost": 400.0,
         "max_vio": 1.0,
         "timing": {"init": 8.0, "solve": 0.5, "post": 0.5},
-        "pre_init": lambda p: setattr(p.params.dis, "custom_integrator", False),
+        "pre_init": [lambda p: setattr(p.params.dis, "custom_integrator", False), lambda p: setattr(p.params.dev, "printing", False)],
     },
 }
 
 @pytest.mark.parametrize("name,conf", TEST_CASES.items(), ids=list(TEST_CASES))
 def test_example_problem(name, conf):
     problem = conf["problem"]
-    # apply any per‐problem tweaks
+    # apply any pre‐init hooks
     if "pre_init" in conf:
-        conf["pre_init"](problem)
+        hooks = conf["pre_init"]
+        # normalize to list
+        if callable(hooks):
+            hooks = [hooks]
+        for fn in hooks:
+            fn(problem)
 
     problem.initialize()
     result = problem.solve()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -22,7 +22,7 @@ TEST_CASES = {
         "max_cost": 2.0,
         "max_vio": 1e-3,
         "max_iters": 10,
-        "timing": {"init": 10.0, "solve": 0.5, "post": 0.5},
+        "timing": {"init": 12.0, "solve": 0.5, "post": 0.5},
         # no custom integrator flag
     },
     "dr_vp_nodal": {

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -22,7 +22,7 @@ TEST_CASES = {
         "max_cost": 2.0,
         "max_vio": 1e-3,
         "max_iters": 10,
-        "timing": {"init": 6.0, "solve": 0.2, "post": 0.2},
+        "timing": {"init": 8.0, "solve": 0.5, "post": 0.5},
         # no custom integrator flag
     },
     "dr_vp_nodal": {
@@ -33,7 +33,7 @@ TEST_CASES = {
         "vio_idx": -1,
         "max_cost": 30.0,
         "max_vio": 1e-3,
-        "timing": {"init": 20.0, "solve": 2.0, "post": 0.5},
+        "timing": {"init": 30.0, "solve": 3.0, "post": 1.0},
         "pre_init": [lambda p: setattr(p.params.dis, "custom_integrator", False), lambda p: setattr(p.params.dev, "printing", False)],
     },
     "dr_vp": {
@@ -44,7 +44,7 @@ TEST_CASES = {
         "vio_idx": -1,
         "max_cost": 45.0,
         "max_vio": 1.0,
-        "timing": {"init": 25.0, "solve": 2.0, "post": 0.5},
+        "timing": {"init": 30.0, "solve": 3.0, "post": 1.0},
         "pre_init": [lambda p: setattr(p.params.dis, "custom_integrator", False), lambda p: setattr(p.params.dev, "printing", False)],
     },
     "cinema_vp": {
@@ -55,7 +55,7 @@ TEST_CASES = {
         "vio_idx": -1,
         "max_cost": 400.0,
         "max_vio": 1.0,
-        "timing": {"init": 8.0, "solve": 0.8, "post": 0.5},
+        "timing": {"init": 8.0, "solve": 1.0, "post": 1.0},
         "pre_init": [lambda p: setattr(p.params.dis, "custom_integrator", False), lambda p: setattr(p.params.dev, "printing", False)],
     },
 }

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -12,140 +12,91 @@ from examples.params.dr_vp_nodal import problem as dr_vp_polytope_problem
 from examples.params.dr_vp_nodal import plotting_dict as dr_vp_polytope_plotting_dict
 from examples.plotting import plot_camera_animation, plot_animation, plot_scp_animation
 
+TEST_CASES = {
+    "obstacle_avoidance": {
+        "problem": obstacle_avoidance_problem,
+        "plotting_dict": obstacle_avoidance_plotting_dict,
+        "plot_funcs": [plot_animation, plot_scp_animation],
+        "cost_idx": -2,
+        "vio_idx": -1,
+        "max_cost": 2.0,
+        "max_vio": 1e-3,
+        "max_iters": 10,
+        "timing": {"init": 6.0, "solve": 0.2, "post": 0.2},
+        # no custom integrator flag
+    },
+    "dr_vp_nodal": {
+        "problem": dr_vp_polytope_problem,
+        "plotting_dict": dr_vp_polytope_plotting_dict,
+        "plot_funcs": [plot_animation, plot_camera_animation, plot_scp_animation],
+        "cost_idx": -2,
+        "vio_idx": -1,
+        "max_cost": 30.0,
+        "max_vio": 1e-3,
+        "timing": {"init": 20.0, "solve": 2.0, "post": 0.5},
+        "pre_init": lambda p: setattr(p.params.dis, "custom_integrator", False),
+    },
+    "dr_vp": {
+        "problem": dr_vp_problem,
+        "plotting_dict": dr_vp_plotting_dict,
+        "plot_funcs": [plot_animation, plot_camera_animation, plot_scp_animation],
+        "cost_idx": -2,
+        "vio_idx": -1,
+        "max_cost": 45.0,
+        "max_vio": 1.0,
+        "timing": {"init": 25.0, "solve": 2.0, "post": 0.5},
+        "pre_init": lambda p: setattr(p.params.dis, "custom_integrator", False),
+    },
+    "cinema_vp": {
+        "problem": cinema_vp_problem,
+        "plotting_dict": cinema_vp_plotting_dict,
+        "plot_funcs": [plot_animation, plot_camera_animation, plot_scp_animation],
+        "cost_idx": -3,
+        "vio_idx": -1,
+        "max_cost": 400.0,
+        "max_vio": 1.0,
+        "timing": {"init": 8.0, "solve": 0.5, "post": 0.5},
+        "pre_init": lambda p: setattr(p.params.dis, "custom_integrator", False),
+    },
+}
 
-def test_obstacle_avoidance():
-    # This test is specific to the obstacle avoidance problem
-    problem = obstacle_avoidance_problem
+@pytest.mark.parametrize("name,conf", TEST_CASES.items(), ids=list(TEST_CASES))
+def test_example_problem(name, conf):
+    problem = conf["problem"]
+    # apply any per‐problem tweaks
+    if "pre_init" in conf:
+        conf["pre_init"](problem)
+
     problem.initialize()
     result = problem.solve()
     result = problem.post_process(result)
 
-    result.update(obstacle_avoidance_plotting_dict)
+    # merge in plotting metadata and run plots
+    result.update(conf["plotting_dict"])
+    for fn in conf["plot_funcs"]:
+        fn(result, problem.params)
 
-    plot_animation(result, problem.params)
-    plot_scp_animation(result, problem.params)
-    
-    # Assuming PTR_main returns a dictionary
-    output_dict = result
-    
-    scp_iters = len(result['discretization_history'])
-    prop_constr_vio = result['x_full'][:,-1][-1]
-    sol_constr_vio = result['x'][:,-1][-1]
-    prop_cost = result['x_full'][:,-2][-1]
-    sol_cost = result['x'][:,-2][-1]
+    # extract metrics
+    scp_iters = len(result["discretization_history"])
+    sol_cost = result["x"][:, conf["cost_idx"]][-1]
+    prop_cost = result["x_full"][:, conf["cost_idx"]][-1]
+    sol_constr_vio  = result["x"][:, conf["vio_idx"]][-1]
+    prop_constr_vio = result["x_full"][:, conf["vio_idx"]][-1]
 
-    assert sol_cost < 2.0, "Problem failed with solution cost"
-    assert prop_cost < 2.0, "Problem failed with propagated cost"
-    assert sol_constr_vio < 1e-3, "Problem failed with solution constraint violation"
-    assert prop_constr_vio < 1e-3, "Problem failed with propagated constraint violation"
-    assert scp_iters < 10, "Problem took more then expected iterations"
-    assert output_dict['converged'], "Problem failed with output"
+    # assertions
+    assert sol_cost < conf["max_cost"], "Problem failed with solution cost"
+    assert prop_cost < conf["max_cost"], "Problem failed with propagated cost"
+    assert sol_constr_vio  < conf["max_vio"], "Problem failed with solution constraint violation"
+    assert prop_constr_vio < conf["max_vio"], "Problem failed with propagated constraint violation"
+    if "max_iters" in conf:
+        assert scp_iters < conf["max_iters"], "Problem took more then expected iterations"
+    assert result["converged"], "Problem failed with output"
 
-    assert problem.timing_init < 6.0, "Problem took more then expected initialization time"
-    assert problem.timing_solve < 0.2, "Problem took more then expected solve time"
-    assert problem.timing_post < 0.2, "Problem took more then expected post process time"
-    
-    # Clean up jax memory usage
-    jax.clear_caches()
+    # timing checks
+    t = conf["timing"]
+    assert problem.timing_init <  t["init"], "Problem took more then expected initialization time"
+    assert problem.timing_solve < t["solve"], "Problem took more then expected solve time"
+    assert problem.timing_post <  t["post"], "Problem took more then expected post process time"
 
-def test_dr_vp_nodal():
-    # This test is specific to the dr_vp_nodal problem
-    problem = dr_vp_polytope_problem
-    problem.params.dis.custom_integrator = False
-    problem.initialize()
-    result = problem.solve()
-    result = problem.post_process(result)
-
-    result.update(dr_vp_plotting_dict)
-
-    plot_animation(result, problem.params)
-    plot_camera_animation(result, problem.params)
-    plot_scp_animation(result, problem.params)
-    
-    # Assuming PTR_main returns a dictionary
-    output_dict = result
-    prop_constr_vio = result['x_full'][:,-1][-1]
-    sol_constr_vio = result['x'][:,-1][-1]
-    prop_cost = result['x_full'][:,-2][-1]
-    sol_cost = result['x'][:,-2][-1]
-
-    assert sol_cost < 30.0, "Problem failed with solution cost"
-    assert prop_cost < 30.0, "Problem failed with propagated cost"
-    assert sol_constr_vio < 1e-3, "Problem failed with solution constraint violation"
-    assert prop_constr_vio < 1e-3, "Problem failed with propagated constraint violation"
-    assert output_dict['converged'], "DR VP Nodal Process failed with output"
-
-    assert problem.timing_init < 20.0, "Problem took more then expected initialization time"
-    assert problem.timing_solve < 2.0, "Problem took more then expected solve time"
-    assert problem.timing_post < 0.5, "Problem took more then expected post process time"
-    
-    # Clean up jax memory usage
-    jax.clear_caches()
-
-def test_dr_vp():
-    # This test is specific to the dr_vp problem
-    problem = dr_vp_problem
-    problem.params.dis.custom_integrator = False
-    problem.initialize()
-    result = problem.solve()
-    result = problem.post_process(result)
-
-    result.update(dr_vp_plotting_dict)
-
-    plot_animation(result, problem.params)
-    plot_camera_animation(result, problem.params)
-    plot_scp_animation(result, problem.params)
-    
-    # Assuming PTR_main returns a dictionary
-    output_dict = result
-    prop_constr_vio = result['x_full'][:,-1][-1]
-    sol_constr_vio = result['x'][:,-1][-1]
-    prop_cost = result['x_full'][:,-2][-1]
-    sol_cost = result['x'][:,-2][-1]
-    
-    assert sol_cost < 45.0, "Problem failed with solution cost"
-    assert prop_cost < 45.0, "Problem failed with propagated cost"
-    assert sol_constr_vio < 1e0, "Problem failed with solution constraint violation"
-    assert prop_constr_vio < 1e0, "Problem failed with propagated constraint violation"
-    assert output_dict['converged'], "DR VP Process failed with output"
-
-    assert problem.timing_init < 25.0, "Problem took more then expected initialization time"
-    assert problem.timing_solve < 2.0, "Problem took more then expected solve time"
-    assert problem.timing_post < 0.5, "Problem took more then expected post process time"
-    
-    # Clean up jax memory usage
-    jax.clear_caches()
-
-def test_cinema_vp():
-    # This test is specific to the cinema_vp problem
-    problem = cinema_vp_problem
-    problem.params.dis.custom_integrator = False
-    problem.initialize()
-    result = problem.solve()
-    result = problem.post_process(result)
-
-    result.update(cinema_vp_plotting_dict)
-
-    plot_animation(result, problem.params)
-    plot_camera_animation(result, problem.params)
-    plot_scp_animation(result, problem.params)
-    
-    # Assuming PTR_main returns a dictionary
-    output_dict = result
-    prop_constr_vio = result['x_full'][:,-1][-1]
-    sol_constr_vio = result['x'][:,-1][-1]
-    prop_cost = result['x_full'][:,-3][-1]
-    sol_cost = result['x'][:,-3][-1]
-    
-    assert sol_cost < 400.0, "Problem failed with solution cost"
-    assert prop_cost < 400.0, "Problem failed with propagated cost"
-    assert sol_constr_vio < 1E0, "Problem failed with solution constraint violation"
-    assert prop_constr_vio < 1e0, "Problem failed with propagated constraint violation"
-    assert output_dict['converged'], "Cinema VP Process failed with output"
-
-    assert problem.timing_init < 8.0, "Problem took more then expected initialization time"
-    assert problem.timing_solve < 0.5, "Problem took more then expected solve time"
-    assert problem.timing_post < 0.5, "Problem took more then expected post process time"
-    
-    # Clean up jax memory usage
+    # clean up
     jax.clear_caches()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -22,7 +22,7 @@ TEST_CASES = {
         "max_cost": 2.0,
         "max_vio": 1e-3,
         "max_iters": 10,
-        "timing": {"init": 8.0, "solve": 0.5, "post": 0.5},
+        "timing": {"init": 10.0, "solve": 0.5, "post": 0.5},
         # no custom integrator flag
     },
     "dr_vp_nodal": {
@@ -55,7 +55,7 @@ TEST_CASES = {
         "vio_idx": -1,
         "max_cost": 400.0,
         "max_vio": 1.0,
-        "timing": {"init": 8.0, "solve": 1.0, "post": 1.0},
+        "timing": {"init": 12.0, "solve": 1.0, "post": 1.0},
         "pre_init": [lambda p: setattr(p.params.dis, "custom_integrator", False), lambda p: setattr(p.params.dev, "printing", False)],
     },
 }


### PR DESCRIPTION
- Fixes #76 -> Printing has been completely moved out of `ptr.py`
- Printing is now handled by a separate thread which only prints at a fixed frequency (30hz).
- Intermediate results from the PTR algorithm are added to a queue for printing
- Dependency injection is used to pass in an `emitter_function` to `PTR_main` which handles the intermediate results -> this means that no queuing or threading dependencies are necessary within `ptr` -> **PTR is now purely algorithmic**
- Fixes #70 
- Fixes #78 -> added profiling for initialization and post processing of `TrajOptProblem`
- Fixes #42 -> added timing information to `TrajOptProblem` and used inside CI, also reorganized `test_examples` to use a single test and a `TEST_CASES` dict to iterate through each of the test configurations -> Fixes #46
- Fixes #74 -> minor fix to prevent nuisance plots opening