### PR TITLE
moved `_resolve_lam_vb`  to problem.initialize

### DIFF
--- a/openscvx/problem.py
+++ b/openscvx/problem.py
@@ -293,20 +293,6 @@ class Problem:
                 )
             self._algorithm = algorithm
 
-        # Build per-constraint lam_vb arrays from symbolic constraints and
-        # re-normalize so that per-constraint .weight() overrides participate
-        # in the normalization scale.  Include byof constraint counts so the
-        # arrays are sized to match the post-lowering constraint list.
-        n_byof_nodal = len(byof.get("nodal_constraints", [])) if byof else 0
-        n_byof_cross = len(byof.get("cross_nodal_constraints", [])) if byof else 0
-        self._algorithm._resolve_lam_vb(
-            N=self.symbolic.N,
-            nodal_constraints=self.symbolic.constraints.nodal,
-            cross_node_constraints=self.symbolic.constraints.cross_node,
-            n_byof_nodal=n_byof_nodal,
-            n_byof_cross=n_byof_cross,
-        )
-
         # Resolve discretizer: None → default, dict → LinearizeDiscretize(**dict), instance → use
         if discretizer is None:
             self._discretizer = LinearizeDiscretize()
@@ -848,6 +834,19 @@ class Problem:
             self.settings.sim.n_controls,
             self.settings.prp.max_tau_len,
             save_compiled=self.settings.sim.save_compiled,
+        )
+
+        # Build per-constraint lam_vb arrays from symbolic constraints and
+        # re-normalize. Deferred to initialize() so that user-set lam_vb
+        # values (assigned after Problem construction) are picked up.
+        n_byof_nodal = len(self._byof.get("nodal_constraints", [])) if self._byof else 0
+        n_byof_cross = len(self._byof.get("cross_nodal_constraints", [])) if self._byof else 0
+        self._algorithm._resolve_lam_vb(
+            N=self.symbolic.N,
+            nodal_constraints=self.symbolic.constraints.nodal,
+            cross_node_constraints=self.symbolic.constraints.cross_node,
+            n_byof_nodal=n_byof_nodal,
+            n_byof_cross=n_byof_cross,
         )
 
         # Initialize the SCP algorithm


### PR DESCRIPTION
Root cause: In commit 137ef78b, _resolve_lam_vb() was placed inside Problem.__init__() (line 302). This method builds the per-constraint lam_vb_nodal and lam_vb_cross arrays using self.weights._raw_lam_vb as the default fill value. But at __init__ time, lam_vb is still 0.0 (the Weights dataclass default), because the user hasn't had a chance to set it yet.

In ascent_launch_vehicle.py, the user sets problem.algorithm.lam_vb = 1e0 on line 553 — after construction. The property setter updates the scalar _raw_lam_vb to 1.0 and calls normalize(), but normalize() sees that _raw_lam_vb_nodal is already set (to the zero arrays from __init__), so it uses those zeros for the normalization scale. The arrays stay at zero forever, making virtual buffers completely ineffective.

Fix: Moved the _resolve_lam_vb() call from Problem.__init__() to Problem.initialize(), just before self._algorithm.initialize(). By this point, the user has set all their weights, so _raw_lam_vb = 1.0 is correctly propagated into the arrays.