### PR TITLE
Fix/incorrect draft release changelog version

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -52,4 +52,4 @@ template: |
 
   ---
 
-  **Full Changelog:** [`$PREVIOUS_TAG...v$NEXT_PATCH_VERSION`](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$NEXT_PATCH_VERSION)
+  **Full Changelog:** [`$PREVIOUS_TAG...v$RESOLVED_VERSION`](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION)


### PR DESCRIPTION
- Fixes issue where draft release contains incorrect predicted version for the `Full Changelog: va.b.c..vc.d.e` line when there is a `minor` or `major` patch, only increments the `patch`
- Now uses `$RESOLVED_VERSION`, same as draft release title