### PR TITLE
Fix/cvxpygen sparsity conflict

### DIFF
--- a/openscvx/solvers/base.py
+++ b/openscvx/solvers/base.py
@@ -245,7 +245,14 @@ _SOLVER_MAP: Dict[str, type] = {}  # populated by __init__.py after all classes 
 
 
 class SolverSpec(BaseModel):
-    """Validates solver configuration from dict/YAML input."""
+    """Validates solver configuration from dict/YAML input.
+
+    !!! warning
+        Enabling ``cvxpygen`` currently disables sparse parameter declarations.
+        cvxpygen does not yet support the N-D sparsity indices used by
+        OpenSCvx's tiled parameters, so all parameters are created as dense
+        when code generation is active.
+    """
 
     type: Literal["PTRSolver"] = "PTRSolver"
     cvx_solver: str = "QOCO"

--- a/openscvx/solvers/ptr_solver.py
+++ b/openscvx/solvers/ptr_solver.py
@@ -234,6 +234,14 @@ class PTRSolver(ConvexSolver):
             B_d_sp = _tile_sparsity(B_d_pat, N - 1)
             C_d_sp = _tile_sparsity(C_d_pat, N - 1)
 
+        # TODO: (griffin-norris) Remove once cvxpygen supports N-D sparsity
+        # indices. cvxpygen's handle_sparsity() assumes 2-D (rows, cols) but
+        # our tiled parameters produce 3-D indices (slices, rows, cols).
+        # Dropping sparsity here is safe — it only affects codegen performance.
+        if self.cvxpygen:
+            A_d_sp = B_d_sp = C_d_sp = None
+            constraint_sparsity = None
+
         # Create all CVXPy variables for the OCP
         self._ocp_vars = create_cvxpy_variables(
             N=N,

--- a/openscvx/solvers/ptr_solver.py
+++ b/openscvx/solvers/ptr_solver.py
@@ -119,6 +119,14 @@ class PTRSolver(ConvexSolver):
             ``{"abstol": 1e-6, "reltol": 1e-9, "enforce_dpp": True}``.
         cvxpygen: Enable CVXPy code generation for faster solves.
             Defaults to ``False``.
+
+            !!! warning
+                Enabling cvxpygen currently disables sparse parameter
+                declarations. cvxpygen does not yet support the N-D sparsity
+                indices used by OpenSCvx's tiled parameters, so all parameters
+                are created as dense when code generation is active. This may
+                increase the generated solver's memory footprint and compile
+                time but does not affect solution correctness.
         cvxpygen_override: Overwrite existing generated solver directory
             without prompting. Defaults to ``False``.
 


### PR DESCRIPTION
- Turn off sparsity when `cvxpygen` is turned on -> Fixes #427
    - Cvxpygen does not support N-D sparsity indices
- Update docstrings to clearly warn about this
- Add `TODO` to remove the patch once `cvxpygen` is up to date