### PR TITLE
Fix/validate input types

### DIFF
--- a/openscvx/problem.py
+++ b/openscvx/problem.py
@@ -50,7 +50,6 @@ from openscvx.lowered.jax_constraints import (
 from openscvx.propagation import get_propagation_solver, propagate_trajectory_results
 from openscvx.solvers import PTRSolver
 from openscvx.symbolic.builder import preprocess_symbolic_problem
-from openscvx.symbolic.constraint_set import ConstraintSet
 from openscvx.symbolic.expr import CTCS, Constraint
 from openscvx.symbolic.expr.control import Control
 from openscvx.symbolic.expr.state import State
@@ -125,17 +124,10 @@ class Problem:
                in dynamics dict, don't provide Time object
         """
 
-        # Validate constraints is a list before wrapping in ConstraintSet
-        if not isinstance(constraints, list):
-            raise TypeError(
-                f"'constraints' must be a list of Constraint objects, "
-                f"got {type(constraints).__name__}"
-            )
-
         # Symbolic Preprocessing & Augmentation
         self.symbolic: SymbolicProblem = preprocess_symbolic_problem(
             dynamics=dynamics,
-            constraints=ConstraintSet(unsorted=list(constraints)),
+            constraints=constraints,
             states=states,
             controls=controls,
             N=N,

--- a/openscvx/symbolic/builder.py
+++ b/openscvx/symbolic/builder.py
@@ -50,7 +50,6 @@ from openscvx.symbolic.preprocessing import (
     validate_and_normalize_constraint_nodes,
     validate_boundary_conditions,
     validate_bounds,
-    validate_constraint_types,
     validate_constraints_at_root,
     validate_dynamics_dict,
     validate_dynamics_dict_dimensions,
@@ -67,7 +66,7 @@ from openscvx.symbolic.time import Time
 
 def preprocess_symbolic_problem(
     dynamics: dict,
-    constraints: ConstraintSet,
+    constraints: list,
     states: List[State],
     controls: List[Control],
     N: int,
@@ -102,8 +101,8 @@ def preprocess_symbolic_problem(
     Args:
         dynamics: Dictionary mapping state names to dynamics expressions.
             Example: {"x": v, "v": u}
-        constraints: ConstraintSet with raw constraints in `unsorted` field.
-            Create with: ConstraintSet(unsorted=[c1, c2, c3])
+        constraints: List of constraint objects (Constraint, NodalConstraint,
+            CrossNodeConstraint, or CTCS).
         states: List of user-defined State objects (should NOT include time or CTCS states)
         controls: List of user-defined Control objects (should NOT include time dilation)
         N: Number of discretization nodes in the trajectory
@@ -143,16 +142,13 @@ def preprocess_symbolic_problem(
         Basic usage with CTCS constraint::
 
             import openscvx as ox
-            from openscvx.symbolic.constraint_set import ConstraintSet
 
             x = ox.State("x", shape=(2,))
             v = ox.State("v", shape=(2,))
             u = ox.Control("u", shape=(2,))
 
             dynamics = {"x": v, "v": u}
-            constraints = ConstraintSet(unsorted=[
-                (ox.Norm(x) <= 5.0).over((0, 50))
-            ])
+            constraints = [(ox.Norm(x) <= 5.0).over((0, 50))]
 
             problem = preprocess_symbolic_problem(
                 dynamics=dynamics,
@@ -191,9 +187,11 @@ def preprocess_symbolic_problem(
     """
 
     # Validate input types before anything else
-    validate_input_types(dynamics, states, controls, N, time)
-    validate_constraint_types(constraints)
+    validate_input_types(dynamics, states, controls, constraints, N, time)
     validate_propagation_input_types(dynamics_prop_extra, states_prop_extra)
+
+    # Wrap validated constraints into a ConstraintSet
+    constraints = ConstraintSet(unsorted=list(constraints))
 
     # Validate user-provided variables have required attributes
     validate_boundary_conditions(states)

--- a/openscvx/symbolic/preprocessing.py
+++ b/openscvx/symbolic/preprocessing.py
@@ -752,6 +752,7 @@ def validate_input_types(
     dynamics: any,
     states: any,
     controls: any,
+    constraints: any,
     N: any,
     time: any,
 ) -> None:
@@ -761,25 +762,11 @@ def validate_input_types(
     instead of a list, or passing wrong types for dynamics, N, or time.
     Should be called before any other validation in the preprocessing pipeline.
 
-    Args:
-        dynamics: Should be a dict mapping state names to dynamics expressions
-        states: Should be a list of State objects
-        controls: Should be a list of Control objects
-        N: Should be a positive integer
-        time: Should be a Time object
-
     Raises:
         TypeError: If any input has the wrong type
         ValueError: If N is not positive
-
-    Example:
-            x = ox.State("x", shape=(3,))
-            u = ox.Control("u", shape=(2,))
-
-            # Wrong: passing bare Control instead of list
-            validate_input_types({"x": u}, [x], u, 50, time)
-            # Raises TypeError: 'controls' must be a list of Control objects ...
     """
+    from openscvx.symbolic.expr import CTCS, Constraint, CrossNodeConstraint, NodalConstraint
     from openscvx.symbolic.time import Time
 
     if not isinstance(dynamics, dict):
@@ -812,6 +799,19 @@ def validate_input_types(
         if not isinstance(c, Control):
             raise TypeError(f"controls[{i}] must be a Control, got {type(c).__name__}")
 
+    if not isinstance(constraints, list):
+        raise TypeError(
+            f"'constraints' must be a list of Constraint objects, got {type(constraints).__name__}"
+        )
+
+    valid_constraint_types = (Constraint, NodalConstraint, CrossNodeConstraint, CTCS)
+    for i, c in enumerate(constraints):
+        if not isinstance(c, valid_constraint_types):
+            raise TypeError(
+                f"constraints[{i}] must be a Constraint, NodalConstraint, "
+                f"CrossNodeConstraint, or CTCS, got {type(c).__name__}"
+            )
+
     if not isinstance(N, int):
         raise TypeError(f"'N' must be an integer, got {type(N).__name__}")
 
@@ -820,40 +820,6 @@ def validate_input_types(
 
     if not isinstance(time, Time):
         raise TypeError(f"'time' must be a Time object, got {type(time).__name__}")
-
-
-def validate_constraint_types(constraints: any) -> None:
-    """Validate that all elements in a ConstraintSet are valid constraint types.
-
-    Each element in constraints.unsorted must be a Constraint, NodalConstraint,
-    CrossNodeConstraint, or CTCS.
-
-    Args:
-        constraints: A ConstraintSet whose unsorted elements will be checked
-
-    Raises:
-        TypeError: If any element is not a valid constraint type
-
-    Example:
-            from openscvx.symbolic.constraint_set import ConstraintSet
-
-            x = ox.State("x", shape=(3,))
-            constraints = ConstraintSet(unsorted=[x <= 5])  # OK
-            validate_constraint_types(constraints)
-
-            bad = ConstraintSet(unsorted=[42])
-            validate_constraint_types(bad)
-            # Raises TypeError: constraints[0] must be a Constraint, ...
-    """
-    from openscvx.symbolic.expr import CTCS, Constraint, CrossNodeConstraint, NodalConstraint
-
-    valid_types = (Constraint, NodalConstraint, CrossNodeConstraint, CTCS)
-    for i, c in enumerate(constraints.unsorted):
-        if not isinstance(c, valid_types):
-            raise TypeError(
-                f"constraints[{i}] must be a Constraint, NodalConstraint, "
-                f"CrossNodeConstraint, or CTCS, got {type(c).__name__}"
-            )
 
 
 def validate_propagation_input_types(

--- a/tests/symbolic/test_preprocessing.py
+++ b/tests/symbolic/test_preprocessing.py
@@ -9,7 +9,6 @@ from openscvx.symbolic.preprocessing import (
     fill_default_guesses,
     validate_boundary_conditions,
     validate_bounds,
-    validate_constraint_types,
     validate_constraints_at_root,
     validate_cross_node_constraint,
     validate_dynamics_dict,
@@ -994,135 +993,113 @@ def valid_inputs():
     x = State("x", shape=(3,))
     u = Control("u", shape=(2,))
     dynamics = {"x": x}
+    constraints = [x <= 5]
     time = Time(initial=0.0, final=10.0, min=0.0, max=20.0)
-    return dynamics, [x], [u], 50, time
+    return dynamics, [x], [u], constraints, 50, time
 
 
 def test_validate_input_types_passes(valid_inputs):
     """Test that valid inputs pass validation."""
-    dynamics, states, controls, N, time = valid_inputs
-    validate_input_types(dynamics, states, controls, N, time)
+    dynamics, states, controls, constraints, N, time = valid_inputs
+    validate_input_types(dynamics, states, controls, constraints, N, time)
 
 
 def test_validate_input_types_bare_control(valid_inputs):
     """Test that passing a bare Control instead of a list raises TypeError with hint."""
-    dynamics, states, _, N, time = valid_inputs
+    dynamics, states, _, constraints, N, time = valid_inputs
     u = Control("thrust", shape=(2,))
 
     with pytest.raises(
         TypeError, match=r"'controls' must be a list.*Control.*Hint.*controls=\[thrust\]"
     ):
-        validate_input_types(dynamics, states, u, N, time)
+        validate_input_types(dynamics, states, u, constraints, N, time)
 
 
 def test_validate_input_types_bare_state(valid_inputs):
     """Test that passing a bare State instead of a list raises TypeError with hint."""
-    dynamics, _, controls, N, time = valid_inputs
+    dynamics, _, controls, constraints, N, time = valid_inputs
     x = State("position", shape=(3,))
 
     with pytest.raises(
         TypeError, match=r"'states' must be a list.*State.*Hint.*states=\[position\]"
     ):
-        validate_input_types(dynamics, x, controls, N, time)
+        validate_input_types(dynamics, x, controls, constraints, N, time)
 
 
 def test_validate_input_types_wrong_element_in_states(valid_inputs):
     """Test that a non-State element in the states list raises TypeError."""
-    dynamics, _, controls, N, time = valid_inputs
+    dynamics, _, controls, constraints, N, time = valid_inputs
 
     with pytest.raises(TypeError, match=r"states\[0\] must be a State, got str"):
-        validate_input_types(dynamics, ["not_a_state"], controls, N, time)
+        validate_input_types(dynamics, ["not_a_state"], controls, constraints, N, time)
 
 
 def test_validate_input_types_wrong_element_in_controls(valid_inputs):
     """Test that a non-Control element in the controls list raises TypeError."""
-    dynamics, states, _, N, time = valid_inputs
+    dynamics, states, _, constraints, N, time = valid_inputs
 
     with pytest.raises(TypeError, match=r"controls\[0\] must be a Control, got int"):
-        validate_input_types(dynamics, states, [42], N, time)
+        validate_input_types(dynamics, states, [42], constraints, N, time)
 
 
 def test_validate_input_types_dynamics_not_dict(valid_inputs):
     """Test that passing non-dict dynamics raises TypeError."""
-    _, states, controls, N, time = valid_inputs
+    _, states, controls, constraints, N, time = valid_inputs
 
     with pytest.raises(TypeError, match="'dynamics' must be a dict"):
-        validate_input_types([1, 2, 3], states, controls, N, time)
+        validate_input_types([1, 2, 3], states, controls, constraints, N, time)
+
+
+def test_validate_input_types_constraints_not_list(valid_inputs):
+    """Test that passing a non-list constraints raises TypeError."""
+    dynamics, states, controls, _, N, time = valid_inputs
+
+    with pytest.raises(TypeError, match="'constraints' must be a list"):
+        validate_input_types(dynamics, states, controls, "not_a_list", N, time)
+
+
+def test_validate_input_types_constraints_invalid_element(valid_inputs):
+    """Test that non-constraint elements raise TypeError."""
+    dynamics, states, controls, _, N, time = valid_inputs
+
+    with pytest.raises(TypeError, match=r"constraints\[0\] must be a Constraint.*got int"):
+        validate_input_types(dynamics, states, controls, [42], N, time)
+
+
+def test_validate_input_types_constraints_mixed_valid_and_invalid(valid_inputs):
+    """Test that invalid element is caught even after valid ones."""
+    dynamics, states, controls, _, N, time = valid_inputs
+    x = State("x", shape=(3,))
+
+    with pytest.raises(TypeError, match=r"constraints\[1\] must be a Constraint.*got str"):
+        validate_input_types(dynamics, states, controls, [x <= 5, "bad"], N, time)
 
 
 def test_validate_input_types_N_not_int(valid_inputs):
     """Test that passing non-int N raises TypeError."""
-    dynamics, states, controls, _, time = valid_inputs
+    dynamics, states, controls, constraints, _, time = valid_inputs
 
     with pytest.raises(TypeError, match="'N' must be an integer, got float"):
-        validate_input_types(dynamics, states, controls, 50.0, time)
+        validate_input_types(dynamics, states, controls, constraints, 50.0, time)
 
 
 def test_validate_input_types_N_not_positive(valid_inputs):
     """Test that passing non-positive N raises ValueError."""
-    dynamics, states, controls, _, time = valid_inputs
+    dynamics, states, controls, constraints, _, time = valid_inputs
 
     with pytest.raises(ValueError, match="'N' must be positive, got 0"):
-        validate_input_types(dynamics, states, controls, 0, time)
+        validate_input_types(dynamics, states, controls, constraints, 0, time)
 
     with pytest.raises(ValueError, match="'N' must be positive, got -5"):
-        validate_input_types(dynamics, states, controls, -5, time)
+        validate_input_types(dynamics, states, controls, constraints, -5, time)
 
 
 def test_validate_input_types_time_not_time(valid_inputs):
     """Test that passing non-Time object raises TypeError."""
-    dynamics, states, controls, N, _ = valid_inputs
+    dynamics, states, controls, constraints, N, _ = valid_inputs
 
     with pytest.raises(TypeError, match="'time' must be a Time object, got float"):
-        validate_input_types(dynamics, states, controls, N, 10.0)
-
-
-# =============================================================================
-# validate_constraint_types Tests
-# =============================================================================
-
-
-def test_validate_constraint_types_passes():
-    """Test that valid constraint types pass validation."""
-    from openscvx.symbolic.constraint_set import ConstraintSet
-    from openscvx.symbolic.expr import CTCS, CrossNodeConstraint
-
-    x = State("x", shape=(3,))
-    cs = ConstraintSet(
-        unsorted=[
-            x <= 5,  # Constraint
-            (x <= 5).at([0, 10]),  # NodalConstraint
-            CrossNodeConstraint(x.at(0) == x.at(10)),  # CrossNodeConstraint
-            CTCS(x <= 5),  # CTCS
-        ]
-    )
-    validate_constraint_types(cs)
-
-
-def test_validate_constraint_types_empty():
-    """Test that empty constraint list passes validation."""
-    from openscvx.symbolic.constraint_set import ConstraintSet
-
-    validate_constraint_types(ConstraintSet(unsorted=[]))
-
-
-def test_validate_constraint_types_invalid_element():
-    """Test that non-constraint elements raise TypeError."""
-    from openscvx.symbolic.constraint_set import ConstraintSet
-
-    cs = ConstraintSet(unsorted=[42])
-    with pytest.raises(TypeError, match=r"constraints\[0\] must be a Constraint.*got int"):
-        validate_constraint_types(cs)
-
-
-def test_validate_constraint_types_mixed_valid_and_invalid():
-    """Test that invalid element is caught even after valid ones."""
-    from openscvx.symbolic.constraint_set import ConstraintSet
-
-    x = State("x", shape=(3,))
-    cs = ConstraintSet(unsorted=[x <= 5, "bad"])
-    with pytest.raises(TypeError, match=r"constraints\[1\] must be a Constraint.*got str"):
-        validate_constraint_types(cs)
+        validate_input_types(dynamics, states, controls, constraints, N, 10.0)
 
 
 # =============================================================================


### PR DESCRIPTION
- Added `validate_input_types()` to check that `dynamics`, `states`, `controls`, `constraints`, `N`, and `time` have correct types before any other validation runs, with actionable hints when a bare `State`/`Control` is passed instead of a list -> Fixes #352
- Added `validate_propagation_input_types()` to check that `dynamics_prop` and `states_prop` are both provided or both omitted, and validates their types