### PR TITLE
Feature/decorator boundary constraint interface

### DIFF
--- a/examples/params/cinema_vp.py
+++ b/examples/params/cinema_vp.py
@@ -4,7 +4,7 @@ import jax.numpy as jnp
 
 from openscvx.trajoptproblem import TrajOptProblem
 from openscvx.utils import qdcm, SSMP, SSM, get_kp_pose
-from openscvx.constraints.boundary import BoundaryConstraint as bc
+from openscvx.constraints.boundary import boundary
 from openscvx.constraints.decorators import ctcs
 
 n = 12  # Number of Nodes
@@ -22,10 +22,10 @@ min_state = np.array(
     [-100.0, -100, -10, -100, -100, -100, -1, -1, -1, -1, -10, -10, -10, 0, 0]
 )  # Lower Bound on the states
 
-initial_state = bc(jnp.array([8.0, -0.2, 2.2, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0]))
+initial_state = boundary(jnp.array([8.0, -0.2, 2.2, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0]))
 initial_state.type[6:14] = "Free"
 
-final_state = bc(jnp.array([-10.0, 0, 2, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 40]))
+final_state = boundary(jnp.array([-10.0, 0, 2, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 40]))
 final_state.type[0:13] = "Free"
 final_state.type[13] = "Minimize" # Minimize fuel usage
 

--- a/examples/params/cinema_vp.py
+++ b/examples/params/cinema_vp.py
@@ -4,8 +4,7 @@ import jax.numpy as jnp
 
 from openscvx.trajoptproblem import TrajOptProblem
 from openscvx.utils import qdcm, SSMP, SSM, get_kp_pose
-from openscvx.constraints.boundary import boundary
-from openscvx.constraints.decorators import ctcs
+from openscvx.constraints import boundary, ctcs
 
 n = 12  # Number of Nodes
 total_time = 40.0  # Total time for the simulation

--- a/examples/params/dr_vp.py
+++ b/examples/params/dr_vp.py
@@ -5,7 +5,7 @@ import jax.numpy as jnp
 
 from openscvx.trajoptproblem import TrajOptProblem
 from openscvx.utils import qdcm, SSMP, SSM, rot, gen_vertices
-from openscvx.constraints.boundary import BoundaryConstraint as bc
+from openscvx.constraints.boundary import boundary
 from openscvx.constraints.decorators import ctcs, nodal
 
 n = 33  # Number of Nodes
@@ -18,10 +18,10 @@ min_state = np.array(
     [-200.0, -100, 15, -100, -100, -100, -1, -1, -1, -1, -10, -10, -10, 0]
 )  # Lower Bound on the states
 
-initial_state = bc(jnp.array([10.0, 0, 20, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]))
+initial_state = boundary(jnp.array([10.0, 0, 20, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]))
 initial_state.type[6:13] = "Free"
 
-final_state = bc(jnp.array([10.0, 0, 20, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, total_time]))
+final_state = boundary(jnp.array([10.0, 0, 20, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, total_time]))
 final_state.type[3:13] = "Free"
 final_state.type[13] = "Minimize"
 

--- a/examples/params/dr_vp.py
+++ b/examples/params/dr_vp.py
@@ -5,8 +5,7 @@ import jax.numpy as jnp
 
 from openscvx.trajoptproblem import TrajOptProblem
 from openscvx.utils import qdcm, SSMP, SSM, rot, gen_vertices
-from openscvx.constraints.boundary import boundary
-from openscvx.constraints.decorators import ctcs, nodal
+from openscvx.constraints import boundary, ctcs, nodal
 
 n = 33  # Number of Nodes
 total_time = 40.0  # Total time for the simulation

--- a/examples/params/dr_vp_nodal.py
+++ b/examples/params/dr_vp_nodal.py
@@ -5,7 +5,7 @@ import jax.numpy as jnp
 
 from openscvx.trajoptproblem import TrajOptProblem
 from openscvx.utils import qdcm, SSMP, SSM, rot, gen_vertices
-from openscvx.constraints.boundary import BoundaryConstraint as bc
+from openscvx.constraints.boundary import boundary
 from openscvx.constraints.decorators import ctcs, nodal
 
 n = 33  # Number of Nodes
@@ -18,10 +18,10 @@ min_state = np.array(
     [-200.0, -100, 15, -100, -100, -100, -1, -1, -1, -1, -10, -10, -10, 0]
 )  # Lower Bound on the states
 
-initial_state = bc(jnp.array([10.0, 0, 20, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]))
+initial_state = boundary(jnp.array([10.0, 0, 20, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]))
 initial_state.type[6:13] = "Free"
 
-final_state = bc(jnp.array([10.0, 0, 20, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, total_time]))
+final_state = boundary(jnp.array([10.0, 0, 20, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, total_time]))
 final_state.type[3:13] = "Free"
 final_state.type[13] = "Minimize"
 

--- a/examples/params/dr_vp_nodal.py
+++ b/examples/params/dr_vp_nodal.py
@@ -5,8 +5,7 @@ import jax.numpy as jnp
 
 from openscvx.trajoptproblem import TrajOptProblem
 from openscvx.utils import qdcm, SSMP, SSM, rot, gen_vertices
-from openscvx.constraints.boundary import boundary
-from openscvx.constraints.decorators import ctcs, nodal
+from openscvx.constraints import boundary, nodal
 
 n = 33  # Number of Nodes
 total_time = 30.0  # Total time for the simulation

--- a/examples/params/dr_vp_polytope.py
+++ b/examples/params/dr_vp_polytope.py
@@ -5,8 +5,7 @@ import cvxpy as cp
 
 from openscvx.trajoptproblem import TrajOptProblem
 from openscvx.utils import qdcm, SSMP, SSM, rot, gen_vertices
-from openscvx.constraints.boundary import boundary
-from openscvx.constraints.decorators import ctcs, nodal
+from openscvx.constraints import boundary, ctcs, nodal
 
 n = 33  # Number of Nodes
 total_time = 30.0  # Total time for the simulation

--- a/examples/params/dr_vp_polytope.py
+++ b/examples/params/dr_vp_polytope.py
@@ -5,7 +5,7 @@ import cvxpy as cp
 
 from openscvx.trajoptproblem import TrajOptProblem
 from openscvx.utils import qdcm, SSMP, SSM, rot, gen_vertices
-from openscvx.constraints.boundary import BoundaryConstraint as bc
+from openscvx.constraints.boundary import boundary
 from openscvx.constraints.decorators import ctcs, nodal
 
 n = 33  # Number of Nodes
@@ -20,10 +20,10 @@ min_state = np.array(
     [-200.0, -100, 15, -100, -100, -100, -1, -1, -1, -1, -10, -10, -10, 0]
 )  # Lower Bound on the states
 
-initial_state = bc(jnp.array([10.0, 0, 20, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]))
+initial_state = boundary(jnp.array([10.0, 0, 20, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]))
 initial_state.type[6:13] = "Free"
 
-final_state = bc(jnp.array([10.0, 0, 20, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, total_time]))
+final_state = boundary(jnp.array([10.0, 0, 20, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, total_time]))
 final_state.type[3:13] = "Free"
 final_state.type[13] = "Minimize"
 

--- a/examples/params/drone_racing.py
+++ b/examples/params/drone_racing.py
@@ -3,8 +3,7 @@ import jax.numpy as jnp
 import cvxpy as cp
 
 from openscvx.trajoptproblem import TrajOptProblem
-from openscvx.constraints.boundary import boundary
-from openscvx.constraints.decorators import ctcs, nodal
+from openscvx.constraints import boundary, ctcs, nodal
 from openscvx.utils import qdcm, SSMP, SSM, rot, gen_vertices
 
 n = 22  # Number of Nodes

--- a/examples/params/drone_racing.py
+++ b/examples/params/drone_racing.py
@@ -3,7 +3,7 @@ import jax.numpy as jnp
 import cvxpy as cp
 
 from openscvx.trajoptproblem import TrajOptProblem
-from openscvx.constraints.boundary import BoundaryConstraint as bc
+from openscvx.constraints.boundary import boundary
 from openscvx.constraints.decorators import ctcs, nodal
 from openscvx.utils import qdcm, SSMP, SSM, rot, gen_vertices
 
@@ -17,10 +17,10 @@ min_state = np.array(
     [-200.0, -100, 15, -100, -100, -100, -1, -1, -1, -1, -10, -10, -10, 0]
 )  # Lower Bound on the states
 
-initial_state = bc(jnp.array([10.0, 0, 20, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]))
+initial_state = boundary(jnp.array([10.0, 0, 20, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]))
 initial_state.type[6:13] = "Free"
 
-final_state = bc(jnp.array([10.0, 0, 20, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, total_time]))
+final_state = boundary(jnp.array([10.0, 0, 20, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, total_time]))
 final_state.type[3:13] = "Free"
 final_state.type[13] = "Minimize"
 

--- a/examples/params/obstacle_avoidance.py
+++ b/examples/params/obstacle_avoidance.py
@@ -2,8 +2,7 @@ import numpy as np
 import jax.numpy as jnp
 
 from openscvx.trajoptproblem import TrajOptProblem
-from openscvx.constraints.boundary import boundary
-from openscvx.constraints.decorators import ctcs
+from openscvx.constraints import boundary, ctcs
 from openscvx.utils import qdcm, SSMP, SSM, generate_orthogonal_unit_vectors
 
 n = 6

--- a/examples/params/obstacle_avoidance.py
+++ b/examples/params/obstacle_avoidance.py
@@ -2,7 +2,7 @@ import numpy as np
 import jax.numpy as jnp
 
 from openscvx.trajoptproblem import TrajOptProblem
-from openscvx.constraints.boundary import BoundaryConstraint as bc
+from openscvx.constraints.boundary import boundary
 from openscvx.constraints.decorators import ctcs
 from openscvx.utils import qdcm, SSMP, SSM, generate_orthogonal_unit_vectors
 
@@ -14,10 +14,10 @@ min_state = np.array(
     [-200., -100, 0, -100, -100, -100, -1, -1, -1, -1, -10, -10, -10, 0]
 )
 
-initial_state = bc(jnp.array([10.0, 0, 2, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]))
+initial_state = boundary(jnp.array([10.0, 0, 2, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]))
 initial_state.type[6:13] = "Free"
 
-final_state = bc(jnp.array([-10.0, 0, 2, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, total_time]))
+final_state = boundary(jnp.array([-10.0, 0, 2, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, total_time]))
 final_state.type[3:13] = "Free"
 final_state.type[13] = "Minimize"
 

--- a/examples/params/obstacle_avoidance_nodal.py
+++ b/examples/params/obstacle_avoidance_nodal.py
@@ -2,7 +2,7 @@ import numpy as np
 import jax.numpy as jnp
 
 from openscvx.trajoptproblem import TrajOptProblem
-from openscvx.constraints.boundary import BoundaryConstraint as bc
+from openscvx.constraints.boundary import boundary
 from openscvx.constraints.decorators import ctcs, nodal
 from openscvx.utils import qdcm, SSMP, SSM, generate_orthogonal_unit_vectors
 
@@ -14,10 +14,10 @@ min_state = np.array(
     [-200., -100, 0, -100, -100, -100, -1, -1, -1, -1, -10, -10, -10, 0]
 )
 
-initial_state = bc(jnp.array([10., 0, 2, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]))
+initial_state = boundary(jnp.array([10., 0, 2, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]))
 initial_state.type[6:13] = "Free"
 
-final_state = bc(jnp.array([-10., 0, 2, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, total_time]))
+final_state = boundary(jnp.array([-10., 0, 2, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, total_time]))
 final_state.type[3:13] = "Free"
 final_state.type[13] = "Minimize"
 

--- a/examples/params/obstacle_avoidance_nodal.py
+++ b/examples/params/obstacle_avoidance_nodal.py
@@ -2,8 +2,7 @@ import numpy as np
 import jax.numpy as jnp
 
 from openscvx.trajoptproblem import TrajOptProblem
-from openscvx.constraints.boundary import boundary
-from openscvx.constraints.decorators import ctcs, nodal
+from openscvx.constraints import boundary, ctcs, nodal
 from openscvx.utils import qdcm, SSMP, SSM, generate_orthogonal_unit_vectors
 
 n = 6

--- a/openscvx/augmentation.py
+++ b/openscvx/augmentation.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from openscvx.constraints.decorators import CTCSConstraint
+from openscvx.constraints.ctcs import CTCSConstraint
 
 def sort_ctcs_constraints(constraints_ctcs: List[CTCSConstraint], N: int):        
     idx_to_nodes: dict[int, tuple] = {}

--- a/openscvx/constraints/__init__.py
+++ b/openscvx/constraints/__init__.py
@@ -1,0 +1,12 @@
+from .boundary import boundary, BoundaryConstraint
+from .ctcs import ctcs, CTCSConstraint
+from .nodal import nodal, NodalConstraint
+
+__all__ = [
+    "boundary",
+    "BoundaryConstraint",
+    "ctcs",
+    "CTCSConstraint",
+    "nodal",
+    "NodalConstraint",
+]

--- a/openscvx/constraints/boundary.py
+++ b/openscvx/constraints/boundary.py
@@ -1,54 +1,49 @@
+from dataclasses import dataclass, field
+from typing import Union, Sequence
 import jax.numpy as jnp
 
 ALLOWED_TYPES = {"Fix", "Free", "Minimize"}
 
-class TypeList:
-    def __init__(self, values):
-        self.values = list(values)
-    
-    def __getitem__(self, key):
-        return self.values[key]
-    
-    def __setitem__(self, key, value):
-        # Handle slice assignment
-        if isinstance(key, slice):
-            indices = range(*key.indices(len(self.values)))
-            # If a single string is given, replicate it for the slice.
-            if isinstance(value, str):
-                value = [value] * len(indices)
-            # Validate every element in the assigned slice.
-            for idx, v in zip(indices, value):
-                self._validate(v)
-                self.values[idx] = v
-        else:
-            self._validate(value)
-            self.values[key] = value
-
-    def _validate(self, v):
-        if v not in ALLOWED_TYPES:
-            raise ValueError(f"Type must be one of {ALLOWED_TYPES}, got {v}")
-
-    def __len__(self):
-        return len(self.values)
-    
-    def __repr__(self):
-        return repr(self.values)
-
+@dataclass
 class BoundaryConstraint:
-    def __init__(self, value: jnp.ndarray, types=None):
-        self.value = value
-        if types is None:
-            types = ["Fix"] * len(value)
-        elif len(types) != len(value):
-            raise ValueError("Length of types must match length of value")
-        # Internally store types using our helper class.
-        self._types = TypeList(types)
-    
+    value: jnp.ndarray
+    types: list[str] = field(init=False)
+
+    def __post_init__(self):
+        self.types = ["Fix"] * len(self.value)
+
+    def __getitem__(self, key):
+        return self.value[key]
+
+    def __setitem__(self, key, val):
+        self.value = self.value.at[key].set(val)
+
     @property
     def type(self):
-        # Expose the helper class so that slice assignments work naturally.
-        return self._types
-    
-    # Make an append method to add new types
-    def append_type(self, new_type):
-        self._types.values.append(new_type)
+        constraint = self
+        class TypeProxy:
+            def __getitem__(self, key):
+                return constraint.types[key]
+
+            def __setitem__(self, key, val: Union[str, Sequence[str]]):
+                indices = range(*key.indices(len(constraint.types))) if isinstance(key, slice) else [key]
+                values = [val] * len(indices) if isinstance(val, str) else val
+
+                if len(values) != len(indices):
+                    raise ValueError("Mismatch between indices and values length")
+
+                for idx, v in zip(indices, values):
+                    if v not in ALLOWED_TYPES:
+                        raise ValueError(f"Invalid type: {v}, must be one of {ALLOWED_TYPES}")
+                    constraint.types[idx] = v
+
+            def __len__(self):
+                return len(constraint.types)
+
+            def __repr__(self):
+                return repr(constraint.types)
+
+        return TypeProxy()
+
+def boundary(arr: jnp.ndarray):
+    return BoundaryConstraint(arr)

--- a/openscvx/constraints/nodal.py
+++ b/openscvx/constraints/nodal.py
@@ -10,12 +10,12 @@ class NodalConstraint:
     func: Callable[[jnp.ndarray, jnp.ndarray], jnp.ndarray]
     nodes: Optional[List[int]] = None
     convex: bool = False
-    inter_nodal: bool = False
+    vectorized: bool = False
 
     def __post_init__(self):
         if not self.convex:
             # TODO: (haynec) switch to AOT instead of JIT
-            if self.inter_nodal:
+            if self.vectorized:
                 # single-node but still using JAX
                 self.g = jit(self.func)
                 self.grad_g_x = jit(jacfwd(self.func, argnums=0))
@@ -42,7 +42,7 @@ def nodal(
             func=f,  # no wraps, just keep the original
             nodes=nodes,
             convex=convex,
-            inter_nodal=inter_nodal,
+            vectorized=inter_nodal,
         )
 
     return decorator if _func is None else decorator(_func)

--- a/openscvx/constraints/nodal.py
+++ b/openscvx/constraints/nodal.py
@@ -35,14 +35,14 @@ def nodal(
     *,
     nodes: Optional[List[int]] = None,
     convex: bool = False,
-    inter_nodal: bool = False,
+    vectorized: bool = False,
 ):
     def decorator(f: Callable[[jnp.ndarray, jnp.ndarray], jnp.ndarray]):
         return NodalConstraint(
             func=f,  # no wraps, just keep the original
             nodes=nodes,
             convex=convex,
-            vectorized=inter_nodal,
+            vectorized=vectorized,
         )
 
     return decorator if _func is None else decorator(_func)

--- a/openscvx/constraints/nodal.py
+++ b/openscvx/constraints/nodal.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass
+from typing import Callable, Optional, List
+
+import jax.numpy as jnp
+from jax import jit, vmap, jacfwd
+
+
+@dataclass
+class NodalConstraint:
+    func: Callable[[jnp.ndarray, jnp.ndarray], jnp.ndarray]
+    nodes: Optional[List[int]] = None
+    convex: bool = False
+    inter_nodal: bool = False
+
+    def __post_init__(self):
+        if not self.convex:
+            # TODO: (haynec) switch to AOT instead of JIT
+            self.g = vmap(jit(self.func), in_axes=(0, 0))
+            self.grad_g_x = jit(vmap(jacfwd(self.func, argnums=0), in_axes=(0, 0)))
+            self.grad_g_u = jit(vmap(jacfwd(self.func, argnums=1), in_axes=(0, 0)))
+        elif self.inter_nodal:
+            # single-node but still using JAX
+            self.g = jit(self.func)
+            self.grad_g_x = jit(jacfwd(self.func, argnums=0))
+            self.grad_g_u = jit(jacfwd(self.func, argnums=1))
+        # if convex=True and inter_nodal=False, assume an external solver (e.g. CVX) will handle it
+
+    def __call__(self, x: jnp.ndarray, u: jnp.ndarray):
+        return self.func(x, u)
+
+
+def nodal(
+    _func=None,
+    *,
+    nodes: Optional[List[int]] = None,
+    convex: bool = False,
+    inter_nodal: bool = False,
+):
+    def decorator(f: Callable[[jnp.ndarray, jnp.ndarray], jnp.ndarray]):
+        return NodalConstraint(
+            func=f,  # no wraps, just keep the original
+            nodes=nodes,
+            convex=convex,
+            inter_nodal=inter_nodal,
+        )
+
+    return decorator if _func is None else decorator(_func)

--- a/openscvx/constraints/nodal.py
+++ b/openscvx/constraints/nodal.py
@@ -15,14 +15,15 @@ class NodalConstraint:
     def __post_init__(self):
         if not self.convex:
             # TODO: (haynec) switch to AOT instead of JIT
-            self.g = vmap(jit(self.func), in_axes=(0, 0))
-            self.grad_g_x = jit(vmap(jacfwd(self.func, argnums=0), in_axes=(0, 0)))
-            self.grad_g_u = jit(vmap(jacfwd(self.func, argnums=1), in_axes=(0, 0)))
-        elif self.inter_nodal:
-            # single-node but still using JAX
-            self.g = jit(self.func)
-            self.grad_g_x = jit(jacfwd(self.func, argnums=0))
-            self.grad_g_u = jit(jacfwd(self.func, argnums=1))
+            if self.inter_nodal:
+                # single-node but still using JAX
+                self.g = jit(self.func)
+                self.grad_g_x = jit(jacfwd(self.func, argnums=0))
+                self.grad_g_u = jit(jacfwd(self.func, argnums=1))
+            else:
+                self.g = vmap(jit(self.func), in_axes=(0, 0))
+                self.grad_g_x = jit(vmap(jacfwd(self.func, argnums=0), in_axes=(0, 0)))
+                self.grad_g_u = jit(vmap(jacfwd(self.func, argnums=1), in_axes=(0, 0)))
         # if convex=True and inter_nodal=False, assume an external solver (e.g. CVX) will handle it
 
     def __call__(self, x: jnp.ndarray, u: jnp.ndarray):

--- a/openscvx/trajoptproblem.py
+++ b/openscvx/trajoptproblem.py
@@ -23,7 +23,8 @@ from openscvx.augmentation import sort_ctcs_constraints
 from openscvx.discretization import get_discretization_solver
 from openscvx.propagation import get_propagation_solver
 from openscvx.constraints.boundary import BoundaryConstraint
-from openscvx.constraints.decorators import CTCSConstraint, NodalConstraint
+from openscvx.constraints.ctcs import CTCSConstraint
+from openscvx.constraints.nodal import NodalConstraint
 from openscvx.ptr import PTR_init, PTR_main
 from openscvx.post_processing import propagate_trajectory_results
 from openscvx.ocp import OptimalControlProblem

--- a/tests/test_constraints/test_boundary.py
+++ b/tests/test_constraints/test_boundary.py
@@ -1,107 +1,60 @@
-# tests/test_boundary_constraint.py
-
 import pytest
 import jax.numpy as jnp
-from openscvx.constraints.boundary import BoundaryConstraint, boundary, ALLOWED_TYPES
+from openscvx.constraints.boundary import BoundaryConstraint, boundary
 
+@pytest.fixture
+def arr():
+    return jnp.array([1.0, 2.0, 3.0])
 
-def test_initial_types_are_fix():
-    arr = jnp.array([1.0, 2.0, 3.0])
+def test_default_types_and_value_get_set(arr):
     bc = BoundaryConstraint(arr)
-    # default types should all be "Fix"
+    # default types
     assert bc.types == ["Fix", "Fix", "Fix"]
+    # __getitem__
+    assert float(bc[1]) == 2.0
+    # __setitem__
+    bc[0] = 5.5
+    assert float(bc[0]) == 5.5
 
-
-def test_getitem_returns_value():
-    arr = jnp.array([10.0, 20.0, 30.0])
-    bc = BoundaryConstraint(arr)
-    assert float(bc[1]) == 20.0
-    # slicing
-    sub = bc[0:2]
-    assert isinstance(sub, jnp.ndarray)
-    assert jnp.all(sub == jnp.array([10.0, 20.0]))
-
-
-def test_setitem_updates_value():
-    arr = jnp.array([0.0, 0.0, 0.0])
-    bc = BoundaryConstraint(arr)
-    bc[2] = 5.5
-    # new array at index 2 should be 5.5
-    assert float(bc[2]) == 5.5
-    # other entries unchanged
-    assert float(bc[0]) == 0.0
-
-
-def test_type_get_single_and_slice():
-    arr = jnp.array([1.0, 2.0, 3.0, 4.0])
+@pytest.mark.parametrize("key,val,expected", [
+    # single-index assignment
+    (1, "Free",            ["Fix", "Free",    "Fix"]),
+    # slice with list
+    (slice(0,2), ["Minimize","Maximize"], ["Minimize","Maximize","Fix"]),
+    # slice with scalar
+    (slice(1,3), "Free",   ["Fix",  "Free",    "Free"]),
+])
+def test_type_set_valid(arr, key, val, expected):
     bc = BoundaryConstraint(arr)
     tp = bc.type
-    # single index
+    tp[key] = val
+    assert bc.types == expected
+
+@pytest.mark.parametrize("key,val,msg", [
+    # mismatched lengths
+    (slice(0,2), ["Free"],             "Mismatch between"),
+    # invalid type name
+    (1,           "NotAValidType",      "Invalid type"),
+])
+def test_type_set_invalid(arr, key, val, msg):
+    bc = BoundaryConstraint(arr)
+    tp = bc.type
+    with pytest.raises(ValueError) as exc:
+        tp[key] = val
+    assert msg in str(exc.value)
+
+def test_type_get_slice_len_and_repr(arr):
+    bc = BoundaryConstraint(arr)
+    tp = bc.type
+    # single get and slice get
     assert tp[0] == "Fix"
-    # slice returns list
     assert tp[1:3] == ["Fix", "Fix"]
-
-
-def test_type_set_single():
-    arr = jnp.array([0.0, 0.0])
-    bc = BoundaryConstraint(arr)
-    tp = bc.type
-    tp[1] = "Free"
-    assert bc.types == ["Fix", "Free"]
-    # ensure allowed set
-    assert tp[1] == "Free"
-
-
-def test_type_set_slice_with_list():
-    arr = jnp.array([0.0, 0.0, 0.0])
-    bc = BoundaryConstraint(arr)
-    tp = bc.type
-    # set indices 0..2 to ["Free","Minimize"]
-    tp[0:2] = ["Free", "Minimize"]
-    assert bc.types == ["Free", "Minimize", "Fix"]
-
-
-def test_type_set_slice_with_scalar():
-    arr = jnp.array([0.0, 0.0, 0.0])
-    bc = BoundaryConstraint(arr)
-    tp = bc.type
-    # set first two entries to "Minimize"
-    tp[0:2] = "Minimize"
-    assert bc.types == ["Minimize", "Minimize", "Fix"]
-
-
-def test_type_set_mismatch_length():
-    arr = jnp.array([0.0, 0.0, 0.0])
-    bc = BoundaryConstraint(arr)
-    tp = bc.type
-    # slice of length 2 but list of length 1 → error
-    with pytest.raises(ValueError) as exc:
-        tp[0:2] = ["Free"]
-    assert "Mismatch between indices and values length" in str(exc.value)
-
-
-def test_type_set_invalid_value():
-    arr = jnp.array([0.0, 0.0])
-    bc = BoundaryConstraint(arr)
-    tp = bc.type
-    with pytest.raises(ValueError) as exc:
-        tp[1] = "InvalidType"
-    assert "Invalid type: InvalidType" in str(exc.value)
-
-
-def test_type_len_and_repr():
-    arr = jnp.array([1.0, 2.0, 3.0])
-    bc = BoundaryConstraint(arr)
-    tp = bc.type
+    # len and repr
     assert len(tp) == 3
-    # repr should match list repr
     assert repr(tp) == repr(bc.types)
 
-
-def test_boundary_factory_function():
-    arr = jnp.array([9.0, 8.0])
+def test_boundary_factory_preserves_array_and_types(arr):
     bc = boundary(arr)
     assert isinstance(bc, BoundaryConstraint)
     assert jnp.all(bc.value == arr)
-    # types initialized correctly
-    assert bc.types == ["Fix", "Fix"]
+    assert bc.types == ["Fix", "Fix", "Fix"]

--- a/tests/test_constraints/test_boundary.py
+++ b/tests/test_constraints/test_boundary.py
@@ -2,9 +2,11 @@ import pytest
 import jax.numpy as jnp
 from openscvx.constraints.boundary import BoundaryConstraint, boundary
 
+
 @pytest.fixture
 def arr():
     return jnp.array([1.0, 2.0, 3.0])
+
 
 def test_default_types_and_value_get_set(arr):
     bc = BoundaryConstraint(arr)
@@ -16,32 +18,41 @@ def test_default_types_and_value_get_set(arr):
     bc[0] = 5.5
     assert float(bc[0]) == 5.5
 
-@pytest.mark.parametrize("key,val,expected", [
-    # single-index assignment
-    (1, "Free",            ["Fix", "Free",    "Fix"]),
-    # slice with list
-    (slice(0,2), ["Minimize","Maximize"], ["Minimize","Maximize","Fix"]),
-    # slice with scalar
-    (slice(1,3), "Free",   ["Fix",  "Free",    "Free"]),
-])
+
+@pytest.mark.parametrize(
+    "key,val,expected",
+    [
+        # single-index assignment
+        (1, "Free", ["Fix", "Free", "Fix"]),
+        # slice with list
+        (slice(0, 2), ["Minimize", "Maximize"], ["Minimize", "Maximize", "Fix"]),
+        # slice with scalar
+        (slice(1, 3), "Free", ["Fix", "Free", "Free"]),
+    ],
+)
 def test_type_set_valid(arr, key, val, expected):
     bc = BoundaryConstraint(arr)
     tp = bc.type
     tp[key] = val
     assert bc.types == expected
 
-@pytest.mark.parametrize("key,val,msg", [
-    # mismatched lengths
-    (slice(0,2), ["Free"],             "Mismatch between"),
-    # invalid type name
-    (1,           "NotAValidType",      "Invalid type"),
-])
+
+@pytest.mark.parametrize(
+    "key,val,msg",
+    [
+        # mismatched lengths
+        (slice(0, 2), ["Free"], "Mismatch between"),
+        # invalid type name
+        (1, "NotAValidType", "Invalid type"),
+    ],
+)
 def test_type_set_invalid(arr, key, val, msg):
     bc = BoundaryConstraint(arr)
     tp = bc.type
     with pytest.raises(ValueError) as exc:
         tp[key] = val
     assert msg in str(exc.value)
+
 
 def test_type_get_slice_len_and_repr(arr):
     bc = BoundaryConstraint(arr)
@@ -52,6 +63,7 @@ def test_type_get_slice_len_and_repr(arr):
     # len and repr
     assert len(tp) == 3
     assert repr(tp) == repr(bc.types)
+
 
 def test_boundary_factory_preserves_array_and_types(arr):
     bc = boundary(arr)

--- a/tests/test_constraints/test_boundary.py
+++ b/tests/test_constraints/test_boundary.py
@@ -1,0 +1,107 @@
+# tests/test_boundary_constraint.py
+
+import pytest
+import jax.numpy as jnp
+from openscvx.constraints.boundary import BoundaryConstraint, boundary, ALLOWED_TYPES
+
+
+def test_initial_types_are_fix():
+    arr = jnp.array([1.0, 2.0, 3.0])
+    bc = BoundaryConstraint(arr)
+    # default types should all be "Fix"
+    assert bc.types == ["Fix", "Fix", "Fix"]
+
+
+def test_getitem_returns_value():
+    arr = jnp.array([10.0, 20.0, 30.0])
+    bc = BoundaryConstraint(arr)
+    assert float(bc[1]) == 20.0
+    # slicing
+    sub = bc[0:2]
+    assert isinstance(sub, jnp.ndarray)
+    assert jnp.all(sub == jnp.array([10.0, 20.0]))
+
+
+def test_setitem_updates_value():
+    arr = jnp.array([0.0, 0.0, 0.0])
+    bc = BoundaryConstraint(arr)
+    bc[2] = 5.5
+    # new array at index 2 should be 5.5
+    assert float(bc[2]) == 5.5
+    # other entries unchanged
+    assert float(bc[0]) == 0.0
+
+
+def test_type_get_single_and_slice():
+    arr = jnp.array([1.0, 2.0, 3.0, 4.0])
+    bc = BoundaryConstraint(arr)
+    tp = bc.type
+    # single index
+    assert tp[0] == "Fix"
+    # slice returns list
+    assert tp[1:3] == ["Fix", "Fix"]
+
+
+def test_type_set_single():
+    arr = jnp.array([0.0, 0.0])
+    bc = BoundaryConstraint(arr)
+    tp = bc.type
+    tp[1] = "Free"
+    assert bc.types == ["Fix", "Free"]
+    # ensure allowed set
+    assert tp[1] == "Free"
+
+
+def test_type_set_slice_with_list():
+    arr = jnp.array([0.0, 0.0, 0.0])
+    bc = BoundaryConstraint(arr)
+    tp = bc.type
+    # set indices 0..2 to ["Free","Minimize"]
+    tp[0:2] = ["Free", "Minimize"]
+    assert bc.types == ["Free", "Minimize", "Fix"]
+
+
+def test_type_set_slice_with_scalar():
+    arr = jnp.array([0.0, 0.0, 0.0])
+    bc = BoundaryConstraint(arr)
+    tp = bc.type
+    # set first two entries to "Minimize"
+    tp[0:2] = "Minimize"
+    assert bc.types == ["Minimize", "Minimize", "Fix"]
+
+
+def test_type_set_mismatch_length():
+    arr = jnp.array([0.0, 0.0, 0.0])
+    bc = BoundaryConstraint(arr)
+    tp = bc.type
+    # slice of length 2 but list of length 1 → error
+    with pytest.raises(ValueError) as exc:
+        tp[0:2] = ["Free"]
+    assert "Mismatch between indices and values length" in str(exc.value)
+
+
+def test_type_set_invalid_value():
+    arr = jnp.array([0.0, 0.0])
+    bc = BoundaryConstraint(arr)
+    tp = bc.type
+    with pytest.raises(ValueError) as exc:
+        tp[1] = "InvalidType"
+    assert "Invalid type: InvalidType" in str(exc.value)
+
+
+def test_type_len_and_repr():
+    arr = jnp.array([1.0, 2.0, 3.0])
+    bc = BoundaryConstraint(arr)
+    tp = bc.type
+    assert len(tp) == 3
+    # repr should match list repr
+    assert repr(tp) == repr(bc.types)
+
+
+def test_boundary_factory_function():
+    arr = jnp.array([9.0, 8.0])
+    bc = boundary(arr)
+    assert isinstance(bc, BoundaryConstraint)
+    assert jnp.all(bc.value == arr)
+    # types initialized correctly
+    assert bc.types == ["Fix", "Fix"]

--- a/tests/test_constraints/test_ctcs.py
+++ b/tests/test_constraints/test_ctcs.py
@@ -3,69 +3,65 @@ import jax.numpy as jnp
 from openscvx.constraints.ctcs import CTCSConstraint, ctcs
 
 
-def test_squared_relu_penalty_in_interval():
-    # a func that returns [-1, 0, 2] → squared_relu ⇒ [0, 0, 4], sum = 4
-    f = lambda x, u: jnp.array([-1.0, 0.0, 2.0])
-    pen = lambda x: jnp.maximum(0, x) ** 2
-    c = CTCSConstraint(func=f, penalty=pen, nodes=(0, 10))
-    res = c(jnp.array([0]), jnp.array([0]), node=5)
-    assert float(res) == 4.0
+@pytest.mark.parametrize(
+    "penalty_name, values, expected_sum",
+    [
+        ("squared_relu", jnp.array([-1.0, 0.0, 2.0]), 4.0),
+        ("huber", jnp.array([0.1, 0.3]), 0.005 + (0.3 - 0.125)),
+    ],
+)
+def test_penalty_within_interval(penalty_name, values, expected_sum):
+    """Both penalties should sum as expected when node is inside [nodes[0], nodes[1])."""
 
-
-def test_squared_relu_outside_interval():
-    # same func, but node == 10 is at the boundary (exclusive) → 0
-    f = lambda x, u: jnp.array([1.0, 2.0])
-    pen = lambda x: jnp.maximum(0, x) ** 2
-    c = CTCSConstraint(func=f, penalty=pen, nodes=(0, 10))
-    assert float(c(jnp.array([0]), jnp.array([0]), node=10)) == 0.0
-    assert float(c(jnp.array([0]), jnp.array([0]), node=-1)) == 0.0
-
-
-def test_huber_penalty_in_interval():
-    # huber with delta=0.25 on [0.1, 0.3] → [0.5*0.1^2=0.005, 0.3-0.125=0.175], sum = 0.18
-    @ctcs(nodes=(0, 5), penalty="huber")
+    @ctcs(nodes=(0, 5), penalty=penalty_name)
     def f(x, u):
-        return jnp.array([0.1, 0.3])
+        return values
 
-    res = f(jnp.array([0]), jnp.array([0]), node=2)
-    assert pytest.approx(float(res), rel=1e-6) == 0.18
+    result = f(jnp.zeros(1), jnp.zeros(1), node=2)
+    assert pytest.approx(float(result), rel=1e-6) == expected_sum
 
 
-def test_unknown_penalty_raises():
+def test_any_penalty_outside_interval_returns_zero():
+    """Regardless of the penalty, outside the interval the constraint yields 0."""
+
+    @ctcs(nodes=(10, 20), penalty="squared_relu")
+    def f(x, u):
+        return jnp.array([100.0])
+
+    # test boundary and below
+    assert float(f(jnp.zeros(1), jnp.zeros(1), node=20)) == 0.0
+    assert float(f(jnp.zeros(1), jnp.zeros(1), node=9)) == 0.0
+
+
+def test_unknown_penalty_raises_immediately():
     with pytest.raises(ValueError) as exc:
         ctcs(lambda x, u: x, penalty="not_a_real_penalty")
     assert "Unknown penalty not_a_real_penalty" in str(exc.value)
 
 
-def test_decorator_returns_CTCSConstraint_and_attributes():
-    @ctcs(nodes=(1, 3), idx=7)
-    def my_constraint(x, u):
+def test_decorator_sets_attributes_and_type():
+    @ctcs(nodes=(1, 3), idx=7, penalty="squared_relu")
+    def my_cons(x, u):
         return x + u
 
-    # should be turned into a CTCSConstraint
-    assert isinstance(my_constraint, CTCSConstraint)
-    assert my_constraint.nodes == (1, 3)
-    assert my_constraint.idx == 7
-    # func should be the original function
-    xs = jnp.array([2.0])
-    us = jnp.array([3.0])
-    # inside interval → (2+3)=5, squared_relu(5)=25
-    out = my_constraint(xs, us, node=2)
-    assert float(out) == 25.0
+    assert isinstance(my_cons, CTCSConstraint)
+    assert my_cons.nodes == (1, 3)
+    assert my_cons.idx == 7
+    # and it still uses squared-relu under the hood
+    out = my_cons(jnp.array([2.0]), jnp.array([3.0]), node=2)
+    assert float(out) == 25.0  # (2+3)=5 → relu² → 25
 
 
 def test_ctcs_called_directly_without_parentheses():
+    """Using `c = ctcs(fn)` should wrap but leave nodes=None, idx=None."""
+
     def raw_fn(x, u):
         return jnp.array([4.0, -1.0])
 
-    c = ctcs(raw_fn)  # equivalent to @ctcs
-    # defaults: penalty="squared_relu", nodes=None, idx=None
+    c = ctcs(raw_fn)
     assert isinstance(c, CTCSConstraint)
     assert c.func is raw_fn
-    assert c.penalty is not None
-    assert c.nodes is None
-    assert c.idx is None
-
-    # calling __call__ without nodes should error
+    assert c.nodes is None and c.idx is None
+    # calling without nodes ought to complain about comparing None to int
     with pytest.raises(TypeError):
-        _ = c(jnp.array([0]), jnp.array([0]), node=0)
+        _ = c(jnp.zeros(1), jnp.zeros(1), node=0)

--- a/tests/test_constraints/test_ctcs.py
+++ b/tests/test_constraints/test_ctcs.py
@@ -1,0 +1,71 @@
+import pytest
+import jax.numpy as jnp
+from openscvx.constraints.ctcs import CTCSConstraint, ctcs
+
+
+def test_squared_relu_penalty_in_interval():
+    # a func that returns [-1, 0, 2] → squared_relu ⇒ [0, 0, 4], sum = 4
+    f = lambda x, u: jnp.array([-1.0, 0.0, 2.0])
+    pen = lambda x: jnp.maximum(0, x) ** 2
+    c = CTCSConstraint(func=f, penalty=pen, nodes=(0, 10))
+    res = c(jnp.array([0]), jnp.array([0]), node=5)
+    assert float(res) == 4.0
+
+
+def test_squared_relu_outside_interval():
+    # same func, but node == 10 is at the boundary (exclusive) → 0
+    f = lambda x, u: jnp.array([1.0, 2.0])
+    pen = lambda x: jnp.maximum(0, x) ** 2
+    c = CTCSConstraint(func=f, penalty=pen, nodes=(0, 10))
+    assert float(c(jnp.array([0]), jnp.array([0]), node=10)) == 0.0
+    assert float(c(jnp.array([0]), jnp.array([0]), node=-1)) == 0.0
+
+
+def test_huber_penalty_in_interval():
+    # huber with delta=0.25 on [0.1, 0.3] → [0.5*0.1^2=0.005, 0.3-0.125=0.175], sum = 0.18
+    @ctcs(nodes=(0, 5), penalty="huber")
+    def f(x, u):
+        return jnp.array([0.1, 0.3])
+
+    res = f(jnp.array([0]), jnp.array([0]), node=2)
+    assert pytest.approx(float(res), rel=1e-6) == 0.18
+
+
+def test_unknown_penalty_raises():
+    with pytest.raises(ValueError) as exc:
+        ctcs(lambda x, u: x, penalty="not_a_real_penalty")
+    assert "Unknown penalty not_a_real_penalty" in str(exc.value)
+
+
+def test_decorator_returns_CTCSConstraint_and_attributes():
+    @ctcs(nodes=(1, 3), idx=7)
+    def my_constraint(x, u):
+        return x + u
+
+    # should be turned into a CTCSConstraint
+    assert isinstance(my_constraint, CTCSConstraint)
+    assert my_constraint.nodes == (1, 3)
+    assert my_constraint.idx == 7
+    # func should be the original function
+    xs = jnp.array([2.0])
+    us = jnp.array([3.0])
+    # inside interval → (2+3)=5, squared_relu(5)=25
+    out = my_constraint(xs, us, node=2)
+    assert float(out) == 25.0
+
+
+def test_ctcs_called_directly_without_parentheses():
+    def raw_fn(x, u):
+        return jnp.array([4.0, -1.0])
+
+    c = ctcs(raw_fn)  # equivalent to @ctcs
+    # defaults: penalty="squared_relu", nodes=None, idx=None
+    assert isinstance(c, CTCSConstraint)
+    assert c.func is raw_fn
+    assert c.penalty is not None
+    assert c.nodes is None
+    assert c.idx is None
+
+    # calling __call__ without nodes should error
+    with pytest.raises(TypeError):
+        _ = c(jnp.array([0]), jnp.array([0]), node=0)

--- a/tests/test_constraints/test_nodal.py
+++ b/tests/test_constraints/test_nodal.py
@@ -1,0 +1,68 @@
+import pytest
+import jax.numpy as jnp
+
+from openscvx.constraints.nodal import NodalConstraint, nodal  
+
+def simple_dot(x, u):
+    # f(x,u) = sum_i x_i * u_i
+    return jnp.dot(x, u)
+
+def test___call___uses_original_func():
+    # __call__ should bypass jax-transformed methods
+    c = NodalConstraint(func=simple_dot, convex=False, vectorized=True)
+    x = jnp.array([1.0, 2.0, 3.0])
+    u = jnp.array([0.1, 0.2, 0.3])
+    # same as simple_dot(x,u)
+    assert c(x, u) == pytest.approx(jnp.dot(x, u))
+
+def test_non_vectorized_batched_g_and_grads():
+    # vectorized=False (default), convex=False
+    c = NodalConstraint(func=simple_dot, convex=False, vectorized=False)
+    # batch of two 2-vectors
+    x = jnp.array([[1.0, 2.0], [3.0, 4.0]])
+    u = jnp.array([[5.0, 6.0], [7.0, 8.0]])
+    # g = vmap(jit(func), in_axes=(0,0))
+    expected = jnp.array([jnp.dot(x[0], u[0]), jnp.dot(x[1], u[1])])
+    out = c.g(x, u)
+    assert out.shape == (2,)
+    assert jnp.allclose(out, expected)
+    # gradient w.r.t. x should be u
+    grad_x = c.grad_g_x(x, u)
+    assert grad_x.shape == x.shape
+    assert jnp.allclose(grad_x, u)
+    # gradient w.r.t. u should be x
+    grad_u = c.grad_g_u(x, u)
+    assert jnp.allclose(grad_u, x)
+
+def test_vectorized_single_node_jit_path():
+    # vectorized=True, convex=False
+    c = NodalConstraint(func=simple_dot, convex=False, vectorized=True)
+    x = jnp.array([2.0, 3.0])
+    u = jnp.array([4.0, 5.0])
+    # g = jit(func)
+    out = c.g(x, u)
+    assert out.shape == ()  # scalar
+    assert out == pytest.approx(2*4 + 3*5)
+    # grads
+    grad_x = c.grad_g_x(x, u)
+    grad_u = c.grad_g_u(x, u)
+    assert jnp.allclose(grad_x, u)
+    assert jnp.allclose(grad_u, x)
+
+def test_convex_skips_jax_transforms():
+    # convex=True should not define g, grad_g_x, or grad_g_u
+    c = NodalConstraint(func=simple_dot, convex=True, vectorized=True)
+    for attr in ("g", "grad_g_x", "grad_g_u"):
+        with pytest.raises(AttributeError):
+            getattr(c, attr)
+
+def test_nodal_decorator_passes_parameters_through():
+    @nodal(nodes=[10,20,30], convex=True, vectorized=False)
+    def f2(x, u):
+        return jnp.sum(x) + jnp.sum(u)
+
+    # decorator returns a fully initialized NodalConstraint
+    assert isinstance(f2, NodalConstraint)
+    assert f2.nodes == [10,20,30]
+    assert f2.convex is True
+    assert f2.vectorized is False

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,4 +1,6 @@
 import pytest
+import os
+import platform
 
 import jax
 
@@ -7,10 +9,20 @@ from examples.params.cinema_vp import plotting_dict as cinema_vp_plotting_dict
 from examples.params.dr_vp import problem as dr_vp_problem
 from examples.params.dr_vp import plotting_dict as dr_vp_plotting_dict
 from examples.params.obstacle_avoidance import problem as obstacle_avoidance_problem
-from examples.params.obstacle_avoidance import plotting_dict as obstacle_avoidance_plotting_dict
+from examples.params.obstacle_avoidance import (
+    plotting_dict as obstacle_avoidance_plotting_dict,
+)
 from examples.params.dr_vp_nodal import problem as dr_vp_polytope_problem
 from examples.params.dr_vp_nodal import plotting_dict as dr_vp_polytope_plotting_dict
 from examples.plotting import plot_camera_animation, plot_animation, plot_scp_animation
+
+CI_OS = os.getenv("RUNNER_OS", platform.system())
+
+OS_MULTIPLIER = {
+    "Windows": 2.0,  # give Windows twice as much time
+    "Linux": 1.0,
+    "Darwin": 1.0,
+}.get(CI_OS, 1.0)
 
 TEST_CASES = {
     "obstacle_avoidance": {
@@ -34,7 +46,10 @@ TEST_CASES = {
         "max_cost": 30.0,
         "max_vio": -1,
         "timing": {"init": 35.0, "solve": 3.0, "post": 1.0},
-        "pre_init": [lambda p: setattr(p.params.dis, "custom_integrator", False), lambda p: setattr(p.params.dev, "printing", False)],
+        "pre_init": [
+            lambda p: setattr(p.params.dis, "custom_integrator", False),
+            lambda p: setattr(p.params.dev, "printing", False),
+        ],
     },
     "dr_vp": {
         "problem": dr_vp_problem,
@@ -45,7 +60,10 @@ TEST_CASES = {
         "max_cost": 45.0,
         "max_vio": 1.0,
         "timing": {"init": 40.0, "solve": 3.0, "post": 1.0},
-        "pre_init": [lambda p: setattr(p.params.dis, "custom_integrator", False), lambda p: setattr(p.params.dev, "printing", False)],
+        "pre_init": [
+            lambda p: setattr(p.params.dis, "custom_integrator", False),
+            lambda p: setattr(p.params.dev, "printing", False),
+        ],
     },
     "cinema_vp": {
         "problem": cinema_vp_problem,
@@ -56,9 +74,17 @@ TEST_CASES = {
         "max_cost": 400.0,
         "max_vio": 1.0,
         "timing": {"init": 12.0, "solve": 1.0, "post": 1.0},
-        "pre_init": [lambda p: setattr(p.params.dis, "custom_integrator", False), lambda p: setattr(p.params.dev, "printing", False)],
+        "pre_init": [
+            lambda p: setattr(p.params.dis, "custom_integrator", False),
+            lambda p: setattr(p.params.dev, "printing", False),
+        ],
     },
 }
+
+for conf in TEST_CASES.values():
+    base = conf["timing"]
+    conf["timing"] = {phase: base[phase] * OS_MULTIPLIER for phase in base}
+
 
 @pytest.mark.parametrize("name,conf", TEST_CASES.items(), ids=list(TEST_CASES))
 def test_example_problem(name, conf):
@@ -85,7 +111,7 @@ def test_example_problem(name, conf):
     scp_iters = len(result["discretization_history"])
     sol_cost = result["x"][:, conf["cost_idx"]][-1]
     prop_cost = result["x_full"][:, conf["cost_idx"]][-1]
-    sol_constr_vio  = result["x"][:, conf["vio_idx"]][-1]
+    sol_constr_vio = result["x"][:, conf["vio_idx"]][-1]
     prop_constr_vio = result["x_full"][:, conf["vio_idx"]][-1]
 
     # assertions
@@ -93,17 +119,29 @@ def test_example_problem(name, conf):
         assert sol_cost < conf["max_cost"], "Problem failed with solution cost"
         assert prop_cost < conf["max_cost"], "Problem failed with propagated cost"
     if conf["max_vio"] > 0.0:
-        assert sol_constr_vio  < conf["max_vio"], "Problem failed with solution constraint violation"
-        assert prop_constr_vio < conf["max_vio"], "Problem failed with propagated constraint violation"
+        assert (
+            sol_constr_vio < conf["max_vio"]
+        ), "Problem failed with solution constraint violation"
+        assert (
+            prop_constr_vio < conf["max_vio"]
+        ), "Problem failed with propagated constraint violation"
     if "max_iters" in conf and conf["max_iters"] > 0:
-        assert scp_iters < conf["max_iters"], "Problem took more then expected iterations"
+        assert (
+            scp_iters < conf["max_iters"]
+        ), "Problem took more then expected iterations"
     assert result["converged"], "Problem failed with output"
 
     # timing checks
     t = conf["timing"]
-    assert problem.timing_init <  t["init"], "Problem took more then expected initialization time"
-    assert problem.timing_solve < t["solve"], "Problem took more then expected solve time"
-    assert problem.timing_post <  t["post"], "Problem took more then expected post process time"
+    assert (
+        problem.timing_init < t["init"]
+    ), "Problem took more then expected initialization time"
+    assert (
+        problem.timing_solve < t["solve"]
+    ), "Problem took more then expected solve time"
+    assert (
+        problem.timing_post < t["post"]
+    ), "Problem took more then expected post process time"
 
     # clean up
     jax.clear_caches()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -59,7 +59,7 @@ TEST_CASES = {
         "vio_idx": -1,
         "max_cost": 45.0,
         "max_vio": 1.0,
-        "timing": {"init": 32.0, "solve": 2.0, "post": 1.0},
+        "timing": {"init": 35.0, "solve": 2.0, "post": 1.0},
         "pre_init": [
             lambda p: setattr(p.params.dis, "custom_integrator", False),
             lambda p: setattr(p.params.dev, "printing", False),
@@ -73,7 +73,7 @@ TEST_CASES = {
         "vio_idx": -1,
         "max_cost": 400.0,
         "max_vio": 1.0,
-        "timing": {"init": 10.0, "solve": 1.0, "post": 1.0},
+        "timing": {"init": 12.0, "solve": 1.0, "post": 1.0},
         "pre_init": [
             lambda p: setattr(p.params.dis, "custom_integrator", False),
             lambda p: setattr(p.params.dev, "printing", False),

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -45,7 +45,7 @@ TEST_CASES = {
         "vio_idx": -1,
         "max_cost": 30.0,
         "max_vio": -1,
-        "timing": {"init": 35.0, "solve": 3.0, "post": 1.0},
+        "timing": {"init": 25.0, "solve": 2.0, "post": 1.0},
         "pre_init": [
             lambda p: setattr(p.params.dis, "custom_integrator", False),
             lambda p: setattr(p.params.dev, "printing", False),
@@ -59,7 +59,7 @@ TEST_CASES = {
         "vio_idx": -1,
         "max_cost": 45.0,
         "max_vio": 1.0,
-        "timing": {"init": 40.0, "solve": 3.0, "post": 1.0},
+        "timing": {"init": 30.0, "solve": 2.0, "post": 1.0},
         "pre_init": [
             lambda p: setattr(p.params.dis, "custom_integrator", False),
             lambda p: setattr(p.params.dev, "printing", False),
@@ -73,7 +73,7 @@ TEST_CASES = {
         "vio_idx": -1,
         "max_cost": 400.0,
         "max_vio": 1.0,
-        "timing": {"init": 12.0, "solve": 1.0, "post": 1.0},
+        "timing": {"init": 8.0, "solve": 1.0, "post": 1.0},
         "pre_init": [
             lambda p: setattr(p.params.dis, "custom_integrator", False),
             lambda p: setattr(p.params.dev, "printing", False),

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -59,7 +59,7 @@ TEST_CASES = {
         "vio_idx": -1,
         "max_cost": 45.0,
         "max_vio": 1.0,
-        "timing": {"init": 30.0, "solve": 2.0, "post": 1.0},
+        "timing": {"init": 32.0, "solve": 2.0, "post": 1.0},
         "pre_init": [
             lambda p: setattr(p.params.dis, "custom_integrator", False),
             lambda p: setattr(p.params.dev, "printing", False),

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -19,7 +19,7 @@ from examples.plotting import plot_camera_animation, plot_animation, plot_scp_an
 CI_OS = os.getenv("RUNNER_OS", platform.system())
 
 OS_MULTIPLIER = {
-    "Windows": 2.0,  # give Windows twice as much time
+    "Windows": 1.5,  # give Windows twice as much time
     "Linux": 1.0,
     "Darwin": 1.0,
 }.get(CI_OS, 1.0)
@@ -73,7 +73,7 @@ TEST_CASES = {
         "vio_idx": -1,
         "max_cost": 400.0,
         "max_vio": 1.0,
-        "timing": {"init": 8.0, "solve": 1.0, "post": 1.0},
+        "timing": {"init": 10.0, "solve": 1.0, "post": 1.0},
         "pre_init": [
             lambda p: setattr(p.params.dis, "custom_integrator", False),
             lambda p: setattr(p.params.dev, "printing", False),


### PR DESCRIPTION
- Fixes #84 -> Boundary constraints are now defined just like CTCS and nodal constraints; with a `boundary()` wrapper around the underlying array, this internally maps them to a `BoundaryConstraint` dataclass
- Added unit tests for boundary, nodal, and CTCS constraints
- Updated the `__init__.py` for `constraints/` so that the user can load the types directly from `openscvx.constraints` instead of going into the individual files
- Fixes #88 -> Separate, per-OS scaling factors applied which should allow bounds to be set much tighter while giving windows enough time