### PR TITLE
Feature/algebraic propagation

### DIFF
--- a/openscvx/lowered/problem.py
+++ b/openscvx/lowered/problem.py
@@ -31,9 +31,8 @@ class LoweredProblem:
         x_prop_unified: Aggregated propagation state interface
         ocp_vars: Typed CVXPy variables and parameters for OCP construction
         cvxpy_params: Dict mapping user parameter names to CVXPy Parameter objects
-        outputs_prop: Dict mapping output names to vmapped JAX functions.
-            These define additional propagation outputs algebraically dependent on
-            other variables (no integration)
+        algebraic_prop: Dict mapping output names to vmapped JAX functions
+            (evaluated, not integrated)
 
     Example:
         After lowering a symbolic problem::
@@ -73,4 +72,4 @@ class LoweredProblem:
     cvxpy_params: Dict[str, "cp.Parameter"]
 
     # Algebraic outputs (vmapped JAX functions for propagation)
-    outputs_prop: Optional[Dict[str, Callable]] = field(default_factory=dict)
+    algebraic_prop: Optional[Dict[str, Callable]] = field(default_factory=dict)

--- a/openscvx/problem.py
+++ b/openscvx/problem.py
@@ -82,7 +82,7 @@ class Problem:
         *,
         dynamics_prop: Optional[dict] = None,
         states_prop: Optional[List[State]] = None,
-        outputs_prop: Optional[dict] = None,
+        algebraic_prop: Optional[dict] = None,
         licq_min=0.0,
         licq_max=1e-4,
         time_dilation_factor_min=0.3,
@@ -110,9 +110,8 @@ class Problem:
                 state dynamics here.
             states_prop (List[State], optional): List of EXTRA State objects for propagation only.
                 Only specify additional states beyond optimization states. Used with dynamics_prop.
-            outputs_prop (dict, optional): Dictionary mapping output names to symbolic expressions
-                for algebraic outputs computed during propagation. These are evaluated (not
-                integrated) at each propagation timestep. Example: {"kinetic_energy": 0.5*m*v**2}.
+            algebraic_prop (dict, optional): Dictionary mapping names to symbolic expressions
+                for outputs evaluated (not integrated) during propagation.
             licq_min: Minimum LICQ constraint value
             licq_max: Maximum LICQ constraint value
             time_dilation_factor_min: Minimum time dilation factor
@@ -144,7 +143,7 @@ class Problem:
             time_dilation_factor_max=time_dilation_factor_max,
             dynamics_prop_extra=dynamics_prop,
             states_prop_extra=states_prop,
-            outputs_prop=outputs_prop,
+            algebraic_prop=algebraic_prop,
             byof=byof,
         )
 
@@ -690,7 +689,7 @@ class Problem:
             self.settings,
             result,
             self._propagation_solver,
-            outputs_prop=self._lowered.outputs_prop,
+            algebraic_prop=self._lowered.algebraic_prop,
         )
         t_f_post = time.time()
 

--- a/openscvx/propagation/post_processing.py
+++ b/openscvx/propagation/post_processing.py
@@ -1,4 +1,5 @@
 import copy
+from typing import Optional
 
 import jax.numpy as jnp
 import numpy as np
@@ -15,7 +16,7 @@ def propagate_trajectory_results(
     settings: Config,
     result: OptimizationResults,
     propagation_solver: callable,
-    outputs_prop: dict = None,
+    algebraic_prop: Optional[dict] = None,
 ) -> OptimizationResults:
     """Propagate the optimal trajectory and compute additional results.
 
@@ -27,7 +28,7 @@ def propagate_trajectory_results(
         settings (Config): Configuration settings.
         result (OptimizationResults): Optimization results object.
         propagation_solver (callable): Function for propagating the system state.
-        outputs_prop (dict, optional): Dictionary mapping output names to vmapped JAX functions.
+        algebraic_prop (dict, optional): Dictionary mapping output names to vmapped JAX functions.
 
     Returns:
         OptimizationResults: Updated results object containing:
@@ -100,8 +101,8 @@ def propagate_trajectory_results(
         trajectory_dict[control.name] = u_full[:, control._slice]
 
     # Compute algebraic outputs (vmapped over time)
-    if outputs_prop:
-        for name, output_fn in outputs_prop.items():
+    if algebraic_prop:
+        for name, output_fn in algebraic_prop.items():
             # output_fn is vmapped: (T, n_x), (T, n_u), node, params -> (T, output_dim)
             # Pass node=0 since algebraic outputs shouldn't depend on node index
             output_values = output_fn(x_full, u_full, 0, params)

--- a/openscvx/symbolic/lower.py
+++ b/openscvx/symbolic/lower.py
@@ -748,14 +748,14 @@ def lower_symbolic_problem(
     )
 
     # Lower algebraic outputs to vmapped JAX functions
-    outputs_prop_lowered = {}
-    if problem.outputs_prop:
-        for name, expr in problem.outputs_prop.items():
+    algebraic_prop_lowered = {}
+    if problem.algebraic_prop:
+        for name, expr in problem.algebraic_prop.items():
             # Lower expression to JAX function: f(x, u, node, params) -> output
             output_fn = lower_to_jax(expr)
             # Vmap over time axis: (T, n_x), (T, n_u) -> (T, output_dim)
             output_fn_vmapped = jax.vmap(output_fn, in_axes=(0, 0, None, None))
-            outputs_prop_lowered[name] = output_fn_vmapped
+            algebraic_prop_lowered[name] = output_fn_vmapped
 
     return LoweredProblem(
         dynamics=dynamics,
@@ -767,5 +767,5 @@ def lower_symbolic_problem(
         x_prop_unified=x_prop_unified,
         ocp_vars=ocp_vars,
         cvxpy_params=cvxpy_params,
-        outputs_prop=outputs_prop_lowered,
+        algebraic_prop=algebraic_prop_lowered,
     )

--- a/openscvx/symbolic/problem.py
+++ b/openscvx/symbolic/problem.py
@@ -60,7 +60,7 @@ class SymbolicProblem:
             None before preprocessing, populated after.
         controls_prop: Propagation controls (typically same as controls).
             None before preprocessing, populated after.
-        outputs_prop: Algebraic outputs computed during propagation (no integration).
+        algebraic_prop: Algebraic outputs computed during propagation (no integration).
             None before preprocessing, populated after.
 
     Example:
@@ -103,7 +103,7 @@ class SymbolicProblem:
 
     # Algebraic outputs computed during propagation (no integration)
     # Maps output names to symbolic expressions
-    outputs_prop: Optional[Dict[str, "Expr"]] = None
+    algebraic_prop: Optional[Dict[str, "Expr"]] = None
 
     @property
     def is_preprocessed(self) -> bool:


### PR DESCRIPTION
- Adds `algebraic_prop` parameter for defining outputs that are evaluated (not integrated) during propagation -> Fixes #306
- Useful for derived quantities like end effector positions, energies, or any algebraic function of state/control
- Expressions are lowered to vmapped JAX functions and computed over the full propagation trajectory
- Results are accessible via `result.trajectory["output_name"]`

```python
import openscvx as ox

q = ox.State("q", shape=(3,))  # joint angles

# Product of Exponentials forward kinematics: T_ee = exp(ξ₁q₁) @ exp(ξ₂q₂) @ exp(ξ₃q₃) @ T_home
T_01 = ox.lie.SE3Exp(ox.Constant(screw_axes[0]) * q[0])
T_12 = ox.lie.SE3Exp(ox.Constant(screw_axes[1]) * q[1])
T_23 = ox.lie.SE3Exp(ox.Constant(screw_axes[2]) * q[2])
T_ee = T_01 @ T_12 @ T_23 @ ox.Constant(T_home)

problem = ox.Problem(
    ...,
    algebraic_prop={
        "end_effector": ox.Concat(T_ee[0, 3], T_ee[1, 3], T_ee[2, 3]),
        "kinetic_energy": 0.5 * mass * velocity ** 2,
    },
)

result = problem.solve()
ee_trajectory = result.trajectory["end_effector"]  # (T, 3)
```