### PR TITLE
Feature/add remaining stl operators

### DIFF
--- a/openscvx/symbolic/expr/__init__.py
+++ b/openscvx/symbolic/expr/__init__.py
@@ -65,8 +65,11 @@ Module Organization:
         `NodalConstraint` for enforcing constraints at discrete nodes and `CTCS` for
         continuous-time constraint satisfaction.
 
-    Signal Temporal Logic (stljax.py):
-        `Or` for logical disjunction in task specifications (stljax-backed).
+    Signal Temporal Logic (stl.py):
+        GMSR-backed smooth task-logic operators (`And`, `Or`, `Not`, `IfThen`,
+        `Always`, `Eventually`, `Until`, `IntegerVariable`) accessible via the
+        `ox.stl` namespace. See also `logic.py` for hard-boolean branching
+        (`All`, `Any`, `Cond`) used inside expressions rather than constraints.
 """
 
 # Arithmetic operations

--- a/openscvx/symbolic/expr/logic.py
+++ b/openscvx/symbolic/expr/logic.py
@@ -3,6 +3,15 @@
 This module provides logical and control flow operations used in optimization problems,
 enabling conditional logic in dynamics and constraints. These operations are
 JAX-only and not supported in CVXPy lowering.
+
+See also:
+    ``openscvx.symbolic.expr.stl`` (``ox.stl``) provides smooth GMSR-backed
+    task-logic operators (``And``, ``Or``, ``Not``, ``IfThen``, ``Always``,
+    ...) for *constraint specification*. Those produce smooth scalar
+    robustness values, not hard booleans, and are the right tool when you
+    want to compose constraints into a task spec. The operators in *this*
+    module (``All``, ``Any``, ``Cond``) are for *expression-level*
+    branching where you need a true boolean reduction over predicates.
 """
 
 from typing import List, Optional, Tuple, Union

--- a/openscvx/symbolic/expr/stl.py
+++ b/openscvx/symbolic/expr/stl.py
@@ -586,8 +586,7 @@ class Always(STLExpr):
         chosen = interval if interval is not None else self.interval
         if chosen is None:
             raise ValueError(
-                "Always requires an interval — pass one to the constructor "
-                "or to .over()."
+                "Always requires an interval — pass one to the constructor or to .over()."
             )
 
         if isinstance(self.predicate, STLExpr):

--- a/openscvx/symbolic/expr/stl.py
+++ b/openscvx/symbolic/expr/stl.py
@@ -240,24 +240,30 @@ class STLExpr(Expr):
 
     Sealing a spec — `.over()` vs `.at()`:
         STL specs live in a symbolic world; to enforce one you must
-        seal it into a concrete constraint via one of two entry points,
-        which represent fundamentally different enforcement strategies:
+        seal it into a concrete constraint via one of two entry points.
+        Both bind the spec to a *where on the trajectory*, but they
+        differ in the **shape** of that where, and that shape is the
+        only thing that determines the lowering:
 
-        - ``.over(interval)`` enforces the spec **throughout** a
-          continuous window. Lowers to a ``CTCS`` (continuous-time
-          constraint satisfaction) wrapper that integrates the
-          violation across the window. Takes an :class:`Interval` (or
-          interval-like value).
-        - ``.at(nodes)`` enforces the spec **only at** an explicit set
-          of discrete node indices. Lowers to a ``NodalConstraint``.
-          Takes a point set, not a window.
+        - ``.over(interval)`` binds the spec to a contiguous interval
+          (an :class:`Interval`, or a length-2 tuple coerced to one).
+          Lowers to a ``CTCS`` that integrates the violation across
+          the window — this is the natural realization of an STL
+          temporal quantifier ``□[a,b] p``.
+        - ``.at(nodes)`` binds the spec to a discrete list of node
+          indices. Lowers to a ``NodalConstraint`` that enforces the
+          predicate independently at each point — semantically a
+          finite conjunction ``p(n_1) ∧ p(n_2) ∧ ...``.
 
-        These have no shared abstraction today: ``.over()`` is window-
-        shaped, ``.at()`` is point-set-shaped, and they produce
-        different constraint types via different lowering paths. Pick
-        whichever matches the semantics you want — "always within this
-        stretch" → ``.over()``, "exactly at these checkpoints" →
-        ``.at()``. See the TODO below for the planned unification.
+        For a temporal operator like :class:`Always`, the interval is
+        part of the formula itself (``Always(p, I)``) and ``.over()``
+        seals it without taking a separate window. Specifying the
+        interval *both* on the operator and at the seal call is a
+        contradiction (not an override) and is rejected; the same
+        rule applies to ``Always(p, I).at(...)``. To pick a discrete
+        point set instead, leave the constructor's interval unset:
+        ``Always(p).at([2, 3, 5])`` is the universal quantifier over
+        a finite set, equivalent to a finite conjunction.
 
     STL Robustness Convention:
         STL uses "robustness" values that are positive when constraints are satisfied.
@@ -280,23 +286,20 @@ class STLExpr(Expr):
         Eventually, Always, or Until for actual STL specifications.
     """
 
-    # TODO: (griffin-norris, haynec, sametusun781) unify the .over()
-    # and .at() syntax in a clean way. Status:
+    # TODO: (griffin-norris, haynec, sametusun781) STL seal API status:
     #   [done]   Intervals are typed (NodeInterval / TimeInterval) and
     #            funnel through Interval.coerce; mixed-interval nesting
     #            is rejected at construction.
-    #   [open]   Intervals can still live on temporal nodes
-    #            (Always.interval) *and* be re-specified at .over()
-    #            time, with override semantics. Probably fine, but the
-    #            override rule should be documented or removed.
-    #   [open]   .over() and .at() have no shared abstraction.
-    #            The natural unification is a single .enforce(window)
-    #            method dispatching on a window type:
-    #              NodeInterval / TimeInterval → CTCS-shaped lowering
-    #              NodeSet      / TimeSet      → nodal-shaped lowering
-    #            That gives one method, four cells, and adds wall-time
-    #            support purely additively. Worth a planning pass with
-    #            collaborators before committing.
+    #   [done]   Override semantics on Always.over() removed: passing
+    #            an interval to both the constructor and .over() now
+    #            raises. Same rule on Always.at() when the operator
+    #            already carries an interval. The interval is part of
+    #            the formula and can only live in one place.
+    #   [done]   .over()/.at() unification: not needed. They are sugar
+    #            for two different region shapes (contiguous interval
+    #            vs. discrete point set) that map to two different
+    #            lowerings (CTCS vs. NodalConstraint). The "shape
+    #            determines lowering" story is the unification.
     #   [open]   TimeInterval lowering itself (gating on the model's
     #            explicit `time` state). Currently raises
     #            NotImplementedError at .over() time.
@@ -330,13 +333,11 @@ class STLExpr(Expr):
             constraint = visit_either.over((3, 5))
 
         See also:
-            :meth:`at` for enforcing the spec at an explicit set of
-            discrete node indices instead of throughout a window.
-            ``.over()`` is window-shaped (lowers to ``CTCS``); ``.at()``
-            is point-set-shaped (lowers to ``NodalConstraint``). They
-            are the two entry points for sealing an STL spec into a
-            concrete constraint and have no shared abstraction today —
-            see the class docstring for context.
+            :meth:`at` for binding the spec to a discrete point set
+            instead of a contiguous interval. The two methods seal to
+            different constraint types (CTCS vs. NodalConstraint)
+            because they pick different region shapes — see the
+            class docstring for the full story.
         """
         from .arithmetic import Neg
         from .constraint import CTCS, Inequality
@@ -376,13 +377,10 @@ class STLExpr(Expr):
                 constraint = visit_either.at([0, 5, 10])
 
         See also:
-            :meth:`over` for enforcing the spec **throughout** a
-            continuous window instead of at a discrete point set.
-            ``.at()`` is point-set-shaped (lowers to
-            ``NodalConstraint``); ``.over()`` is window-shaped (lowers
-            to ``CTCS``). They are the two entry points for sealing an
-            STL spec into a concrete constraint and have no shared
-            abstraction today — see the class docstring for context.
+            :meth:`over` for binding the spec to a contiguous
+            interval instead of a discrete point set. See the class
+            docstring for the full story on how the region shape
+            determines the lowering.
 
         Note:
             This is a base class. Use concrete subclasses like Or, And,
@@ -453,13 +451,15 @@ def _validate_predicates(predicates, min_count, cls_name):
             )
         if isinstance(pred, _TemporalSTLExpr) and pred.interval is not None:
             raise ValueError(
-                f"{cls_name}(...) cannot contain a temporal operator with an "
-                f"explicit interval (got {type(pred).__name__} with "
-                f"interval={pred.interval!r}). Mixed-interval nesting is not "
-                f"yet supported. Either drop the inner interval and let it "
-                f"inherit the ambient window from .over(), or compose the "
-                f"temporal pieces as separate top-level constraints: "
-                f"Always(p, I1).over() and Always(q, I2).over()."
+                f"{cls_name}(...) cannot contain a temporal operator that "
+                f"already carries an interval (got {type(pred).__name__} with "
+                f"interval={pred.interval!r}). Mixed-interval nesting has no "
+                f"defined lowering yet, so the inner interval would be "
+                f"silently dropped. Either drop the inner interval at "
+                f"construction and let it inherit the ambient window from "
+                f"the enclosing .over(), or compose the pieces as separate "
+                f"top-level constraints: Always(p, I1).over() and "
+                f"Always(q, I2).over()."
             )
 
 
@@ -774,6 +774,25 @@ class _TemporalSTLExpr(STLExpr):
 
     interval: Optional[Interval] = None
 
+    def at(self, nodes: Union[list, tuple]) -> "NodalConstraint":
+        """Seal this temporal spec at a discrete set of nodes.
+
+        Only valid when the operator does not already carry an
+        interval. The interval is part of *what the formula says*
+        (``□[a,b] p``); ``.at`` picks a discrete point set instead.
+        Specifying both is a contradiction, not an override, and is
+        rejected.
+        """
+        if self.interval is not None:
+            raise ValueError(
+                f"{type(self).__name__} already carries an interval "
+                f"({self.interval!r}); cannot also seal with .at({nodes!r}). "
+                f"The interval is part of the formula — pick exactly one of "
+                f"a contiguous interval (.over()) or a discrete point set "
+                f"(.at()) by leaving the constructor's interval unset."
+            )
+        return STLExpr.at(self, nodes)
+
 
 class Always(_TemporalSTLExpr):
     """Enforce ``predicate`` at every point in ``interval`` (STL ``Always``).
@@ -849,8 +868,11 @@ class Always(_TemporalSTLExpr):
         """Convert this ``Always`` to a ``CTCS`` constraint.
 
         Args:
-            interval: Optional override for the enforcement interval. If
-                omitted, the interval supplied at construction is used.
+            interval: Enforcement interval, supplied here *or* at
+                construction — but not both. The interval is part of
+                what the formula says (``□[a,b] p``); specifying it in
+                two places is a contradiction, not an override, and is
+                rejected.
             penalty: CTCS penalty function name.
             idx: Optional grouping index for multiple augmented states.
             check_nodally: Whether to additionally enforce at discrete nodes.
@@ -859,6 +881,13 @@ class Always(_TemporalSTLExpr):
             A ``CTCS`` constraint enforcing the inner predicate over the
             interval.
         """
+        if interval is not None and self.interval is not None:
+            raise ValueError(
+                f"Always already carries an interval ({self.interval!r}); "
+                f"cannot also pass interval={interval!r} to .over(). The "
+                f"interval is part of the formula — specify it in exactly "
+                f"one place: either Always(p, I).over() or Always(p).over(I)."
+            )
         chosen = Interval.coerce(interval, interval_type) if interval is not None else self.interval
         if chosen is None:
             raise ValueError(

--- a/openscvx/symbolic/expr/stl.py
+++ b/openscvx/symbolic/expr/stl.py
@@ -478,3 +478,101 @@ def Always(
     return CTCS(
         predicate, penalty=penalty, nodes=interval, idx=idx, check_nodally=check_nodally
     )
+
+
+class _UnimplementedTemporal(STLExpr):
+    """Base class for temporal STL nodes that are not yet implemented.
+
+    Stores the predicate + interval so that future formulations can be
+    swapped in without changing the surface API. Construction succeeds
+    (so that imports and AST inspection work), but any attempt to lower
+    or enforce the node raises NotImplementedError with a clear message.
+    """
+
+    _operator_name: str = "TemporalOperator"
+
+    def __init__(
+        self,
+        predicate: Union[Constraint, "STLExpr"],
+        interval: tuple[int, int],
+    ):
+        _validate_predicates([predicate], 1, self._operator_name)
+        self.predicate = predicate
+        self.interval = interval
+
+    def children(self):
+        return [self.predicate]
+
+    def canonicalize(self) -> "Expr":
+        raise NotImplementedError(
+            f"{self._operator_name} is not yet implemented. A novel formulation "
+            f"is in progress; for now, use ox.stl.Always for pointwise "
+            f"enforcement, or ox.stl.Or/And for explicit disjunctions."
+        )
+
+    def check_shape(self) -> Tuple[int, ...]:
+        self.predicate.check_shape()
+        return ()
+
+    def over(self, *args, **kwargs):
+        raise NotImplementedError(
+            f"{self._operator_name} is not yet implemented. A novel formulation "
+            f"is in progress; for now, use ox.stl.Always for pointwise "
+            f"enforcement, or ox.stl.Or/And for explicit disjunctions."
+        )
+
+    def at(self, *args, **kwargs):
+        raise NotImplementedError(
+            f"{self._operator_name} is not yet implemented. A novel formulation "
+            f"is in progress; for now, use ox.stl.Always for pointwise "
+            f"enforcement, or ox.stl.Or/And for explicit disjunctions."
+        )
+
+    def __repr__(self) -> str:
+        return f"{self._operator_name}({self.predicate!r}, {self.interval!r})"
+
+
+class Eventually(_UnimplementedTemporal):
+    """STL ``Eventually`` operator (placeholder).
+
+    Semantically: ``Eventually(p, (a, b))`` is satisfied iff ``p`` holds at
+    *some* time in ``[a, b]``. Implementation is in progress (a novel
+    formulation by a collaborator); constructing the node is allowed so
+    that downstream code can be sketched, but any use will raise
+    NotImplementedError.
+    """
+
+    _operator_name = "Eventually"
+
+
+class Until(_UnimplementedTemporal):
+    """STL ``Until`` operator (placeholder).
+
+    Not yet implemented. Constructing the node is allowed so downstream
+    code can be sketched; any use raises NotImplementedError.
+    """
+
+    _operator_name = "Until"
+
+    def __init__(
+        self,
+        left: Union[Constraint, "STLExpr"],
+        right: Union[Constraint, "STLExpr"],
+        interval: tuple[int, int],
+    ):
+        _validate_predicates([left, right], 2, "Until")
+        self.left = left
+        self.right = right
+        self.predicate = left  # for _UnimplementedTemporal.children/check_shape
+        self.interval = interval
+
+    def children(self):
+        return [self.left, self.right]
+
+    def check_shape(self) -> Tuple[int, ...]:
+        self.left.check_shape()
+        self.right.check_shape()
+        return ()
+
+    def __repr__(self) -> str:
+        return f"Until({self.left!r}, {self.right!r}, {self.interval!r})"

--- a/openscvx/symbolic/expr/stl.py
+++ b/openscvx/symbolic/expr/stl.py
@@ -428,3 +428,53 @@ class Not(STLExpr):
 
     def __repr__(self) -> str:
         return f"Not({self.predicate!r})"
+
+
+def Always(
+    predicate: Union[Constraint, "STLExpr"],
+    interval: tuple[int, int],
+    penalty: str = "smooth_relu",
+    idx: Optional[int] = None,
+    check_nodally: bool = False,
+) -> "CTCS":
+    """Enforce ``predicate`` at every point in ``interval`` (STL ``Always``).
+
+    This is syntactic sugar around CTCS: enforcing the integral of the
+    constraint violation to be zero across the interval is equivalent to
+    requiring the predicate to hold pointwise. ``Always`` is provided so
+    that STL specifications can be written in notation that mirrors the
+    math, without the user having to remember the CTCS-of-violation
+    encoding.
+
+    Args:
+        predicate: A Constraint or STLExpr that should hold throughout
+            the interval.
+        interval: ``(start, end)`` node indices defining the enforcement
+            window.
+        penalty: CTCS penalty function name.
+        idx: Optional grouping index for multiple augmented states.
+        check_nodally: Whether to additionally enforce at discrete nodes.
+
+    Returns:
+        A ``CTCS`` constraint enforcing ``predicate`` over ``interval``.
+
+    Example::
+
+        import openscvx as ox
+        avoid = ox.linalg.Norm(position - obs) >= safety_radius
+        constraints.append(ox.stl.Always(avoid, (0, N - 1)))
+    """
+    if isinstance(predicate, STLExpr):
+        return predicate.over(
+            interval, penalty=penalty, idx=idx, check_nodally=check_nodally
+        )
+    if not isinstance(predicate, Constraint):
+        raise TypeError(
+            f"Always requires a Constraint or STLExpr predicate, got "
+            f"{type(predicate).__name__}."
+        )
+    from .constraint import CTCS
+
+    return CTCS(
+        predicate, penalty=penalty, nodes=interval, idx=idx, check_nodally=check_nodally
+    )

--- a/openscvx/symbolic/expr/stl.py
+++ b/openscvx/symbolic/expr/stl.py
@@ -440,7 +440,7 @@ class Not(STLExpr):
         # Equivalently, with operator syntax once lifted into STL:
         outside = ~ox.stl.Always(in_zone)  # not always in zone
 
-    Note:
+    !!! note
         ``Not`` is a thin sign flip — there is no smoothing parameter.
         Composing ``Not`` with ``Or``/``And`` recovers De Morgan duals
         through the GMSR machinery rather than as an algebraic rewrite.
@@ -479,12 +479,11 @@ def Always(
 ) -> "CTCS":
     """Enforce ``predicate`` at every point in ``interval`` (STL ``Always``).
 
-    This is syntactic sugar around CTCS: enforcing the integral of the
-    constraint violation to be zero across the interval is equivalent to
-    requiring the predicate to hold pointwise. ``Always`` is provided so
-    that STL specifications can be written in notation that mirrors the
-    math, without the user having to remember the CTCS-of-violation
-    encoding.
+    ``Always(p, (a, b))`` is satisfied iff ``p`` holds at *every* time in
+    the interval ``[a, b]``. This is the universal temporal quantifier of
+    STL and is the natural way to express invariants such as obstacle
+    avoidance, box constraints, or speed limits over a window of the
+    trajectory.
 
     Args:
         predicate: A Constraint or STLExpr that should hold throughout
@@ -503,6 +502,15 @@ def Always(
         import openscvx as ox
         avoid = ox.linalg.Norm(position - obs) >= safety_radius
         constraints.append(ox.stl.Always(avoid, (0, N - 1)))
+
+    !!! note
+        ``Always`` is currently syntactic sugar around CTCS: enforcing
+        the integral of the constraint violation to be zero across the
+        interval is equivalent to requiring the predicate to hold
+        pointwise. It is exposed as a function (returning a ``CTCS``)
+        rather than as an ``STLExpr`` node, so it cannot be composed
+        with ``&``/``|``/``~``; reach for the underlying ``And``/``Or``
+        constructors if you need that.
     """
     if isinstance(predicate, STLExpr):
         return predicate.over(
@@ -523,10 +531,12 @@ def Always(
 class _UnimplementedTemporal(STLExpr):
     """Base class for temporal STL nodes that are not yet implemented.
 
-    Stores the predicate + interval so that future formulations can be
-    swapped in without changing the surface API. Construction succeeds
-    (so that imports and AST inspection work), but any attempt to lower
-    or enforce the node raises NotImplementedError with a clear message.
+    !!! note
+        Stores the predicate + interval so that future formulations can
+        be swapped in without changing the surface API. Construction
+        succeeds (so that imports and AST inspection work), but any
+        attempt to lower or enforce the node raises NotImplementedError
+        with a clear message.
     """
 
     _operator_name: str = "TemporalOperator"
@@ -573,23 +583,33 @@ class _UnimplementedTemporal(STLExpr):
 
 
 class Eventually(_UnimplementedTemporal):
-    """STL ``Eventually`` operator (placeholder).
+    """STL ``Eventually`` operator: ``p`` holds at some time in the interval.
 
     Semantically: ``Eventually(p, (a, b))`` is satisfied iff ``p`` holds at
-    *some* time in ``[a, b]``. Implementation is in progress (a novel
-    formulation by a collaborator); constructing the node is allowed so
-    that downstream code can be sketched, but any use will raise
-    NotImplementedError.
+    *some* time in ``[a, b]``.
+
+    !!! warning "Not yet implemented!"
+        Constructing the node is allowed so that downstream
+        code can be sketched against the eventual API, but any attempt
+        to lower or enforce it raises ``NotImplementedError``.
     """
 
     _operator_name = "Eventually"
 
 
 class Until(_UnimplementedTemporal):
-    """STL ``Until`` operator (placeholder).
+    """STL ``Until`` operator: ``left`` holds until ``right`` holds.
 
-    Not yet implemented. Constructing the node is allowed so downstream
-    code can be sketched; any use raises NotImplementedError.
+    ``Until(left, right, (a, b))`` is satisfied iff there exists a time
+    ``t* ∈ [a, b]`` at which ``right`` holds, and ``left`` holds at every
+    time in ``[a, t*]``. ``Until`` is the most expressive of the standard
+    STL temporal operators; ``Always`` and ``Eventually`` can both be
+    derived from it.
+
+    !!! warning "Not yet implemented!"
+        Constructing the node is allowed so
+        downstream code can be sketched against the eventual API, but
+        any attempt to lower or enforce it raises ``NotImplementedError``.
     """
 
     _operator_name = "Until"

--- a/openscvx/symbolic/expr/stl.py
+++ b/openscvx/symbolic/expr/stl.py
@@ -909,12 +909,12 @@ class _UnimplementedTemporal(_TemporalSTLExpr):
     def __init__(
         self,
         predicate: Union[Constraint, "STLExpr"],
-        interval: IntervalLike,
+        interval: Optional[IntervalLike] = None,
         interval_type: IntervalKind = "nodes",
     ):
         _validate_predicates([predicate], 1, self._operator_name)
         self.predicate = predicate
-        self.interval = Interval.coerce(interval, interval_type)
+        self.interval = Interval.coerce(interval, interval_type) if interval is not None else None
 
     def children(self):
         return [self.predicate]
@@ -952,7 +952,9 @@ class Eventually(_UnimplementedTemporal):
     """STL ``Eventually`` operator: ``p`` holds at some time in the interval.
 
     Semantically: ``Eventually(p, (a, b))`` is satisfied iff ``p`` holds at
-    *some* time in ``[a, b]``.
+    *some* time in ``[a, b]``. The interval is optional — when omitted,
+    the operator inherits the ambient window from the enclosing seal
+    (e.g. ``.over()``), the same way ``Always`` does.
 
     !!! warning "Not yet implemented!"
         Constructing the node is allowed so that downstream
@@ -970,7 +972,9 @@ class Until(_UnimplementedTemporal):
     ``t* ∈ [a, b]`` at which ``right`` holds, and ``left`` holds at every
     time in ``[a, t*]``. ``Until`` is the most expressive of the standard
     STL temporal operators; ``Always`` and ``Eventually`` can both be
-    derived from it.
+    derived from it. The interval is optional — when omitted, the
+    operator inherits the ambient window from the enclosing seal, the
+    same way ``Always`` does.
 
     !!! warning "Not yet implemented!"
         Constructing the node is allowed so
@@ -984,14 +988,14 @@ class Until(_UnimplementedTemporal):
         self,
         left: Union[Constraint, "STLExpr"],
         right: Union[Constraint, "STLExpr"],
-        interval: IntervalLike,
+        interval: Optional[IntervalLike] = None,
         interval_type: IntervalKind = "nodes",
     ):
         _validate_predicates([left, right], 2, "Until")
         self.left = left
         self.right = right
         self.predicate = left  # for _UnimplementedTemporal.children/check_shape
-        self.interval = Interval.coerce(interval, interval_type)
+        self.interval = Interval.coerce(interval, interval_type) if interval is not None else None
 
     def children(self):
         return [self.left, self.right]

--- a/openscvx/symbolic/expr/stl.py
+++ b/openscvx/symbolic/expr/stl.py
@@ -13,11 +13,17 @@ parameterizations that work directly with constraint residuals.
     STL — anything involving an enforcement interval or time-bounded
     quantification — is still being built out:
 
-    - ``Always`` works standalone via ``.over()`` (sugar over CTCS), but
-      when nested inside another STL operator its interval is currently
-      ignored and it lowers to the inner predicate's pointwise
-      robustness. Mixed-interval nesting therefore does not yet have
-      the semantics you would expect from textbook STL.
+    - Intervals are typed: :class:`NodeInterval` (node indices) is
+      implemented end to end. :class:`TimeInterval` (seconds, resolved
+      against the model's explicit ``time`` state) is accepted at
+      construction so downstream code can be sketched against the
+      eventual API, but raises ``NotImplementedError`` at lowering.
+    - Mixed-interval nesting (e.g. ``□[0,5] p ∧ ◇[3,8] q``) has no
+      defined lowering yet and is **rejected at construction time**.
+      Temporal operators used as children of other STL operators must
+      be interval-free and inherit the ambient window from the
+      enclosing ``.over()``. Compose distinct windows as separate
+      top-level constraints instead.
     - ``Eventually`` and ``Until`` are placeholder nodes only —
       construction is allowed so downstream code can be sketched, but
       any attempt to lower or enforce them raises ``NotImplementedError``.
@@ -46,6 +52,7 @@ See also:
     constraints into a task specification.
 """
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional, Tuple, Union
 
 import numpy as np
@@ -57,12 +64,163 @@ if TYPE_CHECKING:
     from .constraint import CTCS, NodalConstraint
 
 
+# ---------------------------------------------------------------------------
+# Interval value objects
+#
+# STL temporal operators take an enforcement interval. There are two
+# fundamentally different *kinds* of interval, and they lower very
+# differently:
+#
+#   - NodeInterval (start_node, end_node): resolved statically at graph
+#     build time. The participating nodes are known before any
+#     optimization runs and the lowering becomes a CTCS window over a
+#     known slice of the trajectory.
+#
+#   - TimeInterval (t_start, t_end) in seconds: resolved at *evaluation*
+#     time against the model's explicit `time` state. The set of nodes
+#     that fall inside the window is iterate-dependent; the interval is
+#     realised by gating the predicate residual on
+#     `(time >= t_start) & (time <= t_end)`. There is no static
+#     "convert to a node slice" step.
+#
+# These are not unit conversions of each other; they are different
+# lowering strategies that share a surface API. The Interval ABC +
+# Interval.coerce give a single, typed construction site so that the
+# rest of the STL stack — constructors, parser, lowerer — never has to
+# hand-roll the dispatch.
+#
+# Status: NodeInterval is implemented end to end. TimeInterval is
+# accepted at construction so that downstream code can be written
+# against the eventual API, but raises NotImplementedError at lowering
+# time.
+# ---------------------------------------------------------------------------
+
+
+class Interval:
+    """Base class for STL enforcement intervals.
+
+    Use :meth:`coerce` to build an ``Interval`` from a user-supplied
+    value (a tuple, an existing ``Interval``, or a parser ``Constant``).
+    Direct instantiation of the subclasses is also supported.
+    """
+
+    @staticmethod
+    def coerce(value: object) -> "Interval":
+        """Coerce a user-supplied interval-like value into an ``Interval``.
+
+        Accepts:
+            - an existing ``Interval`` instance (returned as-is);
+            - a 2-tuple/list of ints → :class:`NodeInterval`;
+            - a 2-tuple/list of floats → :class:`TimeInterval`;
+            - a parser :class:`Constant` wrapping a length-2 array, with
+              the same int-vs-float discrimination on its dtype.
+        """
+        if isinstance(value, Interval):
+            return value
+
+        if isinstance(value, Constant):
+            arr = value.value
+            if arr.shape != (2,):
+                raise TypeError(f"Interval Constant must have shape (2,), got {arr.shape}")
+            if arr.dtype.kind in ("i", "u"):
+                return NodeInterval(int(arr[0]), int(arr[1]))
+            return TimeInterval(float(arr[0]), float(arr[1]))
+
+        if isinstance(value, (tuple, list)) and len(value) == 2:
+            a, b = value
+            if isinstance(a, bool) or isinstance(b, bool):
+                raise TypeError("Interval bounds cannot be bool")
+            if isinstance(a, int) and isinstance(b, int):
+                return NodeInterval(a, b)
+            if isinstance(a, (int, float)) and isinstance(b, (int, float)):
+                return TimeInterval(float(a), float(b))
+
+        raise TypeError(
+            f"Cannot coerce {value!r} to an Interval. Expected an Interval "
+            f"instance, a 2-tuple of ints (node indices) or floats (seconds)."
+        )
+
+
+@dataclass(frozen=True)
+class NodeInterval(Interval):
+    """An interval expressed as ``[start_node, end_node]`` discretization indices.
+
+    Resolved statically at graph build time: the participating nodes are
+    known before any optimization runs.
+    """
+
+    start: int
+    end: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.start, int) or not isinstance(self.end, int):
+            raise TypeError(
+                f"NodeInterval bounds must be int, got "
+                f"({type(self.start).__name__}, {type(self.end).__name__})"
+            )
+        if self.end < self.start:
+            raise ValueError(f"NodeInterval end ({self.end}) must be >= start ({self.start})")
+
+    def __repr__(self) -> str:
+        return f"NodeInterval({self.start}, {self.end})"
+
+
+@dataclass(frozen=True)
+class TimeInterval(Interval):
+    """An interval expressed as ``[t_start, t_end]`` in seconds.
+
+    Resolved at *evaluation* time against the model's explicit ``time``
+    state — the set of nodes that fall inside the window is iterate-
+    dependent and is realised by gating the predicate residual on
+    ``(time >= t_start) & (time <= t_end)``.
+
+    !!! warning "Not yet implemented"
+        Construction is allowed so downstream code can be sketched
+        against the eventual API, but lowering raises
+        ``NotImplementedError``. Use :class:`NodeInterval` for now.
+    """
+
+    start: float
+    end: float
+
+    def __post_init__(self) -> None:
+        if self.end < self.start:
+            raise ValueError(f"TimeInterval end ({self.end}) must be >= start ({self.start})")
+
+    def __repr__(self) -> str:
+        return f"TimeInterval({self.start}, {self.end})"
+
+
+IntervalLike = Union[Interval, Tuple[int, int], Tuple[float, float]]
+
+
 class STLExpr(Expr):
     """Base class for GMSR-based Signal Temporal Logic operators.
 
     Provides common functionality for all GMSR STL operators including
     helper methods `.over()` and `.at()` to convert STL expressions
     to constraints for trajectory optimization.
+
+    Sealing a spec — `.over()` vs `.at()`:
+        STL specs live in a symbolic world; to enforce one you must
+        seal it into a concrete constraint via one of two entry points,
+        which represent fundamentally different enforcement strategies:
+
+        - ``.over(interval)`` enforces the spec **throughout** a
+          continuous window. Lowers to a ``CTCS`` (continuous-time
+          constraint satisfaction) wrapper that integrates the
+          violation across the window. Takes an :class:`Interval` (or
+          interval-like value).
+        - ``.at(nodes)`` enforces the spec **only at** an explicit set
+          of discrete node indices. Lowers to a ``NodalConstraint``.
+          Takes a point set, not a window.
+
+        These have no shared abstraction today: ``.over()`` is window-
+        shaped, ``.at()`` is point-set-shaped, and they produce
+        different constraint types via different lowering paths. Pick
+        whichever matches the semantics you want — "always within this
+        stretch" → ``.over()``, "exactly at these checkpoints" →
+        ``.at()``. See the TODO below for the planned unification.
 
     STL Robustness Convention:
         STL uses "robustness" values that are positive when constraints are satisfied.
@@ -85,28 +243,40 @@ class STLExpr(Expr):
         Eventually, Always, or Until for actual STL specifications.
     """
 
-    # TODO: (griffin-norris, haynec, sametusun781) unify the interval,
-    # .over(), and .at() syntax in a clean way. Currently:
-    #   - intervals can live on temporal nodes (Always.interval) *and*
-    #     be re-specified at .over() time, with override semantics;
-    #   - .over() always means "CTCS-of-violation across this window",
-    #     .at() always means "nodal enforcement at these indices",
-    #     and the two have no shared abstraction;
-    #   - Always is the only operator that meaningfully owns an
-    #     interval today, but Eventually/Until will need them too, and
-    #     mixed-interval nesting (□[0,5] p ∧ ◇[3,8] q) has no story yet.
+    # TODO: (griffin-norris, haynec, sametusun781) unify the .over()
+    # and .at() syntax in a clean way. Status:
+    #   [done]   Intervals are typed (NodeInterval / TimeInterval) and
+    #            funnel through Interval.coerce; mixed-interval nesting
+    #            is rejected at construction.
+    #   [open]   Intervals can still live on temporal nodes
+    #            (Always.interval) *and* be re-specified at .over()
+    #            time, with override semantics. Probably fine, but the
+    #            override rule should be documented or removed.
+    #   [open]   .over() and .at() have no shared abstraction.
+    #            The natural unification is a single .enforce(window)
+    #            method dispatching on a window type:
+    #              NodeInterval / TimeInterval → CTCS-shaped lowering
+    #              NodeSet      / TimeSet      → nodal-shaped lowering
+    #            That gives one method, four cells, and adds wall-time
+    #            support purely additively. Worth a planning pass with
+    #            collaborators before committing.
+    #   [open]   TimeInterval lowering itself (gating on the model's
+    #            explicit `time` state). Currently raises
+    #            NotImplementedError at .over() time.
 
     def over(
         self,
-        interval: tuple[int, int],
+        interval: "IntervalLike",
         penalty: str = "smooth_relu",
         idx: Optional[int] = None,
         check_nodally: bool = False,
     ) -> "CTCS":
-        """Apply this STL expression over a continuous interval using CTCS.
+        """Apply this STL expression over an enforcement interval using CTCS.
 
         Args:
-            interval: Tuple of (start, end) node indices for enforcement interval
+            interval: An ``Interval`` or interval-like value (a 2-tuple of
+                ints for node indices, or a 2-tuple of floats for seconds).
+                See :class:`Interval` for the full coercion rules.
             penalty: Penalty function type for CTCS
             idx: Optional grouping index for multiple augmented states
             check_nodally: Whether to also enforce at discrete nodes
@@ -118,14 +288,36 @@ class STLExpr(Expr):
 
             visit_either = ox.stl.Or(wp1, wp2)
             constraint = visit_either.over((3, 5))
+
+        See also:
+            :meth:`at` for enforcing the spec at an explicit set of
+            discrete node indices instead of throughout a window.
+            ``.over()`` is window-shaped (lowers to ``CTCS``); ``.at()``
+            is point-set-shaped (lowers to ``NodalConstraint``). They
+            are the two entry points for sealing an STL spec into a
+            concrete constraint and have no shared abstraction today —
+            see the class docstring for context.
         """
         from .arithmetic import Neg
         from .constraint import CTCS, Inequality
 
+        coerced = Interval.coerce(interval)
+        if isinstance(coerced, TimeInterval):
+            raise NotImplementedError(
+                "TimeInterval lowering is not yet implemented. Time-based "
+                "intervals will be realised by gating the predicate residual "
+                "on the model's explicit `time` state. Use NodeInterval "
+                "(int node indices) for now."
+            )
+
         constraint = Inequality(Neg(self), Constant(np.array(0.0)))
 
         return CTCS(
-            constraint, penalty=penalty, nodes=interval, idx=idx, check_nodally=check_nodally
+            constraint,
+            penalty=penalty,
+            nodes=(coerced.start, coerced.end),
+            idx=idx,
+            check_nodally=check_nodally,
         )
 
     def at(self, nodes: Union[list, tuple]) -> "NodalConstraint":
@@ -142,6 +334,15 @@ class STLExpr(Expr):
 
                 visit_either = ox.stl.Or(wp1, wp2)
                 constraint = visit_either.at([0, 5, 10])
+
+        See also:
+            :meth:`over` for enforcing the spec **throughout** a
+            continuous window instead of at a discrete point set.
+            ``.at()`` is point-set-shaped (lowers to
+            ``NodalConstraint``); ``.over()`` is window-shaped (lowers
+            to ``CTCS``). They are the two entry points for sealing an
+            STL spec into a concrete constraint and have no shared
+            abstraction today — see the class docstring for context.
 
         Note:
             This is a base class. Use concrete subclasses like Or, And,
@@ -190,7 +391,17 @@ class STLExpr(Expr):
 
 
 def _validate_predicates(predicates, min_count, cls_name):
-    """Validate that predicates are Constraint or STLExpr instances."""
+    """Validate that predicates are Constraint or STLExpr instances.
+
+    Also rejects temporal STL nodes that carry their own enforcement
+    interval as children of another STL operator. Mixed-interval nesting
+    (e.g. ``□[0,5] p ∧ ◇[3,8] q``) has no defined lowering yet, so we
+    refuse it loudly at construction time rather than silently dropping
+    the inner interval at lowering time. The workaround is to either
+    drop the inner interval and let it inherit the ambient window from
+    ``.over()``, or to compose the temporal pieces as separate
+    top-level constraints.
+    """
     if len(predicates) < min_count:
         raise ValueError(f"{cls_name} requires at least {min_count} predicates")
     for pred in predicates:
@@ -199,6 +410,16 @@ def _validate_predicates(predicates, min_count, cls_name):
                 f"{cls_name} requires Constraint or STLExpr predicates, got "
                 f"{type(pred).__name__}. "
                 f"Did you mean to write a constraint like 'expr <= value'?"
+            )
+        if isinstance(pred, _TemporalSTLExpr) and pred.interval is not None:
+            raise ValueError(
+                f"{cls_name}(...) cannot contain a temporal operator with an "
+                f"explicit interval (got {type(pred).__name__} with "
+                f"interval={pred.interval!r}). Mixed-interval nesting is not "
+                f"yet supported. Either drop the inner interval and let it "
+                f"inherit the ambient window from .over(), or compose the "
+                f"temporal pieces as separate top-level constraints: "
+                f"Always(p, I1).over() and Always(q, I2).over()."
             )
 
 
@@ -500,7 +721,21 @@ class Not(STLExpr):
         return f"Not({self.predicate!r})"
 
 
-class Always(STLExpr):
+class _TemporalSTLExpr(STLExpr):
+    """Base class for STL temporal operators (``Always``, ``Eventually``,
+    ``Until``).
+
+    Temporal operators are distinguished from purely-logical operators
+    (``And``, ``Or``, ``Not``, ``IfThen``) by carrying an enforcement
+    :class:`Interval`. Subclasses must set ``self.interval`` (an
+    ``Interval`` or ``None``) in their ``__init__``. This marker is what
+    :func:`_validate_predicates` checks to refuse mixed-interval nesting.
+    """
+
+    interval: Optional[Interval] = None
+
+
+class Always(_TemporalSTLExpr):
     """Enforce ``predicate`` at every point in ``interval`` (STL ``Always``).
 
     ``Always(p, (a, b))`` is satisfied iff ``p`` holds at *every* time in
@@ -532,23 +767,22 @@ class Always(STLExpr):
         interval is equivalent to requiring the predicate to hold
         pointwise. ``.over()`` performs that wrapping.
 
-        When ``Always`` is *nested* inside another STL operator, the
-        stored interval is currently ignored and the node lowers to the
-        inner predicate's pointwise robustness — so nested usage only
-        produces the intended semantics when all interacting temporal
-        operators share the same enforcement window. Mixed-interval
-        nesting will become well-defined once ``Eventually`` and
-        ``Until`` land with their full temporal lowering.
+        When ``Always`` is *nested* inside another STL operator it
+        must be interval-free and inherits the ambient window from the
+        enclosing ``.over()``. Passing an explicit interval to a nested
+        ``Always`` is rejected at construction time, since mixed-
+        interval nesting has no defined lowering yet. To compose
+        distinct windows, use separate top-level constraints.
     """
 
     def __init__(
         self,
         predicate: Union[Constraint, "STLExpr"],
-        interval: Optional[tuple[int, int]] = None,
+        interval: Optional[IntervalLike] = None,
     ):
         _validate_predicates([predicate], 1, "Always")
         self.predicate = predicate
-        self.interval = interval
+        self.interval = Interval.coerce(interval) if interval is not None else None
 
     def children(self):
         return [self.predicate]
@@ -565,7 +799,7 @@ class Always(STLExpr):
 
     def over(
         self,
-        interval: Optional[tuple[int, int]] = None,
+        interval: Optional[IntervalLike] = None,
         penalty: str = "smooth_relu",
         idx: Optional[int] = None,
         check_nodally: bool = False,
@@ -583,10 +817,17 @@ class Always(STLExpr):
             A ``CTCS`` constraint enforcing the inner predicate over the
             interval.
         """
-        chosen = interval if interval is not None else self.interval
+        chosen = Interval.coerce(interval) if interval is not None else self.interval
         if chosen is None:
             raise ValueError(
                 "Always requires an interval — pass one to the constructor or to .over()."
+            )
+        if isinstance(chosen, TimeInterval):
+            raise NotImplementedError(
+                "TimeInterval lowering is not yet implemented. Time-based "
+                "intervals will be realised by gating the predicate residual "
+                "on the model's explicit `time` state. Use NodeInterval "
+                "(int node indices) for now."
             )
 
         if isinstance(self.predicate, STLExpr):
@@ -599,7 +840,7 @@ class Always(STLExpr):
         return CTCS(
             self.predicate,
             penalty=penalty,
-            nodes=chosen,
+            nodes=(chosen.start, chosen.end),
             idx=idx,
             check_nodally=check_nodally,
         )
@@ -610,7 +851,7 @@ class Always(STLExpr):
         return f"Always({self.predicate!r}, {self.interval!r})"
 
 
-class _UnimplementedTemporal(STLExpr):
+class _UnimplementedTemporal(_TemporalSTLExpr):
     """Base class for temporal STL nodes that are not yet implemented.
 
     !!! note
@@ -626,11 +867,11 @@ class _UnimplementedTemporal(STLExpr):
     def __init__(
         self,
         predicate: Union[Constraint, "STLExpr"],
-        interval: tuple[int, int],
+        interval: IntervalLike,
     ):
         _validate_predicates([predicate], 1, self._operator_name)
         self.predicate = predicate
-        self.interval = interval
+        self.interval = Interval.coerce(interval)
 
     def children(self):
         return [self.predicate]
@@ -700,13 +941,13 @@ class Until(_UnimplementedTemporal):
         self,
         left: Union[Constraint, "STLExpr"],
         right: Union[Constraint, "STLExpr"],
-        interval: tuple[int, int],
+        interval: IntervalLike,
     ):
         _validate_predicates([left, right], 2, "Until")
         self.left = left
         self.right = right
         self.predicate = left  # for _UnimplementedTemporal.children/check_shape
-        self.interval = interval
+        self.interval = Interval.coerce(interval)
 
     def children(self):
         return [self.left, self.right]

--- a/openscvx/symbolic/expr/stl.py
+++ b/openscvx/symbolic/expr/stl.py
@@ -118,6 +118,38 @@ class STLExpr(Expr):
             nodes = [nodes]
         return NodalConstraint(constraint, list(nodes))
 
+    # ------------------------------------------------------------------
+    # Operator sugar for natural STL composition.
+    #
+    # These overloads only fire when at least one operand is already an
+    # STLExpr — bare ``Constraint`` objects intentionally do *not* get
+    # ``&``/``|``/``~`` so that ``Cond``/``All``/``Any`` users (see
+    # ``logic.py``) are not surprised by smooth-GMSR semantics sneaking
+    # into their hard-boolean branching. Lift into STL explicitly with
+    # any STL constructor (e.g. ``ox.stl.Always``) and the rest composes:
+    #
+    #     spec = (Always(c1) & Always(c2)) | ~stuck
+    #
+    # Note that smoothing parameters (``c``, ``lite``) cannot be passed
+    # through operator syntax — fall back to ``And(...)``/``Or(...)``/
+    # ``Not(...)`` if you need to tune them.
+    # ------------------------------------------------------------------
+
+    def __and__(self, other):
+        return And(self, other)
+
+    def __rand__(self, other):
+        return And(other, self)
+
+    def __or__(self, other):
+        return Or(self, other)
+
+    def __ror__(self, other):
+        return Or(other, self)
+
+    def __invert__(self):
+        return Not(self)
+
 
 def _validate_predicates(predicates, min_count, cls_name):
     """Validate that predicates are Constraint or STLExpr instances."""

--- a/openscvx/symbolic/expr/stl.py
+++ b/openscvx/symbolic/expr/stl.py
@@ -17,6 +17,14 @@ Author: Samet Uzun and Chris Hayner
 Reference:
     https://doi.org/10.48550/arxiv.2405.10996
     https://doi.org/10.2514/6.2025-1895
+
+See also:
+    ``openscvx.symbolic.expr.logic`` provides ``All``/``Any``/``Cond`` for
+    *hard-boolean* branching inside expressions (e.g. switching dynamics
+    based on a predicate). Those are JAX-only and not differentiable
+    across the branch. The operators in *this* module are smooth and
+    differentiable everywhere, and are the right tool for composing
+    constraints into a task specification.
 """
 
 from typing import TYPE_CHECKING, Optional, Tuple, Union

--- a/openscvx/symbolic/expr/stl.py
+++ b/openscvx/symbolic/expr/stl.py
@@ -380,3 +380,51 @@ class IntegerVariable(STLExpr):
 
     def __repr__(self) -> str:
         return f"IntegerVariable({self.expr!r}, values={self.values.tolist()})"
+
+
+class Not(STLExpr):
+    """GMSR smooth negation.
+
+    Satisfied when the inner predicate is *not* satisfied. Under the GMSR
+    convention this is just a sign flip on the residual: if the inner
+    predicate has robustness ``r``, then ``Not`` has robustness ``-r``.
+
+    Args:
+        predicate: A Constraint or STLExpr to negate.
+
+    Example::
+
+        import openscvx as ox
+        in_zone = ox.linalg.Norm(position - center) <= radius
+        outside = ox.stl.Not(in_zone)
+        # Equivalently, with operator syntax once lifted into STL:
+        outside = ~ox.stl.Always(in_zone)  # not always in zone
+
+    Note:
+        ``Not`` is a thin sign flip — there is no smoothing parameter.
+        Composing ``Not`` with ``Or``/``And`` recovers De Morgan duals
+        through the GMSR machinery rather than as an algebraic rewrite.
+    """
+
+    def __init__(self, predicate: Union[Constraint, "STLExpr"]):
+        _validate_predicates([predicate], 1, "Not")
+        self.predicate = predicate
+
+    def children(self):
+        return [self.predicate]
+
+    def canonicalize(self) -> "Expr":
+        canon = self.predicate.canonicalize()
+        # Double-negation elimination: ~~p -> p
+        if isinstance(canon, Not):
+            return canon.predicate
+        result = Not.__new__(Not)
+        result.predicate = canon
+        return result
+
+    def check_shape(self) -> Tuple[int, ...]:
+        self.predicate.check_shape()
+        return ()
+
+    def __repr__(self) -> str:
+        return f"Not({self.predicate!r})"

--- a/openscvx/symbolic/expr/stl.py
+++ b/openscvx/symbolic/expr/stl.py
@@ -18,6 +18,10 @@ parameterizations that work directly with constraint residuals.
       against the model's explicit ``time`` state) is accepted at
       construction so downstream code can be sketched against the
       eventual API, but raises ``NotImplementedError`` at lowering.
+      The kind of interval is selected explicitly by the
+      ``interval_type`` kwarg on temporal constructors and on
+      ``.over()`` — either ``"nodes"`` (the default) or ``"seconds"``.
+      There is no implicit int-vs-float dispatch.
     - Mixed-interval nesting (e.g. ``□[0,5] p ∧ ◇[3,8] q``) has no
       defined lowering yet and is **rejected at construction time**.
       Temporal operators used as children of other STL operators must
@@ -87,13 +91,19 @@ if TYPE_CHECKING:
 # lowering strategies that share a surface API. The Interval ABC +
 # Interval.coerce give a single, typed construction site so that the
 # rest of the STL stack — constructors, parser, lowerer — never has to
-# hand-roll the dispatch.
+# hand-roll the dispatch. The user picks the kind explicitly via the
+# ``interval_type`` kwarg ("nodes" or "seconds"); there is no implicit
+# int-vs-float inference.
 #
 # Status: NodeInterval is implemented end to end. TimeInterval is
 # accepted at construction so that downstream code can be written
 # against the eventual API, but raises NotImplementedError at lowering
 # time.
 # ---------------------------------------------------------------------------
+
+
+IntervalKind = str  # "nodes" or "seconds"
+_VALID_KINDS = ("nodes", "seconds")
 
 
 class Interval:
@@ -105,40 +115,67 @@ class Interval:
     """
 
     @staticmethod
-    def coerce(value: object) -> "Interval":
+    def coerce(value: object, kind: IntervalKind = "nodes") -> "Interval":
         """Coerce a user-supplied interval-like value into an ``Interval``.
 
-        Accepts:
-            - an existing ``Interval`` instance (returned as-is);
-            - a 2-tuple/list of ints → :class:`NodeInterval`;
-            - a 2-tuple/list of floats → :class:`TimeInterval`;
-            - a parser :class:`Constant` wrapping a length-2 array, with
-              the same int-vs-float discrimination on its dtype.
+        Args:
+            value: One of
+                - an existing ``Interval`` instance (returned as-is, with
+                  a sanity check that ``kind`` matches its concrete type
+                  unless the caller left ``kind`` at the default);
+                - a length-2 tuple/list of numbers;
+                - a parser :class:`Constant` wrapping a length-2 array.
+            kind: ``"nodes"`` (default) selects :class:`NodeInterval`;
+                ``"seconds"`` selects :class:`TimeInterval`. The user
+                names the kind explicitly — there is no inference from
+                int-vs-float.
+
+        For ``kind="nodes"`` the bounds must be integral (Python ``int``
+        or a ``float``/array element exactly equal to an integer); a
+        non-integral bound is rejected loudly. For ``kind="seconds"``
+        any numeric bound is accepted and cast to ``float``.
         """
+        if kind not in _VALID_KINDS:
+            raise ValueError(f"interval_type must be one of {_VALID_KINDS!r}, got {kind!r}")
+
+        # Pre-typed Intervals pass through. If the caller named a kind,
+        # require it to match — silent reinterpretation is exactly the
+        # footgun this API is trying to remove.
         if isinstance(value, Interval):
+            target_cls = NodeInterval if kind == "nodes" else TimeInterval
+            if not isinstance(value, target_cls):
+                raise TypeError(f"interval_type={kind!r} but received {type(value).__name__}")
             return value
 
         if isinstance(value, Constant):
             arr = value.value
             if arr.shape != (2,):
                 raise TypeError(f"Interval Constant must have shape (2,), got {arr.shape}")
-            if arr.dtype.kind in ("i", "u"):
-                return NodeInterval(int(arr[0]), int(arr[1]))
-            return TimeInterval(float(arr[0]), float(arr[1]))
-
-        if isinstance(value, (tuple, list)) and len(value) == 2:
+            a, b = arr[0].item(), arr[1].item()
+        elif isinstance(value, (tuple, list)) and len(value) == 2:
             a, b = value
             if isinstance(a, bool) or isinstance(b, bool):
                 raise TypeError("Interval bounds cannot be bool")
-            if isinstance(a, int) and isinstance(b, int):
-                return NodeInterval(a, b)
-            if isinstance(a, (int, float)) and isinstance(b, (int, float)):
-                return TimeInterval(float(a), float(b))
+            if not isinstance(a, (int, float)) or not isinstance(b, (int, float)):
+                raise TypeError(
+                    f"Interval bounds must be numeric, got ({type(a).__name__}, {type(b).__name__})"
+                )
+        else:
+            raise TypeError(
+                f"Cannot coerce {value!r} to an Interval. Expected an Interval "
+                f"instance, a length-2 tuple/list of numbers, or a length-2 Constant."
+            )
 
-        raise TypeError(
-            f"Cannot coerce {value!r} to an Interval. Expected an Interval "
-            f"instance, a 2-tuple of ints (node indices) or floats (seconds)."
-        )
+        if kind == "nodes":
+            for name, v in (("start", a), ("end", b)):
+                if isinstance(v, float) and not v.is_integer():
+                    raise TypeError(
+                        f"interval_type='nodes' requires integral bounds, got "
+                        f"{name}={v!r}. Pass interval_type='seconds' if you "
+                        f"meant a wall-time interval."
+                    )
+            return NodeInterval(int(a), int(b))
+        return TimeInterval(float(a), float(b))
 
 
 @dataclass(frozen=True)
@@ -191,7 +228,7 @@ class TimeInterval(Interval):
         return f"TimeInterval({self.start}, {self.end})"
 
 
-IntervalLike = Union[Interval, Tuple[int, int], Tuple[float, float]]
+IntervalLike = Union[Interval, Tuple[float, float]]
 
 
 class STLExpr(Expr):
@@ -270,13 +307,16 @@ class STLExpr(Expr):
         penalty: str = "smooth_relu",
         idx: Optional[int] = None,
         check_nodally: bool = False,
+        interval_type: IntervalKind = "nodes",
     ) -> "CTCS":
         """Apply this STL expression over an enforcement interval using CTCS.
 
         Args:
-            interval: An ``Interval`` or interval-like value (a 2-tuple of
-                ints for node indices, or a 2-tuple of floats for seconds).
-                See :class:`Interval` for the full coercion rules.
+            interval: An ``Interval`` or a length-2 tuple of numeric bounds.
+            interval_type: ``"nodes"`` (default) treats the bounds as
+                discretization indices and produces a :class:`NodeInterval`;
+                ``"seconds"`` treats them as wall-time and produces a
+                :class:`TimeInterval` (lowering not yet implemented).
             penalty: Penalty function type for CTCS
             idx: Optional grouping index for multiple augmented states
             check_nodally: Whether to also enforce at discrete nodes
@@ -301,7 +341,7 @@ class STLExpr(Expr):
         from .arithmetic import Neg
         from .constraint import CTCS, Inequality
 
-        coerced = Interval.coerce(interval)
+        coerced = Interval.coerce(interval, interval_type)
         if isinstance(coerced, TimeInterval):
             raise NotImplementedError(
                 "TimeInterval lowering is not yet implemented. Time-based "
@@ -779,10 +819,11 @@ class Always(_TemporalSTLExpr):
         self,
         predicate: Union[Constraint, "STLExpr"],
         interval: Optional[IntervalLike] = None,
+        interval_type: IntervalKind = "nodes",
     ):
         _validate_predicates([predicate], 1, "Always")
         self.predicate = predicate
-        self.interval = Interval.coerce(interval) if interval is not None else None
+        self.interval = Interval.coerce(interval, interval_type) if interval is not None else None
 
     def children(self):
         return [self.predicate]
@@ -803,6 +844,7 @@ class Always(_TemporalSTLExpr):
         penalty: str = "smooth_relu",
         idx: Optional[int] = None,
         check_nodally: bool = False,
+        interval_type: IntervalKind = "nodes",
     ) -> "CTCS":
         """Convert this ``Always`` to a ``CTCS`` constraint.
 
@@ -817,7 +859,7 @@ class Always(_TemporalSTLExpr):
             A ``CTCS`` constraint enforcing the inner predicate over the
             interval.
         """
-        chosen = Interval.coerce(interval) if interval is not None else self.interval
+        chosen = Interval.coerce(interval, interval_type) if interval is not None else self.interval
         if chosen is None:
             raise ValueError(
                 "Always requires an interval — pass one to the constructor or to .over()."
@@ -868,10 +910,11 @@ class _UnimplementedTemporal(_TemporalSTLExpr):
         self,
         predicate: Union[Constraint, "STLExpr"],
         interval: IntervalLike,
+        interval_type: IntervalKind = "nodes",
     ):
         _validate_predicates([predicate], 1, self._operator_name)
         self.predicate = predicate
-        self.interval = Interval.coerce(interval)
+        self.interval = Interval.coerce(interval, interval_type)
 
     def children(self):
         return [self.predicate]
@@ -942,12 +985,13 @@ class Until(_UnimplementedTemporal):
         left: Union[Constraint, "STLExpr"],
         right: Union[Constraint, "STLExpr"],
         interval: IntervalLike,
+        interval_type: IntervalKind = "nodes",
     ):
         _validate_predicates([left, right], 2, "Until")
         self.left = left
         self.right = right
         self.predicate = left  # for _UnimplementedTemporal.children/check_shape
-        self.interval = Interval.coerce(interval)
+        self.interval = Interval.coerce(interval, interval_type)
 
     def children(self):
         return [self.left, self.right]

--- a/openscvx/symbolic/expr/stl.py
+++ b/openscvx/symbolic/expr/stl.py
@@ -1020,11 +1020,12 @@ class Until(_UnimplementedTemporal):
         interval: Optional[IntervalLike] = None,
         interval_type: IntervalKind = "nodes",
     ):
+        # _validate_predicates runs again inside super().__init__, but it
+        # only sees `left`; call it explicitly here to also validate `right`.
         _validate_predicates([left, right], 2, "Until")
+        super().__init__(left, interval=interval, interval_type=interval_type)
         self.left = left
         self.right = right
-        self.predicate = left  # for _UnimplementedTemporal.children/check_shape
-        self.interval = Interval.coerce(interval, interval_type) if interval is not None else None
 
     def children(self):
         return [self.left, self.right]

--- a/openscvx/symbolic/expr/stl.py
+++ b/openscvx/symbolic/expr/stl.py
@@ -7,6 +7,25 @@ differentiable approximations of Boolean logic for use in trajectory optimizatio
 Unlike the stljax module (which uses the stljax library), this module uses GMSR
 parameterizations that work directly with constraint residuals.
 
+!!! warning "Interval and time semantics are a work in progress"
+    The *logical* operators in this module (``And``, ``Or``, ``Not``,
+    ``IfThen``) are stable and compose freely. The *temporal* side of
+    STL — anything involving an enforcement interval or time-bounded
+    quantification — is still being built out:
+
+    - ``Always`` works standalone via ``.over()`` (sugar over CTCS), but
+      when nested inside another STL operator its interval is currently
+      ignored and it lowers to the inner predicate's pointwise
+      robustness. Mixed-interval nesting therefore does not yet have
+      the semantics you would expect from textbook STL.
+    - ``Eventually`` and ``Until`` are placeholder nodes only —
+      construction is allowed so downstream code can be sketched, but
+      any attempt to lower or enforce them raises ``NotImplementedError``.
+      A novel formulation is in progress.
+
+    Treat this surface as load-bearing for *logical* task composition
+    and as preview for *temporal* composition until those gaps close.
+
 GMSR Robustness Convention:
     GMSR functions operate on constraint residuals (negative when satisfied).
     The expression nodes in this module follow the standard STL convention where
@@ -65,6 +84,17 @@ class STLExpr(Expr):
         This is a base class. Use concrete subclasses like Or, And,
         Eventually, Always, or Until for actual STL specifications.
     """
+
+    # TODO: (griffin-norris, haynec, sametusun781) unify the interval,
+    # .over(), and .at() syntax in a clean way. Currently:
+    #   - intervals can live on temporal nodes (Always.interval) *and*
+    #     be re-specified at .over() time, with override semantics;
+    #   - .over() always means "CTCS-of-violation across this window",
+    #     .at() always means "nodal enforcement at these indices",
+    #     and the two have no shared abstraction;
+    #   - Always is the only operator that meaningfully owns an
+    #     interval today, but Eventually/Until will need them too, and
+    #     mixed-interval nesting (□[0,5] p ∧ ◇[3,8] q) has no story yet.
 
     def over(
         self,
@@ -470,13 +500,7 @@ class Not(STLExpr):
         return f"Not({self.predicate!r})"
 
 
-def Always(
-    predicate: Union[Constraint, "STLExpr"],
-    interval: tuple[int, int],
-    penalty: str = "smooth_relu",
-    idx: Optional[int] = None,
-    check_nodally: bool = False,
-) -> "CTCS":
+class Always(STLExpr):
     """Enforce ``predicate`` at every point in ``interval`` (STL ``Always``).
 
     ``Always(p, (a, b))`` is satisfied iff ``p`` holds at *every* time in
@@ -488,44 +512,103 @@ def Always(
     Args:
         predicate: A Constraint or STLExpr that should hold throughout
             the interval.
-        interval: ``(start, end)`` node indices defining the enforcement
-            window.
-        penalty: CTCS penalty function name.
-        idx: Optional grouping index for multiple augmented states.
-        check_nodally: Whether to additionally enforce at discrete nodes.
-
-    Returns:
-        A ``CTCS`` constraint enforcing ``predicate`` over ``interval``.
+        interval: Optional ``(start, end)`` node indices defining the
+            enforcement window. If omitted at construction, must be
+            supplied at ``.over()`` time.
 
     Example::
 
         import openscvx as ox
         avoid = ox.linalg.Norm(position - obs) >= safety_radius
-        constraints.append(ox.stl.Always(avoid, (0, N - 1)))
+        constraints.append(ox.stl.Always(avoid, (0, N - 1)).over())
+
+        # Composes naturally with other STL operators:
+        spec = ox.stl.Always(avoid, (0, N - 1)) & ox.stl.Always(in_box, (0, N - 1))
+        constraints.append(spec.over())
 
     !!! note
-        ``Always`` is currently syntactic sugar around CTCS: enforcing
+        Standalone, ``Always`` is syntactic sugar around CTCS: enforcing
         the integral of the constraint violation to be zero across the
         interval is equivalent to requiring the predicate to hold
-        pointwise. It is exposed as a function (returning a ``CTCS``)
-        rather than as an ``STLExpr`` node, so it cannot be composed
-        with ``&``/``|``/``~``; reach for the underlying ``And``/``Or``
-        constructors if you need that.
-    """
-    if isinstance(predicate, STLExpr):
-        return predicate.over(
-            interval, penalty=penalty, idx=idx, check_nodally=check_nodally
-        )
-    if not isinstance(predicate, Constraint):
-        raise TypeError(
-            f"Always requires a Constraint or STLExpr predicate, got "
-            f"{type(predicate).__name__}."
-        )
-    from .constraint import CTCS
+        pointwise. ``.over()`` performs that wrapping.
 
-    return CTCS(
-        predicate, penalty=penalty, nodes=interval, idx=idx, check_nodally=check_nodally
-    )
+        When ``Always`` is *nested* inside another STL operator, the
+        stored interval is currently ignored and the node lowers to the
+        inner predicate's pointwise robustness — so nested usage only
+        produces the intended semantics when all interacting temporal
+        operators share the same enforcement window. Mixed-interval
+        nesting will become well-defined once ``Eventually`` and
+        ``Until`` land with their full temporal lowering.
+    """
+
+    def __init__(
+        self,
+        predicate: Union[Constraint, "STLExpr"],
+        interval: Optional[tuple[int, int]] = None,
+    ):
+        _validate_predicates([predicate], 1, "Always")
+        self.predicate = predicate
+        self.interval = interval
+
+    def children(self):
+        return [self.predicate]
+
+    def canonicalize(self) -> "Expr":
+        result = Always.__new__(Always)
+        result.predicate = self.predicate.canonicalize()
+        result.interval = self.interval
+        return result
+
+    def check_shape(self) -> Tuple[int, ...]:
+        self.predicate.check_shape()
+        return ()
+
+    def over(
+        self,
+        interval: Optional[tuple[int, int]] = None,
+        penalty: str = "smooth_relu",
+        idx: Optional[int] = None,
+        check_nodally: bool = False,
+    ) -> "CTCS":
+        """Convert this ``Always`` to a ``CTCS`` constraint.
+
+        Args:
+            interval: Optional override for the enforcement interval. If
+                omitted, the interval supplied at construction is used.
+            penalty: CTCS penalty function name.
+            idx: Optional grouping index for multiple augmented states.
+            check_nodally: Whether to additionally enforce at discrete nodes.
+
+        Returns:
+            A ``CTCS`` constraint enforcing the inner predicate over the
+            interval.
+        """
+        chosen = interval if interval is not None else self.interval
+        if chosen is None:
+            raise ValueError(
+                "Always requires an interval — pass one to the constructor "
+                "or to .over()."
+            )
+
+        if isinstance(self.predicate, STLExpr):
+            return self.predicate.over(
+                chosen, penalty=penalty, idx=idx, check_nodally=check_nodally
+            )
+
+        from .constraint import CTCS
+
+        return CTCS(
+            self.predicate,
+            penalty=penalty,
+            nodes=chosen,
+            idx=idx,
+            check_nodally=check_nodally,
+        )
+
+    def __repr__(self) -> str:
+        if self.interval is None:
+            return f"Always({self.predicate!r})"
+        return f"Always({self.predicate!r}, {self.interval!r})"
 
 
 class _UnimplementedTemporal(STLExpr):

--- a/openscvx/symbolic/lowerers/jax/stl.py
+++ b/openscvx/symbolic/lowerers/jax/stl.py
@@ -17,7 +17,15 @@ import jax.numpy as jnp
 from jax import Array
 from jax.typing import ArrayLike
 
-from openscvx.symbolic.expr.stl import And, IfThen, IntegerVariable, Not, Or, STLExpr
+from openscvx.symbolic.expr.stl import (
+    Always,
+    And,
+    IfThen,
+    IntegerVariable,
+    Not,
+    Or,
+    STLExpr,
+)
 from openscvx.symbolic.lowerers.jax._registry import visitor
 
 # ---------------------------------------------------------------------------
@@ -208,6 +216,25 @@ def _visit_ifthen(lowerer, node: IfThen):
         return -gmsr_fn(jnp.array([cond_residual, conseq_residual]), c=c)
 
     return ifthen_fn
+
+
+@visitor(Always)
+def _visit_always(lowerer, node: Always):
+    """Lower nested ``Always`` to JAX.
+
+    When ``Always`` appears as a child of another STL operator, we lower
+    it to the inner predicate's pointwise robustness — the stored
+    interval is ignored. Standalone use goes through ``.over()``, which
+    builds a ``CTCS`` directly and never reaches this visitor.
+    """
+    inner_fns = _lower_predicate_residuals(lowerer, [node.predicate])
+
+    def always_fn(x, u, node_idx, params):
+        # inner_fns returns the residual (negative-when-satisfied);
+        # negate to get robustness (positive-when-satisfied).
+        return -inner_fns[0](x, u, node_idx, params)
+
+    return always_fn
 
 
 @visitor(Not)

--- a/openscvx/symbolic/lowerers/jax/stl.py
+++ b/openscvx/symbolic/lowerers/jax/stl.py
@@ -222,11 +222,17 @@ def _visit_ifthen(lowerer, node: IfThen):
 def _visit_always(lowerer, node: Always):
     """Lower nested ``Always`` to JAX.
 
-    When ``Always`` appears as a child of another STL operator, we lower
-    it to the inner predicate's pointwise robustness — the stored
-    interval is ignored. Standalone use goes through ``.over()``, which
-    builds a ``CTCS`` directly and never reaches this visitor.
+    Mixed-interval nesting is rejected at construction time, so by the
+    time this visitor runs the node is guaranteed to be interval-free
+    and inherits the ambient window from the enclosing ``.over()``. We
+    just lower it to the inner predicate's pointwise robustness.
+    Standalone ``Always`` goes through ``.over()``, which builds a
+    ``CTCS`` directly and never reaches this visitor.
     """
+    assert node.interval is None, (
+        "nested Always with explicit interval should have been rejected at "
+        "construction by _validate_predicates"
+    )
     inner_fns = _lower_predicate_residuals(lowerer, [node.predicate])
 
     def always_fn(x, u, node_idx, params):

--- a/openscvx/symbolic/lowerers/jax/stl.py
+++ b/openscvx/symbolic/lowerers/jax/stl.py
@@ -17,7 +17,7 @@ import jax.numpy as jnp
 from jax import Array
 from jax.typing import ArrayLike
 
-from openscvx.symbolic.expr.stl import And, IfThen, IntegerVariable, Or, STLExpr
+from openscvx.symbolic.expr.stl import And, IfThen, IntegerVariable, Not, Or, STLExpr
 from openscvx.symbolic.lowerers.jax._registry import visitor
 
 # ---------------------------------------------------------------------------
@@ -208,6 +208,22 @@ def _visit_ifthen(lowerer, node: IfThen):
         return -gmsr_fn(jnp.array([cond_residual, conseq_residual]), c=c)
 
     return ifthen_fn
+
+
+@visitor(Not)
+def _visit_not(lowerer, node: Not):
+    """Lower GMSR negation (Not) to JAX.
+
+    Robustness(Not(p)) = -Robustness(p). We compute the inner predicate's
+    residual (negative-when-satisfied) and return it directly: that *is*
+    the negated robustness.
+    """
+    inner_fns = _lower_predicate_residuals(lowerer, [node.predicate])
+
+    def not_fn(x, u, node_idx, params):
+        return inner_fns[0](x, u, node_idx, params)
+
+    return not_fn
 
 
 @visitor(IntegerVariable)

--- a/openscvx/symbolic/parser/stl.py
+++ b/openscvx/symbolic/parser/stl.py
@@ -1,10 +1,19 @@
 """Parser handlers for GMSR-based Signal Temporal Logic operations.
 
-Handlers: Or, And, IfThen, IntegerVariable
+Handlers: Or, And, Not, IfThen, IntegerVariable, Always, Eventually, Until
 """
 
 from openscvx.symbolic.expr.expr import Constant
-from openscvx.symbolic.expr.stl import And, IfThen, IntegerVariable, Or
+from openscvx.symbolic.expr.stl import (
+    Always,
+    And,
+    Eventually,
+    IfThen,
+    IntegerVariable,
+    Not,
+    Or,
+    Until,
+)
 from openscvx.symbolic.parser._registry import function
 
 
@@ -20,6 +29,43 @@ def _parse_and(args, kwargs):
     if len(args) < 2:
         raise ValueError("And() requires at least 2 predicate arguments")
     return And(*args, **kwargs)
+
+
+@function("Not")
+def _parse_not(args, kwargs):
+    if len(args) != 1:
+        raise ValueError("Not() requires exactly 1 predicate argument")
+    return Not(*args, **kwargs)
+
+
+@function("Always")
+def _parse_always(args, kwargs):
+    if len(args) != 2:
+        raise ValueError("Always() requires exactly 2 arguments (predicate, interval)")
+    predicate, interval = args
+    if isinstance(interval, Constant):
+        interval = tuple(int(v) for v in interval.value.tolist())
+    return Always(predicate, interval, **kwargs)
+
+
+@function("Eventually")
+def _parse_eventually(args, kwargs):
+    if len(args) != 2:
+        raise ValueError("Eventually() requires exactly 2 arguments (predicate, interval)")
+    predicate, interval = args
+    if isinstance(interval, Constant):
+        interval = tuple(int(v) for v in interval.value.tolist())
+    return Eventually(predicate, interval, **kwargs)
+
+
+@function("Until")
+def _parse_until(args, kwargs):
+    if len(args) != 3:
+        raise ValueError("Until() requires exactly 3 arguments (left, right, interval)")
+    left, right, interval = args
+    if isinstance(interval, Constant):
+        interval = tuple(int(v) for v in interval.value.tolist())
+    return Until(left, right, interval, **kwargs)
 
 
 @function("IfThen")

--- a/openscvx/symbolic/parser/stl.py
+++ b/openscvx/symbolic/parser/stl.py
@@ -50,18 +50,16 @@ def _parse_always(args, kwargs):
 
 @function("Eventually")
 def _parse_eventually(args, kwargs):
-    if len(args) != 2:
-        raise ValueError("Eventually() requires exactly 2 arguments (predicate, interval)")
-    predicate, interval = args
-    return Eventually(predicate, interval, **kwargs)
+    if len(args) not in (1, 2):
+        raise ValueError("Eventually() requires 1 or 2 arguments (predicate[, interval])")
+    return Eventually(*args, **kwargs)
 
 
 @function("Until")
 def _parse_until(args, kwargs):
-    if len(args) != 3:
-        raise ValueError("Until() requires exactly 3 arguments (left, right, interval)")
-    left, right, interval = args
-    return Until(left, right, interval, **kwargs)
+    if len(args) not in (2, 3):
+        raise ValueError("Until() requires 2 or 3 arguments (left, right[, interval])")
+    return Until(*args, **kwargs)
 
 
 @function("IfThen")

--- a/openscvx/symbolic/parser/stl.py
+++ b/openscvx/symbolic/parser/stl.py
@@ -10,6 +10,7 @@ from openscvx.symbolic.expr.stl import (
     Eventually,
     IfThen,
     IntegerVariable,
+    Interval,
     Not,
     Or,
     Until,
@@ -45,9 +46,7 @@ def _parse_always(args, kwargs):
     if len(args) == 1:
         return Always(args[0], **kwargs)
     predicate, interval = args
-    if isinstance(interval, Constant):
-        interval = tuple(int(v) for v in interval.value.tolist())
-    return Always(predicate, interval, **kwargs)
+    return Always(predicate, Interval.coerce(interval), **kwargs)
 
 
 @function("Eventually")
@@ -55,9 +54,7 @@ def _parse_eventually(args, kwargs):
     if len(args) != 2:
         raise ValueError("Eventually() requires exactly 2 arguments (predicate, interval)")
     predicate, interval = args
-    if isinstance(interval, Constant):
-        interval = tuple(int(v) for v in interval.value.tolist())
-    return Eventually(predicate, interval, **kwargs)
+    return Eventually(predicate, Interval.coerce(interval), **kwargs)
 
 
 @function("Until")
@@ -65,9 +62,7 @@ def _parse_until(args, kwargs):
     if len(args) != 3:
         raise ValueError("Until() requires exactly 3 arguments (left, right, interval)")
     left, right, interval = args
-    if isinstance(interval, Constant):
-        interval = tuple(int(v) for v in interval.value.tolist())
-    return Until(left, right, interval, **kwargs)
+    return Until(left, right, Interval.coerce(interval), **kwargs)
 
 
 @function("IfThen")

--- a/openscvx/symbolic/parser/stl.py
+++ b/openscvx/symbolic/parser/stl.py
@@ -40,8 +40,10 @@ def _parse_not(args, kwargs):
 
 @function("Always")
 def _parse_always(args, kwargs):
-    if len(args) != 2:
-        raise ValueError("Always() requires exactly 2 arguments (predicate, interval)")
+    if len(args) not in (1, 2):
+        raise ValueError("Always() requires 1 or 2 arguments (predicate[, interval])")
+    if len(args) == 1:
+        return Always(args[0], **kwargs)
     predicate, interval = args
     if isinstance(interval, Constant):
         interval = tuple(int(v) for v in interval.value.tolist())

--- a/openscvx/symbolic/parser/stl.py
+++ b/openscvx/symbolic/parser/stl.py
@@ -10,7 +10,6 @@ from openscvx.symbolic.expr.stl import (
     Eventually,
     IfThen,
     IntegerVariable,
-    Interval,
     Not,
     Or,
     Until,
@@ -46,7 +45,7 @@ def _parse_always(args, kwargs):
     if len(args) == 1:
         return Always(args[0], **kwargs)
     predicate, interval = args
-    return Always(predicate, Interval.coerce(interval), **kwargs)
+    return Always(predicate, interval, **kwargs)
 
 
 @function("Eventually")
@@ -54,7 +53,7 @@ def _parse_eventually(args, kwargs):
     if len(args) != 2:
         raise ValueError("Eventually() requires exactly 2 arguments (predicate, interval)")
     predicate, interval = args
-    return Eventually(predicate, Interval.coerce(interval), **kwargs)
+    return Eventually(predicate, interval, **kwargs)
 
 
 @function("Until")
@@ -62,7 +61,7 @@ def _parse_until(args, kwargs):
     if len(args) != 3:
         raise ValueError("Until() requires exactly 3 arguments (left, right, interval)")
     left, right, interval = args
-    return Until(left, right, Interval.coerce(interval), **kwargs)
+    return Until(left, right, interval, **kwargs)
 
 
 @function("IfThen")

--- a/tests/symbolic/expr/test_stl.py
+++ b/tests/symbolic/expr/test_stl.py
@@ -21,7 +21,17 @@ import pytest
 
 from openscvx.symbolic.expr import Constant, State
 from openscvx.symbolic.expr.constraint import CTCS, Inequality, NodalConstraint
-from openscvx.symbolic.expr.stl import And, IfThen, IntegerVariable, Or, STLExpr
+from openscvx.symbolic.expr.stl import (
+    Always,
+    And,
+    Eventually,
+    IfThen,
+    IntegerVariable,
+    Not,
+    Or,
+    STLExpr,
+    Until,
+)
 from openscvx.symbolic.lowerers.jax import JaxLowerer
 
 # =============================================================================
@@ -577,3 +587,333 @@ def test_integer_variable_jax_single_allowed_value():
     fn = _setup_integer_variable_jax(values=[3.0])
     assert float(fn(jnp.array([3.0]), None, None, None)) == pytest.approx(0.0, abs=1e-4)
     assert float(fn(jnp.array([3.5]), None, None, None)) < 0.0
+
+
+# =============================================================================
+# Not – Construction & Tree Structure
+# =============================================================================
+
+
+def test_not_basic_construction():
+    _, p1, _ = _make_predicates()
+    node = Not(p1)
+    assert isinstance(node, STLExpr)
+    assert node.predicate is p1
+
+
+def test_not_children_returns_predicate():
+    _, p1, _ = _make_predicates()
+    assert Not(p1).children() == [p1]
+
+
+def test_not_repr():
+    _, p1, _ = _make_predicates()
+    assert repr(Not(p1)).startswith("Not(")
+
+
+def test_not_check_shape_returns_empty_tuple():
+    _, p1, _ = _make_predicates()
+    assert Not(p1).check_shape() == ()
+
+
+def test_not_rejects_non_constraint_arg():
+    with pytest.raises(TypeError):
+        Not("bad")
+
+
+def test_not_canonicalize_collapses_double_negation():
+    _, p1, _ = _make_predicates()
+    canon = Not(Not(p1)).canonicalize()
+    # ~~p should collapse to (canonicalized) p, not a Not node
+    assert not isinstance(canon, Not)
+
+
+def test_not_canonicalize_preserves_single_negation():
+    _, p1, _ = _make_predicates()
+    canon = Not(p1).canonicalize()
+    assert isinstance(canon, Not)
+
+
+def test_not_accepts_nested_stl():
+    _, p1, p2 = _make_predicates()
+    inner = Or(p1, p2)
+    node = Not(inner)
+    assert isinstance(node, Not)
+    assert node.predicate is inner
+
+
+# =============================================================================
+# Not – JAX Lowering
+# =============================================================================
+
+
+def _setup_not_jax():
+    x_sym = State("x", shape=(2,))
+    x_sym._slice = slice(0, 2)
+    p = x_sym[0] <= Constant(np.array(1.0))  # x[0] <= 1
+    return _lower_stl(Not(p))
+
+
+def test_not_jax_negative_when_inner_satisfied():
+    fn = _setup_not_jax()
+    # x[0]=0.5 satisfies inner predicate → Not should be unsatisfied (negative)
+    assert float(fn(jnp.array([0.5, 0.0]), None, None, None)) < 0.0
+
+
+def test_not_jax_positive_when_inner_violated():
+    fn = _setup_not_jax()
+    # x[0]=2.0 violates inner predicate → Not should be satisfied (positive)
+    assert float(fn(jnp.array([2.0, 0.0]), None, None, None)) > 0.0
+
+
+def test_not_jax_double_negation_matches_inner():
+    x_sym = State("x", shape=(2,))
+    x_sym._slice = slice(0, 2)
+    p = x_sym[0] <= Constant(np.array(1.0))
+    inner_fn = _lower_stl(Or(p, x_sym[1] <= Constant(np.array(2.0))))
+    double_fn = _lower_stl(Not(Not(Or(p, x_sym[1] <= Constant(np.array(2.0))))))
+    x = jnp.array([0.5, 3.0])
+    assert float(double_fn(x, None, None, None)) == pytest.approx(
+        float(inner_fn(x, None, None, None)), abs=1e-6
+    )
+
+
+# =============================================================================
+# Always – Construction & Tree Structure
+# =============================================================================
+
+
+def test_always_basic_construction():
+    _, p1, _ = _make_predicates()
+    node = Always(p1, (0, 5))
+    assert isinstance(node, STLExpr)
+    assert node.predicate is p1
+    assert node.interval == (0, 5)
+
+
+def test_always_interval_optional():
+    _, p1, _ = _make_predicates()
+    node = Always(p1)
+    assert node.interval is None
+
+
+def test_always_children_returns_predicate():
+    _, p1, _ = _make_predicates()
+    assert Always(p1, (0, 5)).children() == [p1]
+
+
+def test_always_repr_with_interval():
+    _, p1, _ = _make_predicates()
+    r = repr(Always(p1, (0, 5)))
+    assert r.startswith("Always(")
+    assert "(0, 5)" in r
+
+
+def test_always_repr_without_interval():
+    _, p1, _ = _make_predicates()
+    assert repr(Always(p1)).startswith("Always(")
+
+
+def test_always_check_shape_returns_empty_tuple():
+    _, p1, _ = _make_predicates()
+    assert Always(p1, (0, 5)).check_shape() == ()
+
+
+def test_always_rejects_non_constraint_predicate():
+    with pytest.raises(TypeError):
+        Always("bad", (0, 5))
+
+
+def test_always_canonicalize_preserves_interval():
+    _, p1, _ = _make_predicates()
+    canon = Always(p1, (3, 7)).canonicalize()
+    assert isinstance(canon, Always)
+    assert canon.interval == (3, 7)
+
+
+def test_always_accepts_nested_stl_predicate():
+    _, p1, p2 = _make_predicates()
+    inner = And(p1, p2)
+    node = Always(inner, (0, 5))
+    assert isinstance(node, Always)
+    assert node.predicate is inner
+
+
+# =============================================================================
+# Always – .over() seals to CTCS
+# =============================================================================
+
+
+def test_always_over_uses_stored_interval():
+    _, p1, _ = _make_predicates()
+    ctcs = Always(p1, (3, 7)).over()
+    assert isinstance(ctcs, CTCS)
+    assert ctcs.nodes == (3, 7)
+
+
+def test_always_over_override_interval():
+    _, p1, _ = _make_predicates()
+    ctcs = Always(p1, (3, 7)).over((0, 10))
+    assert ctcs.nodes == (0, 10)
+
+
+def test_always_over_requires_interval_somewhere():
+    _, p1, _ = _make_predicates()
+    with pytest.raises(ValueError, match="interval"):
+        Always(p1).over()
+
+
+def test_always_over_with_stl_predicate_returns_ctcs():
+    _, p1, p2 = _make_predicates()
+    ctcs = Always(And(p1, p2), (0, 5)).over()
+    assert isinstance(ctcs, CTCS)
+
+
+# =============================================================================
+# Always – JAX lowering (nested usage)
+# =============================================================================
+
+
+def _setup_always_nested_jax():
+    """Always nested inside an And — visitor lowers to inner robustness."""
+    x_sym = State("x", shape=(2,))
+    x_sym._slice = slice(0, 2)
+    p1 = x_sym[0] <= Constant(np.array(1.0))
+    p2 = x_sym[1] <= Constant(np.array(2.0))
+    return _lower_stl(And(Always(p1, (0, 5)), Always(p2, (0, 5))))
+
+
+def test_always_nested_jax_positive_when_both_satisfied():
+    fn = _setup_always_nested_jax()
+    assert float(fn(jnp.array([0.5, 1.5]), None, None, None)) > 0.0
+
+
+def test_always_nested_jax_negative_when_one_violated():
+    fn = _setup_always_nested_jax()
+    assert float(fn(jnp.array([0.5, 3.0]), None, None, None)) < 0.0
+
+
+# =============================================================================
+# Operator overloads on STLExpr (&, |, ~)
+# =============================================================================
+
+
+def test_stlexpr_or_operator_builds_or_node():
+    _, p1, p2 = _make_predicates()
+    node = Or(p1, p2) | Or(p2, p1)
+    assert isinstance(node, Or)
+    assert len(node.predicates) == 2
+
+
+def test_stlexpr_and_operator_builds_and_node():
+    _, p1, p2 = _make_predicates()
+    node = Or(p1, p2) & Or(p2, p1)
+    assert isinstance(node, And)
+    assert len(node.predicates) == 2
+
+
+def test_stlexpr_invert_operator_builds_not_node():
+    _, p1, p2 = _make_predicates()
+    node = ~Or(p1, p2)
+    assert isinstance(node, Not)
+
+
+def test_stlexpr_operator_with_constraint_on_left():
+    """Constraint & STLExpr → STLExpr.__rand__ kicks in."""
+    _, p1, p2 = _make_predicates()
+    node = p1 & Or(p1, p2)
+    assert isinstance(node, And)
+
+
+def test_stlexpr_operator_with_constraint_on_right():
+    _, p1, p2 = _make_predicates()
+    node = Or(p1, p2) | p1
+    assert isinstance(node, Or)
+
+
+def test_constraint_does_not_have_and_overload():
+    """Bare Constraint & Constraint should NOT build an STL node."""
+    _, p1, p2 = _make_predicates()
+    with pytest.raises(TypeError):
+        p1 & p2  # type: ignore[operator]
+
+
+def test_stlexpr_operator_composition_lowers_correctly():
+    """(Or & Or) | ~Or should produce a valid lowered function."""
+    x_sym = State("x", shape=(2,))
+    x_sym._slice = slice(0, 2)
+    p1 = x_sym[0] <= Constant(np.array(1.0))
+    p2 = x_sym[1] <= Constant(np.array(2.0))
+    spec = (Or(p1, p2) & Or(p1, p2)) | ~Or(p1, p2)
+    fn = _lower_stl(spec)
+    out = fn(jnp.array([0.5, 1.5]), None, None, None)
+    assert jnp.shape(out) == ()
+
+
+# =============================================================================
+# Eventually & Until – placeholders
+# =============================================================================
+
+
+def test_eventually_construction_succeeds():
+    _, p1, _ = _make_predicates()
+    node = Eventually(p1, (0, 5))
+    assert isinstance(node, STLExpr)
+    assert node.predicate is p1
+    assert node.interval == (0, 5)
+
+
+def test_eventually_canonicalize_raises():
+    _, p1, _ = _make_predicates()
+    with pytest.raises(NotImplementedError, match="Eventually"):
+        Eventually(p1, (0, 5)).canonicalize()
+
+
+def test_eventually_over_raises():
+    _, p1, _ = _make_predicates()
+    with pytest.raises(NotImplementedError, match="Eventually"):
+        Eventually(p1, (0, 5)).over((0, 5))
+
+
+def test_eventually_at_raises():
+    _, p1, _ = _make_predicates()
+    with pytest.raises(NotImplementedError, match="Eventually"):
+        Eventually(p1, (0, 5)).at([0])
+
+
+def test_eventually_repr():
+    _, p1, _ = _make_predicates()
+    r = repr(Eventually(p1, (0, 5)))
+    assert "Eventually" in r
+
+
+def test_until_construction_succeeds():
+    _, p1, p2 = _make_predicates()
+    node = Until(p1, p2, (0, 5))
+    assert isinstance(node, STLExpr)
+    assert node.left is p1
+    assert node.right is p2
+    assert node.interval == (0, 5)
+
+
+def test_until_children_returns_both_sides():
+    _, p1, p2 = _make_predicates()
+    assert Until(p1, p2, (0, 5)).children() == [p1, p2]
+
+
+def test_until_canonicalize_raises():
+    _, p1, p2 = _make_predicates()
+    with pytest.raises(NotImplementedError, match="Until"):
+        Until(p1, p2, (0, 5)).canonicalize()
+
+
+def test_until_over_raises():
+    _, p1, p2 = _make_predicates()
+    with pytest.raises(NotImplementedError, match="Until"):
+        Until(p1, p2, (0, 5)).over((0, 5))
+
+
+def test_until_repr():
+    _, p1, p2 = _make_predicates()
+    r = repr(Until(p1, p2, (0, 5)))
+    assert "Until" in r

--- a/tests/symbolic/expr/test_stl.py
+++ b/tests/symbolic/expr/test_stl.py
@@ -27,10 +27,12 @@ from openscvx.symbolic.expr.stl import (
     Eventually,
     IfThen,
     IntegerVariable,
+    Interval,
     NodeInterval,
     Not,
     Or,
     STLExpr,
+    TimeInterval,
     Until,
 )
 from openscvx.symbolic.lowerers.jax import JaxLowerer
@@ -913,6 +915,77 @@ def test_until_over_raises():
     _, p1, p2 = _make_predicates()
     with pytest.raises(NotImplementedError, match="Until"):
         Until(p1, p2, (0, 5)).over((0, 5))
+
+
+# =============================================================================
+# Interval.coerce – explicit interval_type dispatch
+# =============================================================================
+
+
+def test_coerce_default_kind_is_nodes():
+    assert Interval.coerce((0, 5)) == NodeInterval(0, 5)
+
+
+def test_coerce_seconds_kind_builds_time_interval():
+    iv = Interval.coerce((0.0, 5.0), "seconds")
+    assert isinstance(iv, TimeInterval)
+    assert iv.start == 0.0 and iv.end == 5.0
+
+
+def test_coerce_seconds_accepts_int_bounds():
+    # "seconds" is permissive: any numeric is fine
+    iv = Interval.coerce((0, 5), "seconds")
+    assert isinstance(iv, TimeInterval)
+
+
+def test_coerce_nodes_rejects_non_integral_float():
+    with pytest.raises(TypeError, match="integral"):
+        Interval.coerce((0.0, 5.5), "nodes")
+
+
+def test_coerce_nodes_accepts_integral_float():
+    # 5.0 is exactly an integer — fine under "nodes"
+    assert Interval.coerce((0.0, 5.0), "nodes") == NodeInterval(0, 5)
+
+
+def test_coerce_invalid_kind_raises():
+    with pytest.raises(ValueError, match="interval_type"):
+        Interval.coerce((0, 5), "frames")
+
+
+def test_coerce_passthrough_typed_interval_matching_kind():
+    iv = NodeInterval(0, 5)
+    assert Interval.coerce(iv, "nodes") is iv
+
+
+def test_coerce_passthrough_typed_interval_mismatched_kind_raises():
+    iv = TimeInterval(0.0, 5.0)
+    with pytest.raises(TypeError, match="nodes"):
+        Interval.coerce(iv, "nodes")
+
+
+def test_always_interval_type_seconds_builds_time_interval():
+    _, p1, _ = _make_predicates()
+    node = Always(p1, (0.0, 5.0), interval_type="seconds")
+    assert isinstance(node.interval, TimeInterval)
+
+
+def test_always_over_interval_type_seconds_raises_not_implemented():
+    _, p1, _ = _make_predicates()
+    with pytest.raises(NotImplementedError, match="TimeInterval"):
+        Always(p1).over((0.0, 5.0), interval_type="seconds")
+
+
+def test_stl_over_interval_type_seconds_raises_not_implemented():
+    _, p1, p2 = _make_predicates()
+    with pytest.raises(NotImplementedError, match="TimeInterval"):
+        Or(p1, p2).over((0.0, 5.0), interval_type="seconds")
+
+
+def test_until_interval_type_seconds():
+    _, p1, p2 = _make_predicates()
+    node = Until(p1, p2, (0.0, 5.0), interval_type="seconds")
+    assert isinstance(node.interval, TimeInterval)
 
 
 def test_until_repr():

--- a/tests/symbolic/expr/test_stl.py
+++ b/tests/symbolic/expr/test_stl.py
@@ -982,6 +982,19 @@ def test_stl_over_interval_type_seconds_raises_not_implemented():
         Or(p1, p2).over((0.0, 5.0), interval_type="seconds")
 
 
+def test_eventually_interval_optional():
+    _, p1, _ = _make_predicates()
+    node = Eventually(p1)
+    assert node.interval is None
+
+
+def test_until_interval_optional():
+    _, p1, p2 = _make_predicates()
+    node = Until(p1, p2)
+    assert node.interval is None
+    assert node.left is p1 and node.right is p2
+
+
 def test_until_interval_type_seconds():
     _, p1, p2 = _make_predicates()
     node = Until(p1, p2, (0.0, 5.0), interval_type="seconds")

--- a/tests/symbolic/expr/test_stl.py
+++ b/tests/symbolic/expr/test_stl.py
@@ -27,6 +27,7 @@ from openscvx.symbolic.expr.stl import (
     Eventually,
     IfThen,
     IntegerVariable,
+    NodeInterval,
     Not,
     Or,
     STLExpr,
@@ -688,7 +689,7 @@ def test_always_basic_construction():
     node = Always(p1, (0, 5))
     assert isinstance(node, STLExpr)
     assert node.predicate is p1
-    assert node.interval == (0, 5)
+    assert node.interval == NodeInterval(0, 5)
 
 
 def test_always_interval_optional():
@@ -728,7 +729,7 @@ def test_always_canonicalize_preserves_interval():
     _, p1, _ = _make_predicates()
     canon = Always(p1, (3, 7)).canonicalize()
     assert isinstance(canon, Always)
-    assert canon.interval == (3, 7)
+    assert canon.interval == NodeInterval(3, 7)
 
 
 def test_always_accepts_nested_stl_predicate():
@@ -775,12 +776,13 @@ def test_always_over_with_stl_predicate_returns_ctcs():
 
 
 def _setup_always_nested_jax():
-    """Always nested inside an And — visitor lowers to inner robustness."""
+    """Always nested inside an And — children must be interval-free and
+    inherit the ambient window from the enclosing .over()."""
     x_sym = State("x", shape=(2,))
     x_sym._slice = slice(0, 2)
     p1 = x_sym[0] <= Constant(np.array(1.0))
     p2 = x_sym[1] <= Constant(np.array(2.0))
-    return _lower_stl(And(Always(p1, (0, 5)), Always(p2, (0, 5))))
+    return _lower_stl(And(Always(p1), Always(p2)))
 
 
 def test_always_nested_jax_positive_when_both_satisfied():
@@ -860,7 +862,7 @@ def test_eventually_construction_succeeds():
     node = Eventually(p1, (0, 5))
     assert isinstance(node, STLExpr)
     assert node.predicate is p1
-    assert node.interval == (0, 5)
+    assert node.interval == NodeInterval(0, 5)
 
 
 def test_eventually_canonicalize_raises():
@@ -893,7 +895,7 @@ def test_until_construction_succeeds():
     assert isinstance(node, STLExpr)
     assert node.left is p1
     assert node.right is p2
-    assert node.interval == (0, 5)
+    assert node.interval == NodeInterval(0, 5)
 
 
 def test_until_children_returns_both_sides():

--- a/tests/symbolic/expr/test_stl.py
+++ b/tests/symbolic/expr/test_stl.py
@@ -852,7 +852,7 @@ def test_constraint_does_not_have_and_overload():
     """Bare Constraint & Constraint should NOT build an STL node."""
     _, p1, p2 = _make_predicates()
     with pytest.raises(TypeError):
-        p1 & p2  # type: ignore[operator]
+        _ = p1 & p2  # type: ignore[operator]
 
 
 def test_stlexpr_operator_composition_lowers_correctly():

--- a/tests/symbolic/expr/test_stl.py
+++ b/tests/symbolic/expr/test_stl.py
@@ -754,16 +754,29 @@ def test_always_over_uses_stored_interval():
     assert ctcs.nodes == (3, 7)
 
 
-def test_always_over_override_interval():
+def test_always_over_rejects_interval_specified_twice():
     _, p1, _ = _make_predicates()
-    ctcs = Always(p1, (3, 7)).over((0, 10))
-    assert ctcs.nodes == (0, 10)
+    with pytest.raises(ValueError, match="already carries an interval"):
+        Always(p1, (3, 7)).over((0, 10))
 
 
 def test_always_over_requires_interval_somewhere():
     _, p1, _ = _make_predicates()
-    with pytest.raises(ValueError, match="interval"):
+    with pytest.raises(ValueError, match="requires an interval"):
         Always(p1).over()
+
+
+def test_always_at_lowers_to_nodal_when_no_interval():
+    _, p1, _ = _make_predicates()
+    nodal = Always(p1).at([2, 3, 5])
+    assert isinstance(nodal, NodalConstraint)
+    assert nodal.nodes == [2, 3, 5]
+
+
+def test_always_at_rejects_when_interval_set():
+    _, p1, _ = _make_predicates()
+    with pytest.raises(ValueError, match="already carries an interval"):
+        Always(p1, (0, 5)).at([2, 3])
 
 
 def test_always_over_with_stl_predicate_returns_ctcs():


### PR DESCRIPTION
## Summary

- Added remaining STL operators -> Fixes #373
    - Added `Not` STLExpr (with double-negation elimination)
    - Promoted `Always` to a real `STLExpr` node (was: function returning `CTCS`) so it nests inside `And`/`Or`/`Not`/
`IfThen` and composes with the new operators. `.over()` still seals it into a `CTCS`.
    - Added `Eventually` and `Until` placeholder nodes — constructible (so downstream code can be sketched) but raise `NotImplementedError` on lower/enforce. Real formulation in progress.
- Added `&`/`|`/`~` operator overloads on `STLExpr` so STL specs can be composed with natural syntax. Operators are intentionally **not** added to `Constraint` to avoid colliding with `logic.py`'s hard-boolean `All`/`Any`/`Cond`.

## New surface

```python
import openscvx as ox

avoid  = ox.linalg.Norm(position - obs)    >= safety_radius
in_box = ox.linalg.Norm(position - center) <= box_radius

# Standalone — interval at construction, .over() seals into a CTCS
constraints.append(ox.stl.Always(avoid, (0, N - 1)).over())

# Nested composition with operator sugar
spec = (ox.stl.Always(avoid) & ox.stl.Always(in_box)) | ~stuck
constraints.append(spec.over((0, N - 1)))
```

> [!NOTE]
> Intervals currently live in exactly one place: on the operator or at `.over()`
> ```python
> Always(p, I).over(...)  # raises
> Always(p, I).at(...)    # raises
> ```
> This may change once we properly support intervals for the STL operators