### PR TITLE
Feature/augmented states

### DIFF
--- a/examples/params/cinema_vp.py
+++ b/examples/params/cinema_vp.py
@@ -10,7 +10,6 @@ from openscvx.constraints.decorators import ctcs
 n = 12  # Number of Nodes
 total_time = 40.0  # Total time for the simulation
 
-
 fuel_inds = 13  # Fuel Index in State
 t_inds = 14
 s_inds = 6  # Time dilation index in Control

--- a/examples/params/cinema_vp.py
+++ b/examples/params/cinema_vp.py
@@ -136,7 +136,7 @@ problem = TrajOptProblem(
     x_min=min_state,
     u_max=max_control,  # Upper Bound on the controls
     u_min=min_control,  # Lower Bound on the controls
-    ctcs_augmentation_max=1e-8,
+    licq_max=1e-8,
 )
 
 problem.params.prp.dt = 0.1

--- a/openscvx/config.py
+++ b/openscvx/config.py
@@ -77,11 +77,11 @@ class SimConfig:
         self.n_controls = len(self.max_control)
 
         assert (
-            len(self.initial_state.value) == self.n_states - 1
-        ), f"Initial state must have {self.n_states - 1} elements"
+            len(self.initial_state.value) == self.n_states - (self.idx_y.stop - self.idx_y.start)
+        ), f"Initial state must have {self.n_states - (self.idx_y.stop - self.idx_y.start)} elements"
         assert (
-            len(self.final_state.value) == self.n_states - 1
-        ), f"Final state must have {self.n_states - 1} elements"
+            len(self.final_state.value) == self.n_states - (self.idx_y.stop - self.idx_y.start)
+        ), f"Final state must have {self.n_states - (self.idx_y.stop - self.idx_y.start)} elements"
         assert (
             self.max_state.shape[0] == self.n_states
         ), f"Max state must have {self.n_states} elements"

--- a/openscvx/constraints/boundary.py
+++ b/openscvx/constraints/boundary.py
@@ -48,3 +48,7 @@ class BoundaryConstraint:
     def type(self):
         # Expose the helper class so that slice assignments work naturally.
         return self._types
+    
+    # Make an append method to add new types
+    def append_type(self, new_type):
+        self._types.values.append(new_type)

--- a/openscvx/constraints/ctcs.py
+++ b/openscvx/constraints/ctcs.py
@@ -1,9 +1,9 @@
 import jax.numpy as jnp
 
-def get_g_func(constraints_ctcs: list[callable]):
+def get_g_func(constraints_ctcs: list[callable, callable]):
     def g_func(x: jnp.array, u: jnp.array) -> jnp.array:
         g_sum = 0
         for g in constraints_ctcs:
-            g_sum += g(x, u)
+            g_sum += g(x,u)
         return g_sum
     return g_func

--- a/openscvx/constraints/decorators.py
+++ b/openscvx/constraints/decorators.py
@@ -2,9 +2,11 @@ from jax import jit, vmap, jacfwd
 import jax.numpy as jnp
 
 
-def ctcs(func: callable, penalty="squared_relu") -> callable:
+def ctcs(func: callable, penalty="squared_relu", nodes = "all", exclusive = False) -> callable:
     """Decorator to mark a function as a 'ctcs' constraint."""
     func.constraint_type = "ctcs"
+    func.nodes = nodes
+    func.exclusive = exclusive
     if penalty == "squared_relu":
         func.penalty = lambda x: jnp.maximum(0, x) ** 2
     elif penalty == "huber":

--- a/openscvx/constraints/decorators.py
+++ b/openscvx/constraints/decorators.py
@@ -2,11 +2,13 @@ from jax import jit, vmap, jacfwd
 import jax.numpy as jnp
 
 
-def ctcs(func: callable, penalty="squared_relu", nodes = "all", exclusive = False) -> callable:
+def ctcs(func: callable, penalty="squared_relu", nodes = "all", exclusive = False, licq_max=None) -> callable:
     """Decorator to mark a function as a 'ctcs' constraint."""
     func.constraint_type = "ctcs"
     func.nodes = nodes
     func.exclusive = exclusive
+    func.licq_max = licq_max
+    
     if penalty == "squared_relu":
         func.penalty = lambda x: jnp.maximum(0, x) ** 2
     elif penalty == "huber":

--- a/openscvx/constraints/decorators.py
+++ b/openscvx/constraints/decorators.py
@@ -2,12 +2,11 @@ from jax import jit, vmap, jacfwd
 import jax.numpy as jnp
 
 
-def ctcs(func: callable, penalty="squared_relu", nodes = "all", exclusive = False, licq_max=None) -> callable:
+def ctcs(func: callable, penalty="squared_relu", nodes = "all", exclusive = False) -> callable:
     """Decorator to mark a function as a 'ctcs' constraint."""
     func.constraint_type = "ctcs"
     func.nodes = nodes
     func.exclusive = exclusive
-    func.licq_max = licq_max
     
     if penalty == "squared_relu":
         func.penalty = lambda x: jnp.maximum(0, x) ** 2

--- a/openscvx/dynamics.py
+++ b/openscvx/dynamics.py
@@ -2,12 +2,19 @@ import jax
 import jax.numpy as jnp
 
 
-def get_augmented_dynamics(dynamics: callable, g_func: callable):
+def get_augmented_dynamics(dynamics: callable, g_func: dict[str, callable]):
     def dynamics_augmented(x: jnp.array, u: jnp.array) -> jnp.array:
         # TODO: (norrisg) only pass user-defined portion of x to dynamics in case user has `-1` or similar indexing in function
         x_dot = dynamics(x, u)
-        y_dot = g_func(x, u)
-        return jnp.hstack([x_dot, y_dot])
+        # y_dot = g_func(x, u)
+        # return jnp.hstack([x_dot, y_dot])
+
+        # Iterate through the g_func dictionary and stack the output each function
+        # to x_dot
+        for key, g in g_func.items():
+            x_dot = jnp.hstack([x_dot, g(x, u)])
+        
+        return x_dot
 
     return dynamics_augmented
 

--- a/openscvx/dynamics.py
+++ b/openscvx/dynamics.py
@@ -6,12 +6,10 @@ def get_augmented_dynamics(dynamics: callable, g_func: dict[str, callable]):
     def dynamics_augmented(x: jnp.array, u: jnp.array) -> jnp.array:
         # TODO: (norrisg) only pass user-defined portion of x to dynamics in case user has `-1` or similar indexing in function
         x_dot = dynamics(x, u)
-        # y_dot = g_func(x, u)
-        # return jnp.hstack([x_dot, y_dot])
 
         # Iterate through the g_func dictionary and stack the output each function
         # to x_dot
-        for key, g in g_func.items():
+        for _, g in g_func.items():
             x_dot = jnp.hstack([x_dot, g(x, u)])
         
         return x_dot

--- a/openscvx/ocp.py
+++ b/openscvx/ocp.py
@@ -85,7 +85,7 @@ def OptimalControlProblem(params: Config):
                 constr += [((g[idx_ncvx][node] + grad_g_x[idx_ncvx][node] @ dx[node] + grad_g_u[idx_ncvx][node] @ du[node])) == nu_vb[idx_ncvx][node] for node in nodes]
                 idx_ncvx += 1
 
-    for i in range(params.sim.n_states-1):
+    for i in range(params.sim.n_states-params.sim.num_augmented_states):
         if params.sim.initial_state.type[i] == 'Fix':
             constr += [x_nonscaled[0][i] == params.sim.initial_state.value[i]]  # Initial Boundary Conditions
         if params.sim.final_state.type[i] == 'Fix':
@@ -129,8 +129,14 @@ def OptimalControlProblem(params: Config):
                 cost += params.scp.lam_vb * cp.sum(cp.pos(nu_vb[idx_ncvx]))
                 idx_ncvx += 1
 
-    constr += [cp.abs(x_nonscaled[i][params.sim.idx_y] - x_nonscaled[i-1][params.sim.idx_y]) <= params.sim.max_state[params.sim.idx_y] for i in range(1, params.scp.n)] # LICQ Constraint
-    constr += [x_nonscaled[0][params.sim.idx_y] == 0]
+    for idx, nodes in zip(np.arange(params.sim.idx_y.start, params.sim.idx_y.stop), params.sim.y_nodes):  
+        if nodes == 'all':
+            constr += [cp.abs(x_nonscaled[i][idx] - x_nonscaled[i-1][params.sim.idx_y]) <= params.sim.max_state[params.sim.idx_y] for i in range(1, params.scp.n)] # LICQ Constraint
+            constr += [x_nonscaled[0][idx] == 0]
+        else:
+            constr += [cp.abs(x_nonscaled[i][idx] - x_nonscaled[i-1][params.sim.idx_y]) <= params.sim.max_state[params.sim.idx_y] for i in range(nodes[0], nodes[1])]
+            constr += [x_nonscaled[0][idx] == 0]
+
     
     #########
     # PROBLEM

--- a/openscvx/ocp.py
+++ b/openscvx/ocp.py
@@ -131,10 +131,14 @@ def OptimalControlProblem(params: Config):
 
     for idx, nodes in zip(np.arange(params.sim.idx_y.start, params.sim.idx_y.stop), params.sim.y_nodes):  
         if nodes == 'all':
-            constr += [cp.abs(x_nonscaled[i][idx] - x_nonscaled[i-1][params.sim.idx_y]) <= params.sim.max_state[params.sim.idx_y] for i in range(1, params.scp.n)] # LICQ Constraint
+            constr += [cp.abs(x_nonscaled[i][idx] - x_nonscaled[i-1][idx]) <= params.sim.max_state[idx] for i in range(1, params.scp.n)] # LICQ Constraint
             constr += [x_nonscaled[0][idx] == 0]
         else:
-            constr += [cp.abs(x_nonscaled[i][idx] - x_nonscaled[i-1][params.sim.idx_y]) <= params.sim.max_state[params.sim.idx_y] for i in range(nodes[0], nodes[1])]
+            if nodes[0] == 0:
+                start_indx = 1
+            else:
+                start_indx = nodes[0]
+            constr += [cp.abs(x_nonscaled[i][idx] - x_nonscaled[i-1][idx]) <= params.sim.max_state[idx] for i in range(start_indx, nodes[1])]
             constr += [x_nonscaled[0][idx] == 0]
 
     


### PR DESCRIPTION
Changelog:
- Added ability to have multiple augmented states for constraint violation. 
- The `ctcs` decorator now has the additional arguments `nodes = "all", exclusive = False`. Setting nodes to `"all"` will apply the `ctcs` constraint over the full interval. Unless `exclusive` is set to be `True`, the constraints will be grouped into the same augmented state corresponding to their associated nodes. If `exclusive` is `True`, then the constraint will gets its own _exclusive_ augmented state.  To set it over a subinterval set to 'nodes=(1, 4)' where the `tuple` correspond to the beginning node and final node. Note that is the beginning node is 0 it will be fixed to 1 as the LICQ constraint is formulated as from `y_k - y_k-1 <= eps_licq`, see the implementation below.

```python
if nodes[0] == 0:
    start_indx = 1
else:
    start_indx = nodes[0]
constr += [cp.abs(x_nonscaled[i][idx] - x_nonscaled[i-1][idx]) <= params.sim.max_state[idx] for i in range(start_indx, nodes[1])]
```