### PR TITLE
Feature/optional solver time limit

### DIFF
--- a/openscvx/algorithms/__init__.py
+++ b/openscvx/algorithms/__init__.py
@@ -129,6 +129,7 @@ class PenalizedTrustRegionConfig(BaseModel):
         return v
 
     k_max: int = 200
+    t_max: Optional[float] = None
     lam_prox: Union[float, Dict[str, Any]] = 1e-1
     lam_vc: Union[float, Dict[str, Any]] = 1e0
     lam_cost: Union[float, Dict[str, Any]] = 1e-2

--- a/openscvx/algorithms/base.py
+++ b/openscvx/algorithms/base.py
@@ -718,6 +718,10 @@ class Algorithm(ABC):
     #: Maximum number of SCP iterations. Subclasses must set this in ``__init__``.
     k_max: int
 
+    #: Optional wall-clock time limit in seconds. ``None`` means no limit.
+    #: Subclasses must set this in ``__init__``.
+    t_max: Optional[float]
+
     @abstractmethod
     def initialize(
         self,

--- a/openscvx/algorithms/penalized_trust_region.py
+++ b/openscvx/algorithms/penalized_trust_region.py
@@ -87,6 +87,7 @@ class PenalizedTrustRegion(Algorithm):
         self,
         autotuner: "AutotuningBase" = None,
         k_max: int = 200,
+        t_max: float | None = None,
         lam_prox: Union[float, Dict[str, Union[float, list]]] = 1e-1,
         lam_vc: Union[float, Dict[str, Union[float, list]]] = 1e0,
         lam_cost: Union[float, Dict[str, float]] = 1e-2,
@@ -103,6 +104,8 @@ class PenalizedTrustRegion(Algorithm):
             autotuner: Weight adaptation strategy. Defaults to
                 :class:`AugmentedLagrangian` when ``None``.
             k_max: Maximum SCP iterations. Defaults to 200.
+            t_max: Wall-clock time limit in seconds. ``None`` (default)
+                disables the time limit.
             lam_prox: Trust region (proximal) weight. Either a float
                 (applied uniformly to all states and controls) or a dict
                 mapping state/control names to weights, e.g.
@@ -166,6 +169,7 @@ class PenalizedTrustRegion(Algorithm):
 
         # SCP convergence parameters
         self.k_max = k_max
+        self.t_max = t_max
         self.ep_tr = ep_tr
         self.ep_vb = ep_vb
         self.ep_vc = ep_vc

--- a/openscvx/problem.py
+++ b/openscvx/problem.py
@@ -972,12 +972,18 @@ class Problem:
         }
 
     def solve(
-        self, max_iters: Optional[int] = None, continuous: bool = False
+        self,
+        max_iters: Optional[int] = None,
+        time_limit: Optional[float] = None,
+        continuous: bool = False,
     ) -> OptimizationResults:
         """Run the SCP algorithm until convergence or iteration limit.
 
         Args:
             max_iters: Maximum iterations (default: algorithm.k_max)
+            time_limit: Wall-clock time limit in seconds. Overrides
+                ``algorithm.t_max`` when provided. ``None`` (default) falls
+                back to ``algorithm.t_max``.
             continuous: If True, run all iterations regardless of convergence
 
         Returns:
@@ -1007,10 +1013,13 @@ class Problem:
             printing.header(self._columns)
 
         k_max = max_iters if max_iters is not None else self._algorithm.k_max
+        t_max = time_limit if time_limit is not None else self._algorithm.t_max
 
         while self._state.k <= k_max:
             result = self.step()
             if result["converged"] and not continuous:
+                break
+            if t_max is not None and (time.time() - t_0_while) >= t_max:
                 break
 
         t_f_while = time.time()
@@ -1030,7 +1039,8 @@ class Problem:
         # Store solution state
         self._solution = copy.deepcopy(self._state)
 
-        return self._format_result(self._state, self._state.k <= k_max)
+        timed_out = t_max is not None and self.timing_solve >= t_max
+        return self._format_result(self._state, self._state.k <= k_max and not timed_out)
 
     def post_process(self) -> OptimizationResults:
         """Propagate solution through full nonlinear dynamics for high-fidelity trajectory.


### PR DESCRIPTION
- Add optional wall-clock time limit (`t_max`) for SCP solves, symmetrical to `k_max` -> Fixes #386
- Default is None (off) — no behavior change for existing users
- Configurable via algorithm dict, algorithm instance, or per-solve override
- Time is checked between iterations (never interrupts a subproblem mid-solve)
- Solve reports `converged=False` on timeout, same as hitting the iteration limit

```python
# Algorithm config (same pattern as k_max)
problem = Problem(..., algorithm={"k_max": 200, "t_max": 30.0})

# Per-solve override
result = problem.solve(time_limit=10.0)
```