### PR TITLE
Fix/examples test timing limits

### DIFF
--- a/tests/test_brachistochrone.py
+++ b/tests/test_brachistochrone.py
@@ -76,7 +76,7 @@ def _assert_brachistochrone_accuracy(comparison, problem, result):
         assert num_iters < 27, f"Took {num_iters} SCP iterations (expected < 15)"
 
     # Check timing - these are generous limits for a simple problem like brachistochrone
-    assert problem.timing_init < 12.0, (
+    assert problem.timing_init < 15.0, (
         f"Initialization took {problem.timing_init:.2f}s (expected < 12s)"
     )
     assert problem.timing_solve < 1.2, f"Solve took {problem.timing_solve:.2f}s (expected < 1.2s)"


### PR DESCRIPTION
- Increase initialization timing bound for brachistochrone tests from `12.0` to `15.0` -> Fixes #455 