### PR TITLE
Chore/animated examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ solver/*
 # Images
 *.eps
 
+# Animation renders
+examples/animations/mp4/
+
 # Numpy files
 *.npy
 

--- a/examples/animations/7_dof_arm.py
+++ b/examples/animations/7_dof_arm.py
@@ -74,7 +74,7 @@ keypoint_home_positions = {
 }
 
 # --- Render settings ---------------------------------------------------------
-OUTPUT_PATH = os.path.join(current_dir, "7_dof_arm_overview.mp4")
+OUTPUT_PATH = os.path.join(current_dir, "mp4", "7_dof_arm_overview.mp4")
 WIDTH = 1080
 HEIGHT = 1080
 FPS = 60

--- a/examples/animations/7_dof_arm.py
+++ b/examples/animations/7_dof_arm.py
@@ -1,0 +1,216 @@
+"""Cinematic offline render of the 7-DOF arm pick-and-place example.
+
+The trajectory optimization problem itself lives in
+``examples/arm/7_dof_arm.py``; this file imports that ``problem`` and the
+robot parameters, solves it, builds a viser scene with arm links / joint
+frames / EE trail, and drives it frame-by-frame while piping raw RGB into
+ffmpeg to produce an mp4.
+
+Run it with::
+
+    python examples/animations/7_dof_arm.py
+
+The script prints a viser URL and waits. Open the URL in a browser — as soon
+as the client connects, the render begins. Requires ``ffmpeg`` on ``PATH``;
+``openscvx`` does not depend on it.
+
+Only one camera mode is provided — ``"overview"`` — a static elevated camera
+that frames the full pick-and-place workspace.
+
+Tweak ``OUTPUT_PATH`` / ``WIDTH`` / ``HEIGHT`` / ``FPS`` below for different
+output variants.
+"""
+
+import importlib
+import os
+import sys
+
+import numpy as np
+
+# Add the project root so `examples.*` imports resolve.
+current_dir = os.path.dirname(os.path.abspath(__file__))
+grandparent_dir = os.path.dirname(os.path.dirname(current_dir))
+sys.path.append(grandparent_dir)
+
+from examples.animations._camera import overview_pose
+from examples.animations._render import render_animation_to_video
+from examples.plotting_viser import AnimatedServerHandle
+from openscvx.plotting.viser import (
+    add_animated_trail,
+    add_ghost_trajectory,
+    add_position_marker,
+    add_target_markers,
+    compute_velocity_colors,
+    create_server,
+)
+
+# Import the arm example by path (filename starts with a digit).
+_arm_spec = importlib.util.spec_from_file_location(
+    "arm_7dof", os.path.join(grandparent_dir, "examples", "arm", "7_dof_arm.py")
+)
+_arm_mod = importlib.util.module_from_spec(_arm_spec)
+_arm_spec.loader.exec_module(_arm_mod)
+
+problem = _arm_mod.problem
+d1 = _arm_mod.d1
+a2 = _arm_mod.a2
+a3 = _arm_mod.a3
+a4 = _arm_mod.a4
+joint_names = _arm_mod.joint_names
+waypoint_names = _arm_mod.waypoint_names
+waypoint_positions = _arm_mod.waypoint_positions
+
+# Keypoint home positions (derived from link lengths — defined in __main__ of
+# the arm example, so we replicate them here).
+keypoint_home_positions = {
+    "base": np.array([0.0, 0.0, 0.0]),
+    "shoulder": np.array([0.0, 0.0, d1]),
+    "elbow": np.array([a2, 0.0, d1]),
+    "wrist": np.array([a2 + a3, 0.0, d1]),
+    "ee": np.array([a2 + a3 + a4, 0.0, d1]),
+}
+
+# --- Render settings ---------------------------------------------------------
+OUTPUT_PATH = os.path.join(current_dir, "7_dof_arm_overview.mp4")
+WIDTH = 1080
+HEIGHT = 1080
+FPS = 60
+CRF = 16
+
+# Oversampling for smooth trails.
+STRIDE = 4
+PROPAGATION_HZ = FPS * STRIDE
+
+# --- Camera settings ---------------------------------------------------------
+OVERVIEW_AZIMUTH = np.radians(20.0)
+OVERVIEW_ELEVATION = np.radians(15.0)
+OVERVIEW_RADIUS_MARGIN = 1.0
+OVERVIEW_FOV_DEG = 60.0
+
+
+if __name__ == "__main__":
+    import jaxlie
+
+    problem.settings.prp.dt = 1.0 / PROPAGATION_HZ
+    problem.initialize()
+    problem.solve()
+    results = problem.post_process()
+
+    ee_pos = np.asarray(results.trajectory["ee_position"], dtype=np.float64)
+    n_frames = len(ee_pos)
+
+    # -- Extract joint keypoint positions from propagated transforms -----------
+    keypoints = np.zeros((n_frames, 5, 3))
+    joint_quats = np.zeros((n_frames, 5, 4))
+    for k, name in enumerate(joint_names):
+        T_k = np.asarray(results.trajectory[f"T_{name}"])  # (T, 4, 4)
+        p_home = np.append(keypoint_home_positions[name], 1.0)
+        keypoints[:, k] = (T_k @ p_home)[:, :3]
+        joint_quats[:, k] = np.array(
+            [jaxlie.SO3.from_matrix(T_k[t, :3, :3]).wxyz for t in range(n_frames)]
+        )
+
+    # -- Build viser scene (mirrors examples/arm/7_dof_arm.py) -----------------
+    server = create_server(ee_pos, show_grid=False)
+    server.scene.add_grid("/grid", width=1.5, height=1.5, cell_size=0.25)
+    server.scene.add_frame("/origin", axes_length=0.1, axes_radius=0.003)
+
+    # Waypoint markers
+    marker_colors = {
+        "home": (100, 150, 255),
+        "pre_grasp": (255, 180, 50),
+        "grasp": (255, 50, 50),
+        "pre_place": (255, 180, 50),
+        "place": (255, 50, 50),
+    }
+    add_target_markers(
+        server,
+        waypoint_positions,
+        radius=0.015,
+        colors=[marker_colors[name] for name in waypoint_names],
+    )
+
+    # Ghost EE trajectory + animated trail
+    ee_colors = compute_velocity_colors(np.asarray(results.trajectory.get("velocity")))
+    add_ghost_trajectory(server, ee_pos, ee_colors, point_size=0.005)
+    _, update_trail = add_animated_trail(server, ee_pos, ee_colors, point_size=0.008)
+
+    # Animated EE position marker
+    _, update_marker = add_position_marker(server, ee_pos, radius=0.015)
+
+    # Animated arm links (line segments between consecutive keypoints)
+    link_rgb = np.array(
+        [
+            [180, 180, 180],  # base -> shoulder
+            [100, 180, 255],  # shoulder -> elbow
+            [100, 255, 150],  # elbow -> wrist
+            [255, 200, 100],  # wrist -> ee
+        ],
+        dtype=np.uint8,
+    )
+    link_colors = np.stack([link_rgb, link_rgb], axis=1)  # (4, 2, 3)
+
+    init_points = np.stack(
+        [np.stack([keypoints[0, k], keypoints[0, k + 1]]) for k in range(4)]
+    ).astype(np.float32)
+
+    arm_handle = server.scene.add_line_segments(
+        "/arm_links",
+        points=init_points,
+        colors=link_colors,
+        line_width=5.0,
+    )
+
+    # Joint coordinate frames
+    joint_frame_handles = []
+    for k in range(5):
+        h = server.scene.add_frame(
+            f"/joint_{joint_names[k]}",
+            wxyz=joint_quats[0, k].astype(np.float32),
+            position=keypoints[0, k].astype(np.float32),
+            axes_length=0.06,
+            axes_radius=0.002,
+        )
+        joint_frame_handles.append(h)
+
+    def update_arm(frame_idx: int) -> None:
+        pts = np.stack(
+            [np.stack([keypoints[frame_idx, k], keypoints[frame_idx, k + 1]]) for k in range(4)]
+        ).astype(np.float32)
+        arm_handle.points = pts
+        for k, h in enumerate(joint_frame_handles):
+            h.position = keypoints[frame_idx, k].astype(np.float32)
+            h.wxyz = joint_quats[frame_idx, k].astype(np.float32)
+
+    # -- Manual-step handle for the renderer -----------------------------------
+    traj_time = np.asarray(results.trajectory["time"], dtype=np.float64).flatten()
+    handle = AnimatedServerHandle(
+        server=server,
+        traj_time=traj_time,
+        update_callbacks=[update_trail, update_marker, update_arm],
+    )
+
+    # -- Camera: overview framing the full workspace ---------------------------
+    # Frame on waypoint positions + EE path so the full motion is visible.
+    all_points = np.vstack([ee_pos, np.array(waypoint_positions)])
+    static_pose = overview_pose(
+        all_points,
+        azimuth=OVERVIEW_AZIMUTH,
+        elevation=OVERVIEW_ELEVATION,
+        radius_margin=OVERVIEW_RADIUS_MARGIN,
+        fov_deg=OVERVIEW_FOV_DEG,
+    )
+
+    def camera_pose_fn(frame_idx: int):
+        return static_pose
+
+    render_animation_to_video(
+        handle,
+        OUTPUT_PATH,
+        camera_pose_fn,
+        width=WIDTH,
+        height=HEIGHT,
+        fps=FPS,
+        crf=CRF,
+        stride=STRIDE,
+    )

--- a/examples/animations/7_dof_arm.py
+++ b/examples/animations/7_dof_arm.py
@@ -47,7 +47,7 @@ from openscvx.plotting.viser import (
 
 # Import the arm example by path (filename starts with a digit).
 _arm_spec = importlib.util.spec_from_file_location(
-    "arm_7dof", os.path.join(grandparent_dir, "examples", "arm", "7_dof_arm.py")
+    "arm_7dof", os.path.join(grandparent_dir, "examples", "arm", "7_dof_arm_collision.py")
 )
 _arm_mod = importlib.util.module_from_spec(_arm_spec)
 _arm_spec.loader.exec_module(_arm_mod)

--- a/examples/animations/7_dof_arm.py
+++ b/examples/animations/7_dof_arm.py
@@ -37,6 +37,7 @@ from examples.animations._render import render_animation_to_video
 from examples.plotting_viser import AnimatedServerHandle
 from openscvx.plotting.viser import (
     add_animated_trail,
+    add_ellipsoid_obstacles,
     add_ghost_trajectory,
     add_position_marker,
     add_target_markers,
@@ -59,6 +60,8 @@ a4 = _arm_mod.a4
 joint_names = _arm_mod.joint_names
 waypoint_names = _arm_mod.waypoint_names
 waypoint_positions = _arm_mod.waypoint_positions
+obstacle_center = _arm_mod.obstacle_center
+obstacle_radius = _arm_mod.obstacle_radius
 
 # Keypoint home positions (derived from link lengths — defined in __main__ of
 # the arm example, so we replicate them here).
@@ -82,7 +85,7 @@ STRIDE = 4
 PROPAGATION_HZ = FPS * STRIDE
 
 # --- Camera settings ---------------------------------------------------------
-OVERVIEW_AZIMUTH = np.radians(20.0)
+OVERVIEW_AZIMUTH = np.radians(60.0)
 OVERVIEW_ELEVATION = np.radians(15.0)
 OVERVIEW_RADIUS_MARGIN = 1.0
 OVERVIEW_FOV_DEG = 60.0
@@ -128,6 +131,12 @@ if __name__ == "__main__":
         waypoint_positions,
         radius=0.015,
         colors=[marker_colors[name] for name in waypoint_names],
+    )
+
+    add_ellipsoid_obstacles(
+        server,
+        centers=[obstacle_center],
+        radii=[np.full(3, 1.0 / obstacle_radius)],
     )
 
     # Ghost EE trajectory + animated trail

--- a/examples/animations/_camera.py
+++ b/examples/animations/_camera.py
@@ -11,9 +11,7 @@ import numpy as np
 import viser.transforms as vtf
 
 
-def look_at_wxyz(
-    pos: np.ndarray, target: np.ndarray, up: np.ndarray
-) -> np.ndarray:
+def look_at_wxyz(pos: np.ndarray, target: np.ndarray, up: np.ndarray) -> np.ndarray:
     """Quaternion (w,x,y,z) for a camera at ``pos`` looking at ``target``.
 
     Uses the OpenCV camera convention that viser expects: +X right, +Y down,
@@ -82,11 +80,14 @@ def onboard_pose(
     """
     # R_body_to_world from the attitude quaternion (w, x, y, z)
     w, x, y, z = attitude_wxyz
-    R_bw = np.array([
-        [1 - 2*(y*y + z*z), 2*(x*y - z*w), 2*(x*z + y*w)],
-        [2*(x*y + z*w), 1 - 2*(x*x + z*z), 2*(y*z - x*w)],
-        [2*(x*z - y*w), 2*(y*z + x*w), 1 - 2*(x*x + y*y)],
-    ], dtype=np.float64)
+    R_bw = np.array(
+        [
+            [1 - 2 * (y * y + z * z), 2 * (x * y - z * w), 2 * (x * z + y * w)],
+            [2 * (x * y + z * w), 1 - 2 * (x * x + z * z), 2 * (y * z - x * w)],
+            [2 * (x * z - y * w), 2 * (y * z + x * w), 1 - 2 * (x * x + y * y)],
+        ],
+        dtype=np.float64,
+    )
 
     # Sensor-to-world: columns are the sensor axes in world coords.
     # R_sb is body-to-sensor, so R_sb.T is sensor-to-body.
@@ -129,11 +130,13 @@ def overview_pose(
     radius = max_extent / np.sin(half_fov_rad) * radius_margin
 
     cos_el = np.cos(elevation)
-    cam_pos = center + radius * np.array([
-        cos_el * np.cos(azimuth),
-        cos_el * np.sin(azimuth),
-        np.sin(elevation),
-    ])
+    cam_pos = center + radius * np.array(
+        [
+            cos_el * np.cos(azimuth),
+            cos_el * np.sin(azimuth),
+            np.sin(elevation),
+        ]
+    )
     look_at = center.copy()
     wxyz = look_at_wxyz(cam_pos, look_at, up)
     return cam_pos, wxyz, look_at

--- a/examples/animations/_camera.py
+++ b/examples/animations/_camera.py
@@ -1,0 +1,139 @@
+"""Reusable camera pose helpers for viser animation rendering.
+
+All functions return ``(cam_position, cam_wxyz, look_at)`` tuples suitable for
+passing to ``render_animation_to_video``'s ``camera_pose_fn`` argument. They
+depend only on numpy and ``viser.transforms`` — no openscvx imports.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import viser.transforms as vtf
+
+
+def look_at_wxyz(
+    pos: np.ndarray, target: np.ndarray, up: np.ndarray
+) -> np.ndarray:
+    """Quaternion (w,x,y,z) for a camera at ``pos`` looking at ``target``.
+
+    Uses the OpenCV camera convention that viser expects: +X right, +Y down,
+    +Z forward. See ``examples/animations/camera_control_notes.md``.
+    """
+    forward = target - pos
+    forward /= np.linalg.norm(forward)
+    right = np.cross(forward, up)
+    right_norm = np.linalg.norm(right)
+    if right_norm < 1e-6:
+        # Gimbal lock: forward is (nearly) parallel to up. Pick an arbitrary
+        # world axis that isn't, so the camera stays defined. The chosen axis
+        # determines the "roll" of the camera at the singularity — not great
+        # cinematically, but prevents a NaN crash.
+        fallback = np.array([1.0, 0.0, 0.0]) if abs(forward[0]) < 0.9 else np.array([0.0, 1.0, 0.0])
+        right = np.cross(forward, fallback)
+        right_norm = np.linalg.norm(right)
+    right /= right_norm
+    cam_down = np.cross(forward, right)  # = -world_up projected perp to forward
+    R_world_cam = np.stack([right, cam_down, forward], axis=1)
+    return vtf.SO3.from_matrix(R_world_cam).wxyz
+
+
+def chase_pose(
+    subject: np.ndarray,
+    focus: np.ndarray,
+    *,
+    chase_distance: float = 15.0,
+    vertical_offset: float = 2.0,
+    up=(0.0, 0.0, 1.0),
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return ``(cam_pos, cam_wxyz, look_at)`` for a chase camera behind ``subject``.
+
+    The camera sits on the ray from ``focus`` through ``subject``, extended
+    ``chase_distance`` units past the subject, then lifted along world up by
+    ``vertical_offset``. It always looks at ``focus``.
+    """
+    subject = np.asarray(subject, dtype=np.float64)
+    focus = np.asarray(focus, dtype=np.float64)
+    up = np.asarray(up, dtype=np.float64)
+
+    ray = subject - focus
+    ray_norm = np.linalg.norm(ray)
+    if ray_norm < 1e-6:
+        cam_pos = subject + vertical_offset * up
+    else:
+        cam_pos = subject + chase_distance * (ray / ray_norm) + vertical_offset * up
+
+    wxyz = look_at_wxyz(cam_pos, focus, up)
+    return cam_pos, wxyz, focus
+
+
+def onboard_pose(
+    position: np.ndarray,
+    attitude_wxyz: np.ndarray,
+    R_sb: np.ndarray,
+    *,
+    forward_offset: float = 0.0,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return ``(cam_pos, cam_wxyz, look_at)`` for a sensor-mounted FPV camera.
+
+    Places the camera at ``position`` (shifted slightly forward along the sensor
+    boresight by ``forward_offset``) with orientation matching the sensor frame —
+    i.e. looking along the sensor boresight (+Z in sensor frame, mapped through
+    ``R_sb`` and the body attitude to world coordinates).
+    """
+    # R_body_to_world from the attitude quaternion (w, x, y, z)
+    w, x, y, z = attitude_wxyz
+    R_bw = np.array([
+        [1 - 2*(y*y + z*z), 2*(x*y - z*w), 2*(x*z + y*w)],
+        [2*(x*y + z*w), 1 - 2*(x*x + z*z), 2*(y*z - x*w)],
+        [2*(x*z - y*w), 2*(y*z + x*w), 1 - 2*(x*x + y*y)],
+    ], dtype=np.float64)
+
+    # Sensor-to-world: columns are the sensor axes in world coords.
+    # R_sb is body-to-sensor, so R_sb.T is sensor-to-body.
+    R_sensor_to_world = R_bw @ R_sb.T
+
+    # Viser uses OpenCV convention (+X right, +Y DOWN, +Z forward).
+    # The sensor frame has +Y UP, so we rotate 180deg around the boresight (Z)
+    # to flip both X and Y, converting to the convention viser expects.
+    R_opencv_from_sensor = np.diag([-1.0, -1.0, 1.0])
+    R_cam_to_world = R_sensor_to_world @ R_opencv_from_sensor
+
+    wxyz = vtf.SO3.from_matrix(R_cam_to_world).wxyz
+    # Boresight is sensor +Z expressed in world frame (unchanged by the flip).
+    boresight_world = R_sensor_to_world[:, 2]
+    cam_pos = position + forward_offset * boresight_world
+    look_at = cam_pos + 10.0 * boresight_world
+    return cam_pos, wxyz, look_at
+
+
+def overview_pose(
+    positions: np.ndarray,
+    *,
+    azimuth: float = np.radians(135.0),
+    elevation: float = np.radians(25.0),
+    radius_margin: float = 0.75,
+    fov_deg: float = 60.0,
+    up=(0.0, 0.0, 1.0),
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return a static ``(cam_pos, cam_wxyz, look_at)`` that frames all ``positions``.
+
+    The camera is placed on a sphere around the centroid of ``positions``,
+    parameterized by ``azimuth`` (angle in XY from +X, CCW) and ``elevation``
+    (angle above the horizon). The radius is auto-computed so the full extent
+    fits within ``fov_deg``, then scaled by ``radius_margin``.
+    """
+    up = np.asarray(up, dtype=np.float64)
+    center = positions.mean(axis=0)
+    max_extent = np.max(np.linalg.norm(positions - center, axis=1))
+    half_fov_rad = np.radians(fov_deg / 2.0)
+    radius = max_extent / np.sin(half_fov_rad) * radius_margin
+
+    cos_el = np.cos(elevation)
+    cam_pos = center + radius * np.array([
+        cos_el * np.cos(azimuth),
+        cos_el * np.sin(azimuth),
+        np.sin(elevation),
+    ])
+    look_at = center.copy()
+    wxyz = look_at_wxyz(cam_pos, look_at, up)
+    return cam_pos, wxyz, look_at

--- a/examples/animations/_render.py
+++ b/examples/animations/_render.py
@@ -12,7 +12,7 @@ Typical usage (from an animation example):
     handle = create_animated_plotting_server(results, ..., controls="manual")
 
     def camera_pose_fn(frame_idx):
-        return polytope_follow_pose(positions[frame_idx], polytope_center)
+        return chase_pose(positions[frame_idx], target_center)
 
     render_animation_to_video(handle, "out.mp4", camera_pose_fn)
 

--- a/examples/animations/_render.py
+++ b/examples/animations/_render.py
@@ -84,6 +84,7 @@ def render_animation_to_video(
     settle_s: float = 0.0,
     client: viser.ClientHandle | None = None,
     progress_every: int = 30,
+    fov_deg: float | None = None,
 ) -> Path:
     """Render frames of ``handle`` to an H.264 mp4 by piping raw RGB into ffmpeg.
 
@@ -134,6 +135,8 @@ def render_animation_to_video(
             ``get_render``. Usually 0; bump if you see torn/partial frames.
         client: Pre-connected client. If ``None``, waits for one.
         progress_every: Print a progress line every N rendered frames.
+        fov_deg: If given, override the client camera's vertical field of view
+            (in degrees) before rendering. Useful for matching a sensor FOV.
 
     Returns:
         Absolute path to the written mp4.
@@ -159,6 +162,9 @@ def render_animation_to_video(
 
     if client is None:
         client = wait_for_client(handle.server)
+
+    if fov_deg is not None:
+        client.camera.fov = np.radians(fov_deg)
 
     n = handle.n_frames
     if end_frame is None:

--- a/examples/animations/_render.py
+++ b/examples/animations/_render.py
@@ -1,0 +1,243 @@
+"""Offline video rendering for animated viser examples.
+
+Pipes raw RGB frames from ``client.get_render()`` directly into ffmpeg over
+stdin, so there are no intermediate PNG files and no Python image library
+required. The only runtime dependency is ``ffmpeg`` on ``PATH``; ``openscvx``
+itself gains nothing from this module.
+
+Typical usage (from an animation example):
+
+.. code-block:: python
+
+    handle = create_animated_plotting_server(results, ..., controls="manual")
+
+    def camera_pose_fn(frame_idx):
+        return polytope_follow_pose(positions[frame_idx], polytope_center)
+
+    render_animation_to_video(handle, "out.mp4", camera_pose_fn)
+
+The render blocks on a viser client connection, so you run the script, wait
+for the "[render] waiting for a viser client..." line, open the printed viser
+URL in a browser, and the render starts automatically.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import Callable
+
+import numpy as np
+import viser
+
+from examples.plotting_viser import AnimatedServerHandle
+
+# frame_idx -> (camera_position, camera_wxyz, camera_look_at)
+CameraPoseFn = Callable[[int], tuple[np.ndarray, np.ndarray, np.ndarray]]
+
+
+def wait_for_client(
+    server: viser.ViserServer,
+    timeout_s: float = 300.0,
+    poll_interval_s: float = 0.25,
+) -> viser.ClientHandle:
+    """Block until at least one viser client connects; return the first one.
+
+    Prints a reminder so the user knows they need to open the printed viser
+    URL in a browser for the render to proceed.
+    """
+    print(
+        f"[render] waiting for a viser client to connect "
+        f"(open the viser URL above; timeout in {int(timeout_s)}s)..."
+    )
+    t0 = time.time()
+    while True:
+        clients = server.get_clients()
+        if clients:
+            client = next(iter(clients.values()))
+            print(f"[render] client connected.")
+            return client
+        if time.time() - t0 > timeout_s:
+            raise TimeoutError(
+                f"No viser client connected within {timeout_s:.0f}s. "
+                f"Open the viser URL in a browser to start the render."
+            )
+        time.sleep(poll_interval_s)
+
+
+def render_animation_to_video(
+    handle: AnimatedServerHandle,
+    output_path: str | Path,
+    camera_pose_fn: CameraPoseFn,
+    *,
+    width: int = 1280,
+    height: int = 720,
+    fps: int = 30,
+    crf: int = 16,
+    preset: str = "slow",
+    background_color: tuple[int, int, int] = (25, 25, 30),
+    start_frame: int = 0,
+    end_frame: int | None = None,
+    stride: int = 1,
+    settle_s: float = 0.0,
+    client: viser.ClientHandle | None = None,
+    progress_every: int = 30,
+) -> Path:
+    """Render frames of ``handle`` to an H.264 mp4 by piping raw RGB into ffmpeg.
+
+    Each frame is fetched with ``transport_format="png"`` so we get a *lossless*
+    RGBA array from the browser — no JPEG pre-compression stacked under the
+    final h.264 pass. The alpha channel is composited onto ``background_color``
+    in numpy before writing, which also lets us pick a dark scene background
+    (viser's ``configure_theme(dark_mode=True)`` only styles the GUI panels,
+    not the 3D canvas). Both the browser's live view and the rendered frames
+    see the same background because we also push ``background_color`` to
+    ``server.scene.set_background_image`` as a 1x1 solid color.
+
+    The video's playback rate (``fps``) is independent of how many frames the
+    trajectory contains — ``stride`` controls the frame range from the trajectory
+    that gets written. For realtime playback, pick ``fps`` so that
+    ``len(range(start_frame, end_frame, stride)) / fps`` matches the trajectory
+    duration. For slow-motion, raise ``fps`` relative to that; for time-lapse,
+    lower it.
+
+    Args:
+        handle: Handle returned by
+            ``create_animated_plotting_server(..., controls="manual")``.
+        output_path: Destination mp4 file. Parent dirs are created.
+        camera_pose_fn: ``frame_idx -> (position, wxyz, look_at)``. Called once
+            per rendered frame to position the camera.
+        width: Output video width in pixels.
+        height: Output video height in pixels.
+        fps: Output video frame rate.
+        crf: H.264 constant-rate factor; lower is higher quality. 16 is
+            visually near-lossless, 18 is high quality, 23 is ffmpeg's default.
+        preset: ffmpeg x264 preset (``ultrafast``..``veryslow``). ``slow`` gives
+            noticeably better quality/size than ``medium`` for static-heavy 3D
+            scenes at modest encode-time cost.
+        background_color: RGB tuple (0..255) for the scene background. Applied
+            both to viser's scene (so the live view matches) and as the
+            composite color for alpha channel in rendered frames.
+        start_frame: First trajectory frame index to render (inclusive).
+        end_frame: One past the last trajectory frame to render. ``None`` means
+            up to ``handle.n_frames``.
+        stride: Trajectory frame stride. ``stride=2`` renders every other
+            frame, halving the output length at fixed ``fps``.
+        settle_s: Optional sleep between pushing scene state and calling
+            ``get_render``. Usually 0; bump if you see torn/partial frames.
+        client: Pre-connected client. If ``None``, waits for one.
+        progress_every: Print a progress line every N rendered frames.
+
+    Returns:
+        Absolute path to the written mp4.
+    """
+    ffmpeg = shutil.which("ffmpeg")
+    if ffmpeg is None:
+        raise RuntimeError(
+            "ffmpeg not found on PATH. Install it locally (e.g. "
+            "`brew install ffmpeg` on macOS) — openscvx does not include it "
+            "as a package dependency."
+        )
+
+    output_path = Path(output_path).expanduser().resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Push the background color to viser so the live browser view matches the
+    # rendered output. `configure_theme(dark_mode=True)` only styles GUI panels;
+    # the 3D canvas clear color is controlled separately by set_background_image.
+    bg_rgb = np.asarray(background_color, dtype=np.uint8).reshape(1, 1, 3)
+    bg_image = np.broadcast_to(bg_rgb, (2, 2, 3)).copy()
+    handle.server.scene.set_background_image(bg_image, format="png")
+    bg_float = np.asarray(background_color, dtype=np.float32).reshape(1, 1, 3)
+
+    if client is None:
+        client = wait_for_client(handle.server)
+
+    n = handle.n_frames
+    if end_frame is None:
+        end_frame = n
+    frame_indices = list(range(start_frame, min(end_frame, n), max(stride, 1)))
+    if not frame_indices:
+        raise ValueError(
+            f"No frames to render: start_frame={start_frame}, "
+            f"end_frame={end_frame}, n_frames={n}, stride={stride}"
+        )
+
+    cmd = [
+        ffmpeg,
+        "-y",
+        "-f", "rawvideo",
+        "-vcodec", "rawvideo",
+        "-s", f"{width}x{height}",
+        "-pix_fmt", "rgb24",
+        "-r", str(fps),
+        "-i", "-",
+        "-c:v", "libx264",
+        "-pix_fmt", "yuv420p",
+        "-crf", str(crf),
+        "-preset", preset,
+        "-movflags", "+faststart",
+        str(output_path),
+    ]
+
+    print(
+        f"[render] {len(frame_indices)} frame(s) @ {fps} fps, "
+        f"{width}x{height} -> {output_path}"
+    )
+
+    proc = subprocess.Popen(cmd, stdin=subprocess.PIPE)
+    assert proc.stdin is not None
+
+    try:
+        t_render_start = time.time()
+        for out_i, frame_i in enumerate(frame_indices):
+            handle.step(frame_i)
+            pos, wxyz, look_at = camera_pose_fn(frame_i)
+            with client.atomic():
+                client.camera.position = pos
+                client.camera.wxyz = wxyz
+                client.camera.look_at = look_at
+            if settle_s > 0:
+                time.sleep(settle_s)
+            # PNG transport is lossless RGBA. JPEG would introduce a second
+            # compression pass on top of h.264 and visibly hurts quality.
+            img = client.get_render(height=height, width=width, transport_format="png")
+            if img.ndim != 3 or img.shape[0] != height or img.shape[1] != width:
+                raise RuntimeError(
+                    f"Unexpected get_render shape {img.shape}; "
+                    f"expected ({height}, {width}, 3 or 4)."
+                )
+            if img.dtype != np.uint8:
+                img = img.astype(np.uint8)
+            if img.shape[2] == 4:
+                # Composite RGBA onto the chosen background color. Empty scene
+                # pixels come back alpha=0 so they'd otherwise be undefined.
+                alpha = img[:, :, 3:4].astype(np.float32) * (1.0 / 255.0)
+                rgb = img[:, :, :3].astype(np.float32)
+                composed = rgb * alpha + bg_float * (1.0 - alpha)
+                img = composed.astype(np.uint8)
+            proc.stdin.write(img.tobytes())
+            if progress_every > 0 and (out_i + 1) % progress_every == 0:
+                elapsed = time.time() - t_render_start
+                done = out_i + 1
+                rate = done / max(elapsed, 1e-6)
+                eta = (len(frame_indices) - done) / max(rate, 1e-6)
+                print(
+                    f"[render]   frame {done}/{len(frame_indices)} "
+                    f"({rate:.1f} fps, eta {eta:.0f}s)"
+                )
+        proc.stdin.close()
+    except BrokenPipeError as e:
+        proc.wait()
+        raise RuntimeError(
+            "ffmpeg closed its input pipe unexpectedly. See ffmpeg stderr above."
+        ) from e
+
+    ret = proc.wait()
+    if ret != 0:
+        raise RuntimeError(f"ffmpeg exited with code {ret}")
+
+    print(f"[render] done: {output_path}")
+    return output_path

--- a/examples/animations/_render.py
+++ b/examples/animations/_render.py
@@ -57,7 +57,7 @@ def wait_for_client(
         clients = server.get_clients()
         if clients:
             client = next(iter(clients.values()))
-            print(f"[render] client connected.")
+            print("[render] client connected.")
             return client
         if time.time() - t0 > timeout_s:
             raise TimeoutError(
@@ -179,24 +179,32 @@ def render_animation_to_video(
     cmd = [
         ffmpeg,
         "-y",
-        "-f", "rawvideo",
-        "-vcodec", "rawvideo",
-        "-s", f"{width}x{height}",
-        "-pix_fmt", "rgb24",
-        "-r", str(fps),
-        "-i", "-",
-        "-c:v", "libx264",
-        "-pix_fmt", "yuv420p",
-        "-crf", str(crf),
-        "-preset", preset,
-        "-movflags", "+faststart",
+        "-f",
+        "rawvideo",
+        "-vcodec",
+        "rawvideo",
+        "-s",
+        f"{width}x{height}",
+        "-pix_fmt",
+        "rgb24",
+        "-r",
+        str(fps),
+        "-i",
+        "-",
+        "-c:v",
+        "libx264",
+        "-pix_fmt",
+        "yuv420p",
+        "-crf",
+        str(crf),
+        "-preset",
+        preset,
+        "-movflags",
+        "+faststart",
         str(output_path),
     ]
 
-    print(
-        f"[render] {len(frame_indices)} frame(s) @ {fps} fps, "
-        f"{width}x{height} -> {output_path}"
-    )
+    print(f"[render] {len(frame_indices)} frame(s) @ {fps} fps, {width}x{height} -> {output_path}")
 
     proc = subprocess.Popen(cmd, stdin=subprocess.PIPE)
     assert proc.stdin is not None
@@ -236,8 +244,7 @@ def render_animation_to_video(
                 rate = done / max(elapsed, 1e-6)
                 eta = (len(frame_indices) - done) / max(rate, 1e-6)
                 print(
-                    f"[render]   frame {done}/{len(frame_indices)} "
-                    f"({rate:.1f} fps, eta {eta:.0f}s)"
+                    f"[render]   frame {done}/{len(frame_indices)} ({rate:.1f} fps, eta {eta:.0f}s)"
                 )
         proc.stdin.close()
     except BrokenPipeError as e:

--- a/examples/animations/_render.py
+++ b/examples/animations/_render.py
@@ -77,7 +77,7 @@ def render_animation_to_video(
     fps: int = 30,
     crf: int = 16,
     preset: str = "slow",
-    background_color: tuple[int, int, int] = (25, 25, 30),
+    background_color: tuple[int, int, int] = (16, 17, 19),
     start_frame: int = 0,
     end_frame: int | None = None,
     stride: int = 1,
@@ -90,11 +90,16 @@ def render_animation_to_video(
     Each frame is fetched with ``transport_format="png"`` so we get a *lossless*
     RGBA array from the browser — no JPEG pre-compression stacked under the
     final h.264 pass. The alpha channel is composited onto ``background_color``
-    in numpy before writing, which also lets us pick a dark scene background
-    (viser's ``configure_theme(dark_mode=True)`` only styles the GUI panels,
-    not the 3D canvas). Both the browser's live view and the rendered frames
-    see the same background because we also push ``background_color`` to
-    ``server.scene.set_background_image`` as a 1x1 solid color.
+    in numpy before writing.
+
+    Why compositing is necessary: viser's dark mode puts the canvas over a
+    ``theme.colors.dark[9]`` (= ``#101113``) DOM element (see viser client
+    ``App.tsx:426``), and the browser compositor blends the scene over that
+    background at display time. But ``client.get_render`` returns only the
+    WebGL canvas pixels, which are transparent where nothing is drawn — so
+    we have to composite ourselves. The default ``background_color`` matches
+    Mantine's ``dark[9]`` exactly so the rendered frames are indistinguishable
+    from the live view.
 
     The video's playback rate (``fps``) is independent of how many frames the
     trajectory contains — ``stride`` controls the frame range from the trajectory

--- a/examples/animations/_sensor_view.py
+++ b/examples/animations/_sensor_view.py
@@ -1,0 +1,306 @@
+"""Offline mp4 render of the 2D camera animation panel.
+
+Mirrors ``_render.py`` for the viser 3D scene: iterates the *same* frame-index
+set (``range(start_frame, end_frame, stride)``) so the resulting mp4 is
+frame-perfectly aligned with the viser recording and can be composited with
+ffmpeg afterwards.
+
+Uses matplotlib's Agg canvas rather than plotly + kaleido so there's no
+headless-Chrome dependency — matplotlib is already a project dep. Raw RGB
+frames are piped straight into ``ffmpeg -f rawvideo`` (same pattern as
+``_render.py``), so there's no intermediate PNGs and no Python-side decode.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+import matplotlib
+import numpy as np
+
+# Agg = headless raster backend; required for server/CI rendering, and avoids
+# opening a GUI window during the frame loop.
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+from matplotlib.backends.backend_agg import FigureCanvasAgg  # noqa: E402
+from matplotlib.figure import Figure  # noqa: E402
+
+from examples.plotting import full_subject_traj_time  # noqa: E402
+
+# Default per-subject palette, cycled by index. Kept in sync with the viser
+# target-marker palette at ``openscvx/plotting/viser/animated.py:182-189`` so
+# that subject k in the camera panel is the same color as target k rendered
+# in the viser scene. If that palette ever changes, update this one too.
+VISER_SUBJECT_PALETTE: tuple[tuple[int, int, int], ...] = (
+    (255, 50, 50),    # Red
+    (50, 255, 50),    # Green
+    (50, 50, 255),    # Blue
+    (255, 255, 50),   # Yellow
+    (255, 50, 255),   # Magenta
+    (50, 255, 255),   # Cyan
+)
+
+
+def _cone_outline_xy(results, n_grid: int = 50) -> tuple[np.ndarray, np.ndarray]:
+    """Closed (X, Y) polyline for the red camera-frame outline.
+
+    Reproduces the math from ``plot_camera_animation`` exactly so this panel
+    matches the GUI version pixel-for-pixel (modulo renderer).
+    """
+    A = np.diag(
+        [
+            1 / np.tan(np.pi / results["alpha_y"]),
+            1 / np.tan(np.pi / results["alpha_x"]),
+        ]
+    )
+    range_limit = 10 if "moving_subject" in results else 80
+    norm = results["norm_type"]
+    ord_ = np.inf if norm == "inf" else norm
+
+    xs = np.linspace(-range_limit, range_limit, n_grid)
+    ys = np.linspace(-range_limit, range_limit, n_grid)
+    X, Y = np.meshgrid(xs, ys)
+    X, Y = X.flatten(), Y.flatten()
+    # Keep the original (x_val outer, y_val inner) ordering so the sort-by-arctan
+    # below produces the same outline as the existing GUI plot.
+    Z = np.array(
+        [np.linalg.norm(A @ np.array([x_val, y_val]), ord=ord_) for x_val in xs for y_val in ys]
+    )
+    X, Y = X / Z, Y / Z
+    order = np.argsort(np.arctan2(Y, X))
+    X, Y = X[order], Y[order]
+    X = np.append(X, X[0])
+    Y = np.append(Y, Y[0])
+    return X, Y
+
+
+def _project_subject(sub: np.ndarray) -> np.ndarray:
+    """Divide sensor-frame (x, y, z) by z so trajectories live on the image plane."""
+    out = np.asarray(sub, dtype=np.float64).copy()
+    if out.size == 0:
+        return out
+    out[:, 0] = out[:, 0] / out[:, 2]
+    out[:, 1] = out[:, 1] / out[:, 2]
+    return out
+
+
+def _rgb_from_0_255(color) -> tuple[float, float, float]:
+    """Convert either a 0..255 (r, g, b) tuple or a plotly ``"rgb(r, g, b)"``
+    string (what ``generate_subject_colors`` actually returns) to matplotlib 0..1.
+    """
+    if isinstance(color, str):
+        inner = color[color.index("(") + 1 : color.rindex(")")]
+        r, g, b = (int(v.strip()) for v in inner.split(","))
+    else:
+        r, g, b = color
+    return (r / 255.0, g / 255.0, b / 255.0)
+
+
+def render_camera_panel_to_video(
+    results,
+    output_path: str | Path,
+    *,
+    start_frame: int = 0,
+    end_frame: int | None = None,
+    stride: int = 1,
+    fps: int = 30,
+    width: int = 1080,
+    height: int = 1080,
+    crf: int = 16,
+    preset: str = "slow",
+    background_color: tuple[int, int, int] = (16, 17, 19),
+    cone_color: tuple[int, int, int] = (255, 100, 100),
+    subject_colors: tuple[tuple[int, int, int], ...] | None = None,
+    progress_every: int = 30,
+) -> Path:
+    """Render the 2D camera-frame animation to an mp4, aligned with ``_render.py``.
+
+    Iterates ``range(start_frame, min(end_frame, n), max(stride, 1))`` — pass the
+    *exact same* ``start_frame`` / ``end_frame`` / ``stride`` you pass to
+    :func:`render_animation_to_video` and the two mp4s will be the same length
+    with matched frame indices, ready to composite side-by-side with ffmpeg
+    (e.g. ``ffmpeg -i viser.mp4 -i camera.mp4 -filter_complex hstack=inputs=2 ...``).
+
+    Args:
+        results: Post-processed :class:`OptimizationResults` with ``init_poses``,
+            ``R_sb``, ``alpha_x``, ``alpha_y``, ``norm_type`` populated (i.e.,
+            after ``results.update(plotting_dict)``).
+        output_path: Destination mp4. Parent dirs are created.
+        start_frame, end_frame, stride: Frame-index range. Mirror whatever you
+            pass to ``render_animation_to_video`` for frame-perfect alignment.
+        fps: Output video frame rate. Match the viser-side ``fps``.
+        width, height: Output pixel dimensions.
+        crf, preset: x264 quality / speed knobs (see ``_render.py``).
+        background_color: RGB tuple applied to both the figure and axes
+            facecolors. Defaults to viser's Mantine ``dark[9]`` (#101113) so
+            side-by-side composites are visually seamless.
+        cone_color: RGB tuple for the camera-frame outline. Defaults to
+            ``(255, 100, 100)`` to match the viser viewcone ring color used
+            when ``viewcone_ring_only=True`` is passed to
+            ``create_animated_plotting_server``.
+        subject_colors: Palette cycled by subject index. Defaults to
+            :data:`VISER_SUBJECT_PALETTE` so each subject's trail color matches
+            the corresponding viser target-marker color.
+        progress_every: Print a progress line every N rendered frames.
+
+    Returns:
+        Absolute path to the written mp4.
+    """
+    ffmpeg = shutil.which("ffmpeg")
+    if ffmpeg is None:
+        raise RuntimeError(
+            "ffmpeg not found on PATH. Install it locally (e.g. `brew install ffmpeg`)."
+        )
+
+    output_path = Path(output_path).expanduser().resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # `full_subject_traj_time` currently ignores its `params` argument — passing
+    # None keeps this helper decoupled from the example's Config object.
+    _, subs_sen, _, subs_sen_node = full_subject_traj_time(results, None)
+    palette = subject_colors if subject_colors is not None else VISER_SUBJECT_PALETTE
+    colors = [palette[k % len(palette)] for k in range(len(subs_sen))]
+    cone_X, cone_Y = _cone_outline_xy(results)
+
+    # Pre-project every subject trajectory once — inside the loop we only slice.
+    subs_sen_proj = [_project_subject(s) for s in subs_sen]
+    subs_sen_node_proj = [_project_subject(s) for s in subs_sen_node]
+
+    # Node markers must appear when the *time* of the current propagation sample
+    # passes the node time, not when a sample-count ratio ticks over. The
+    # original `plot_camera_animation` uses the ratio form, which silently
+    # desyncs the markers from the continuous line whenever nodes aren't
+    # uniformly spaced in propagation-time (common with free-final-time or
+    # time-dilated problems).
+    t_full = np.asarray(results.trajectory["time"], dtype=np.float64).flatten()
+    t_nodes = np.asarray(results.nodes["time"], dtype=np.float64).flatten()
+
+    n = len(subs_sen_proj[0])
+    if end_frame is None:
+        end_frame = n
+    frame_indices = list(range(start_frame, min(end_frame, n), max(stride, 1)))
+    if not frame_indices:
+        raise ValueError(
+            f"No frames to render: start_frame={start_frame}, "
+            f"end_frame={end_frame}, n_samples={n}, stride={stride}"
+        )
+
+    bg_mpl = _rgb_from_0_255(background_color)
+
+    # Build figure once; we'll reuse it and just update line data each frame.
+    dpi = 100
+    fig = Figure(figsize=(width / dpi, height / dpi), dpi=dpi)
+    canvas = FigureCanvasAgg(fig)
+    fig.patch.set_facecolor(bg_mpl)
+    ax = fig.add_axes([0, 0, 1, 1])  # full-figure axes, zero margins
+    ax.set_facecolor(bg_mpl)
+    ax.set_xlim(-1.1, 1.1)
+    ax.set_ylim(-1.1, 1.1)
+    ax.set_aspect("equal")
+    ax.set_xticks([])
+    ax.set_yticks([])
+    for spine in ax.spines.values():
+        spine.set_visible(False)
+
+    # Static cone outline — default color matches the viser viewcone ring.
+    ax.plot(cone_X, cone_Y, color=_rgb_from_0_255(cone_color), linewidth=5.0, zorder=2)
+
+    # One Line2D + one scatter per subject — we mutate their data per frame
+    # instead of recreating artists (much cheaper than cla+replot).
+    line_artists = []
+    marker_artists = []
+    for sub_idx in range(len(subs_sen_proj)):
+        c = _rgb_from_0_255(colors[sub_idx])
+        (ln,) = ax.plot([], [], color=c, linewidth=3.0, zorder=3)
+        # Use ax.plot with marker-only for a single Line2D (scatter is slower).
+        (mk,) = ax.plot([], [], linestyle="none", marker="o", markersize=6.0, color=c, zorder=4)
+        line_artists.append(ln)
+        marker_artists.append(mk)
+
+    cmd = [
+        ffmpeg,
+        "-y",
+        "-f",
+        "rawvideo",
+        "-vcodec",
+        "rawvideo",
+        "-s",
+        f"{width}x{height}",
+        "-pix_fmt",
+        "rgb24",
+        "-r",
+        str(fps),
+        "-i",
+        "-",
+        "-c:v",
+        "libx264",
+        "-pix_fmt",
+        "yuv420p",
+        "-crf",
+        str(crf),
+        "-preset",
+        preset,
+        "-movflags",
+        "+faststart",
+        str(output_path),
+    ]
+
+    print(
+        f"[camera-panel] {len(frame_indices)} frame(s) @ {fps} fps, "
+        f"{width}x{height} -> {output_path}"
+    )
+    proc = subprocess.Popen(cmd, stdin=subprocess.PIPE)
+    assert proc.stdin is not None
+
+    try:
+        t_start = time.time()
+        for out_i, i in enumerate(frame_indices):
+            current_t = t_full[i]
+            # How many node times have we passed at this propagation sample?
+            # `side="right"` includes nodes whose time equals the current time.
+            n_nodes_visible = int(np.searchsorted(t_nodes, current_t, side="right"))
+            for sub_idx, (sub, sub_nodal) in enumerate(zip(subs_sen_proj, subs_sen_node_proj)):
+                line_artists[sub_idx].set_data(sub[: i + 1, 0], sub[: i + 1, 1])
+                node_slice = sub_nodal[: min(n_nodes_visible, sub_nodal.shape[0])]
+                if node_slice.size:
+                    marker_artists[sub_idx].set_data(node_slice[:, 0], node_slice[:, 1])
+                else:
+                    marker_artists[sub_idx].set_data([], [])
+
+            canvas.draw()
+            # buffer_rgba is (H, W, 4) uint8; drop alpha (figure has opaque bg).
+            rgba = np.asarray(canvas.buffer_rgba())
+            if rgba.shape[0] != height or rgba.shape[1] != width:
+                raise RuntimeError(
+                    f"Canvas returned {rgba.shape[:2]}, expected {(height, width)}. "
+                    f"Check dpi/figsize."
+                )
+            proc.stdin.write(rgba[..., :3].tobytes())
+
+            if progress_every > 0 and (out_i + 1) % progress_every == 0:
+                elapsed = time.time() - t_start
+                done = out_i + 1
+                rate = done / max(elapsed, 1e-6)
+                eta = (len(frame_indices) - done) / max(rate, 1e-6)
+                print(
+                    f"[camera-panel]   frame {done}/{len(frame_indices)} "
+                    f"({rate:.1f} fps, eta {eta:.0f}s)"
+                )
+        proc.stdin.close()
+    except BrokenPipeError as e:
+        proc.wait()
+        raise RuntimeError(
+            "ffmpeg closed its input pipe unexpectedly. See ffmpeg stderr above."
+        ) from e
+    finally:
+        plt.close(fig)
+
+    ret = proc.wait()
+    if ret != 0:
+        raise RuntimeError(f"ffmpeg exited with code {ret}")
+
+    print(f"[camera-panel] done: {output_path}")
+    return output_path

--- a/examples/animations/_sensor_view.py
+++ b/examples/animations/_sensor_view.py
@@ -35,12 +35,12 @@ from examples.plotting import full_subject_traj_time  # noqa: E402
 # that subject k in the camera panel is the same color as target k rendered
 # in the viser scene. If that palette ever changes, update this one too.
 VISER_SUBJECT_PALETTE: tuple[tuple[int, int, int], ...] = (
-    (255, 50, 50),    # Red
-    (50, 255, 50),    # Green
-    (50, 50, 255),    # Blue
-    (255, 255, 50),   # Yellow
-    (255, 50, 255),   # Magenta
-    (50, 255, 255),   # Cyan
+    (255, 50, 50),  # Red
+    (50, 255, 50),  # Green
+    (50, 50, 255),  # Blue
+    (255, 255, 50),  # Yellow
+    (255, 50, 255),  # Magenta
+    (50, 255, 255),  # Cyan
 )
 
 

--- a/examples/animations/dr_vp_polytope.py
+++ b/examples/animations/dr_vp_polytope.py
@@ -46,7 +46,7 @@ CAMERA_MODE = "chase"
 OUTPUT_PATH = os.path.join(current_dir, f"dr_vp_polytope_{CAMERA_MODE}.mp4")
 WIDTH = 1080
 HEIGHT = 1080
-FPS = 60
+FPS = 30
 CRF = 16  # lower = crisper; 16 is visually near-lossless
 
 # Oversampling factor for the propagation: how many trajectory samples we

--- a/examples/animations/dr_vp_polytope.py
+++ b/examples/animations/dr_vp_polytope.py
@@ -62,7 +62,7 @@ def orbit_camera(
     """Continuously orbit every connected client's camera around a fixed `center`.
 
     Useful for surveying a static scene (e.g. the polytope target cluster).
-    For a camera that follows the drone, see `drone_tracking_camera`.
+    For a camera that follows the drone, see `polytope_follow_camera`.
     """
     center = np.asarray(center, dtype=np.float64)
     up = np.asarray(up, dtype=np.float64)
@@ -80,42 +80,49 @@ def orbit_camera(
     threading.Thread(target=_loop, daemon=True).start()
 
 
-def drone_tracking_camera(
+def polytope_follow_camera(
     server,
     positions: np.ndarray,
     traj_time: np.ndarray,
-    radius: float = 8.0,
-    height: float = 3.0,
-    period_s: float = 8.0,
+    polytope_center: np.ndarray,
+    chase_distance: float = 15.0,
+    vertical_offset: float = 2.0,
     fps: int = 60,
     up=(0.0, 0.0, 1.0),
 ):
-    """Orbit the camera around the moving drone, keeping it centered in frame.
+    """Chase camera that rides behind the drone and frames the polytope targets.
 
-    The camera laps the drone every `period_s` seconds (constant angular speed
-    in the drone's frame — cinematic regardless of how fast the drone moves).
+    At each frame the camera sits on the ray from `polytope_center` through the
+    drone, extended `chase_distance` units past the drone, then lifted by
+    `vertical_offset` along world-up so the drone isn't a single-pixel occlusion
+    of the targets. The camera always looks at `polytope_center`, so the viewer
+    sees the drone silhouetted against the target cluster — which is exactly
+    the geometry the viewplanning constraint is enforcing (the drone's sensor
+    boresight points along `drone -> polytope_center`).
 
-    The function runs on its own wall-clock loop synchronized to the
-    trajectory's realtime duration `(traj_time[-1] - traj_time[0])`. The
-    trajectory animation server (`create_animated_plotting_server`) uses an
-    independent realtime clock too — they stay in lock-step as long as the
-    Animation panel's "Speed" slider is left at 1.0× and playback isn't
-    paused or scrubbed. If they drift, restart playback from the beginning
-    to re-sync.
+    Because the camera pose is a pure function of the drone's position, there
+    is no independent clock and no drift concern: the camera is wherever the
+    drone is, period. If playback is paused or scrubbed in the Animation panel,
+    the camera simply stops moving along with the scene.
 
     Args:
         server: The viser server returned by `create_animated_plotting_server`.
         positions: (N, 3) drone position trajectory in world coordinates.
         traj_time: (N,) timestamps matching `positions`, monotonically increasing.
-        radius: Horizontal orbit radius around the drone (world units).
-        height: Vertical offset of the camera above the drone (world units).
-        period_s: Seconds per full camera revolution around the drone.
+        polytope_center: (3,) world-coordinate center of the viewplanning polytope.
+        chase_distance: How far past the drone (along the polytope->drone ray)
+            to place the camera. Larger values = wider shot.
+        vertical_offset: World-up offset added to the camera position so the
+            drone is framed above/below the polytope center rather than directly
+            in front of it.
         fps: Camera update rate.
         up: World up direction (default z-up).
     """
     positions = np.asarray(positions, dtype=np.float64)
     traj_time = np.asarray(traj_time, dtype=np.float64).flatten()
+    polytope_center = np.asarray(polytope_center, dtype=np.float64)
     up = np.asarray(up, dtype=np.float64)
+    lift = vertical_offset * up
 
     t_start = float(traj_time[0])
     t_end = float(traj_time[-1])
@@ -130,15 +137,25 @@ def drone_tracking_camera(
     def _loop():
         t0 = _time.time()
         while True:
-            wall = (_time.time() - t0) % duration
-            sim_t = t_start + wall
-            theta = 2 * np.pi * (wall / period_s)
+            sim_t = t_start + ((_time.time() - t0) % duration)
+            drone = drone_at(sim_t)
 
-            target = drone_at(sim_t)
-            pos = target + np.array(
-                [radius * np.cos(theta), radius * np.sin(theta), height]
+            ray = drone - polytope_center
+            ray_norm = np.linalg.norm(ray)
+            # Degenerate case: drone exactly at polytope center. Shouldn't
+            # happen for a viewplanning trajectory, but guard anyway.
+            if ray_norm < 1e-6:
+                _time.sleep(1.0 / fps)
+                continue
+            ray_hat = ray / ray_norm
+
+            cam_pos = drone + chase_distance * ray_hat + lift
+            _set_camera(
+                server,
+                cam_pos,
+                _look_at_wxyz(cam_pos, polytope_center, up),
+                polytope_center,
             )
-            _set_camera(server, pos, _look_at_wxyz(pos, target, up), target)
             _time.sleep(1.0 / fps)
 
     threading.Thread(target=_loop, daemon=True).start()
@@ -164,14 +181,18 @@ if __name__ == "__main__":
         frame_duration_ms=200,
     )
 
-    # Cinematic orbit around the polytope target cluster.
-    # orbit_camera(traj_server)
+    # Center of the viewplanning polytope (mean of its vertices).
+    polytope_center = np.asarray(results["init_poses"]).mean(axis=0)
 
-    # Camera that orbits the drone, keeping it centered in frame.
-    drone_tracking_camera(
+    # Cinematic orbit around the polytope target cluster.
+    # orbit_camera(traj_server, center=tuple(polytope_center))
+
+    # Chase camera that rides behind the drone and frames the polytope.
+    polytope_follow_camera(
         traj_server,
         results.trajectory["position"],
         results.trajectory["time"],
+        polytope_center=polytope_center,
     )
 
     # Keep both servers running

--- a/examples/animations/dr_vp_polytope.py
+++ b/examples/animations/dr_vp_polytope.py
@@ -112,24 +112,33 @@ if __name__ == "__main__":
     # Select camera pose function based on mode.
     render_fov: float | None = None
     if CAMERA_MODE == "chase":
+
         def camera_pose_fn(frame_idx: int):
             return chase_pose(
-                positions[frame_idx], polytope_center,
-                chase_distance=CHASE_DISTANCE, vertical_offset=VERTICAL_OFFSET,
+                positions[frame_idx],
+                polytope_center,
+                chase_distance=CHASE_DISTANCE,
+                vertical_offset=VERTICAL_OFFSET,
             )
     elif CAMERA_MODE == "onboard":
         render_fov = sensor_fov_deg + ONBOARD_FOV_PADDING
+
         def camera_pose_fn(frame_idx: int):
             return onboard_pose(
-                positions[frame_idx], attitude[frame_idx], R_sb,
+                positions[frame_idx],
+                attitude[frame_idx],
+                R_sb,
                 forward_offset=ONBOARD_FORWARD_OFFSET,
             )
     elif CAMERA_MODE == "overview":
         static_pose = overview_pose(
             positions,
-            azimuth=OVERVIEW_AZIMUTH, elevation=OVERVIEW_ELEVATION,
-            radius_margin=OVERVIEW_RADIUS_MARGIN, fov_deg=OVERVIEW_FOV_DEG,
+            azimuth=OVERVIEW_AZIMUTH,
+            elevation=OVERVIEW_ELEVATION,
+            radius_margin=OVERVIEW_RADIUS_MARGIN,
+            fov_deg=OVERVIEW_FOV_DEG,
         )
+
         def camera_pose_fn(frame_idx: int):
             return static_pose
     else:

--- a/examples/animations/dr_vp_polytope.py
+++ b/examples/animations/dr_vp_polytope.py
@@ -35,6 +35,7 @@ grandparent_dir = os.path.dirname(os.path.dirname(current_dir))
 sys.path.append(grandparent_dir)
 
 from examples.animations._camera import chase_pose, onboard_pose, overview_pose
+from examples.animations._sensor_view import render_camera_panel_to_video
 from examples.animations._render import render_animation_to_video
 from examples.drone.dr_vp_polytope import plotting_dict, problem
 from examples.plotting_viser import create_animated_plotting_server
@@ -42,8 +43,14 @@ from examples.plotting_viser import create_animated_plotting_server
 # Camera mode: "chase" | "onboard" | "overview"
 CAMERA_MODE = "chase"
 
+# Also render the 2D plotly camera panel as a separate mp4 using the exact
+# same frame-index set as the viser render, so they can be composited together
+# (e.g. `ffmpeg -i viser.mp4 -i camera.mp4 -filter_complex hstack=inputs=2`).
+RENDER_CAMERA_PANEL = True
+
 # --- Render settings ---------------------------------------------------------
 OUTPUT_PATH = os.path.join(current_dir, f"dr_vp_polytope_{CAMERA_MODE}.mp4")
+CAMERA_PANEL_PATH = os.path.join(current_dir, "dr_vp_polytope_camera.mp4")
 WIDTH = 1080
 HEIGHT = 1080
 FPS = 30
@@ -155,3 +162,19 @@ if __name__ == "__main__":
         stride=STRIDE,
         fov_deg=render_fov,
     )
+
+    if RENDER_CAMERA_PANEL:
+        # Same start_frame / end_frame / stride / fps as the viser render above,
+        # so frame index i in the panel mp4 corresponds to frame i in the viser
+        # mp4 — safe to composite without resampling.
+        render_camera_panel_to_video(
+            results,
+            CAMERA_PANEL_PATH,
+            start_frame=0,
+            end_frame=None,
+            stride=STRIDE,
+            fps=FPS,
+            width=HEIGHT,  # square panel matches viser output aspect
+            height=HEIGHT,
+            crf=CRF,
+        )

--- a/examples/animations/dr_vp_polytope.py
+++ b/examples/animations/dr_vp_polytope.py
@@ -26,6 +26,30 @@ from examples.plotting_viser import (
 )
 
 
+def _look_at_wxyz(pos: np.ndarray, target: np.ndarray, up: np.ndarray) -> np.ndarray:
+    """Quaternion (w,x,y,z) for a camera at `pos` looking at `target`.
+
+    Uses the OpenCV camera convention that viser expects: +X right, +Y down,
+    +Z forward. See `examples/animations/camera_control_notes.md`.
+    """
+    forward = target - pos
+    forward /= np.linalg.norm(forward)
+    right = np.cross(forward, up)
+    right /= np.linalg.norm(right)
+    cam_down = np.cross(forward, right)  # = -world_up projected perp to forward
+    R_world_cam = np.stack([right, cam_down, forward], axis=1)
+    return vtf.SO3.from_matrix(R_world_cam).wxyz
+
+
+def _set_camera(server, pos: np.ndarray, wxyz: np.ndarray, look_at: np.ndarray) -> None:
+    """Atomically push a camera pose to every connected client."""
+    for _, client in server.get_clients().items():
+        with client.atomic():
+            client.camera.position = pos
+            client.camera.wxyz = wxyz
+            client.camera.look_at = look_at
+
+
 def orbit_camera(
     server,
     center=(100.0, -50.0, 20.0),
@@ -35,11 +59,10 @@ def orbit_camera(
     fps=60,
     up=(0.0, 0.0, 1.0),
 ):
-    """Continuously orbit every connected client's camera around `center`.
+    """Continuously orbit every connected client's camera around a fixed `center`.
 
-    See `examples/animations/camera_control_notes.md` for the underlying
-    viser API and the rationale for setting both `position` and `wxyz`
-    atomically (assigning `look_at` alone does not reorient the camera).
+    Useful for surveying a static scene (e.g. the polytope target cluster).
+    For a camera that follows the drone, see `drone_tracking_camera`.
     """
     center = np.asarray(center, dtype=np.float64)
     up = np.asarray(up, dtype=np.float64)
@@ -51,22 +74,71 @@ def orbit_camera(
             pos = center + np.array(
                 [radius * np.cos(theta), radius * np.sin(theta), height]
             )
+            _set_camera(server, pos, _look_at_wxyz(pos, center, up), center)
+            _time.sleep(1.0 / fps)
 
-            # viser uses the OpenCV camera convention: +X right, +Y down,
-            # +Z forward (toward the look target).
-            forward = center - pos
-            forward /= np.linalg.norm(forward)
-            right = np.cross(forward, up)
-            right /= np.linalg.norm(right)
-            cam_down = np.cross(forward, right)  # = -world_up projected perp to forward
-            R_world_cam = np.stack([right, cam_down, forward], axis=1)
-            wxyz = vtf.SO3.from_matrix(R_world_cam).wxyz
+    threading.Thread(target=_loop, daemon=True).start()
 
-            for _, client in server.get_clients().items():
-                with client.atomic():
-                    client.camera.position = pos
-                    client.camera.wxyz = wxyz
-                    client.camera.look_at = center
+
+def drone_tracking_camera(
+    server,
+    positions: np.ndarray,
+    traj_time: np.ndarray,
+    radius: float = 8.0,
+    height: float = 3.0,
+    period_s: float = 8.0,
+    fps: int = 60,
+    up=(0.0, 0.0, 1.0),
+):
+    """Orbit the camera around the moving drone, keeping it centered in frame.
+
+    The camera laps the drone every `period_s` seconds (constant angular speed
+    in the drone's frame — cinematic regardless of how fast the drone moves).
+
+    The function runs on its own wall-clock loop synchronized to the
+    trajectory's realtime duration `(traj_time[-1] - traj_time[0])`. The
+    trajectory animation server (`create_animated_plotting_server`) uses an
+    independent realtime clock too — they stay in lock-step as long as the
+    Animation panel's "Speed" slider is left at 1.0× and playback isn't
+    paused or scrubbed. If they drift, restart playback from the beginning
+    to re-sync.
+
+    Args:
+        server: The viser server returned by `create_animated_plotting_server`.
+        positions: (N, 3) drone position trajectory in world coordinates.
+        traj_time: (N,) timestamps matching `positions`, monotonically increasing.
+        radius: Horizontal orbit radius around the drone (world units).
+        height: Vertical offset of the camera above the drone (world units).
+        period_s: Seconds per full camera revolution around the drone.
+        fps: Camera update rate.
+        up: World up direction (default z-up).
+    """
+    positions = np.asarray(positions, dtype=np.float64)
+    traj_time = np.asarray(traj_time, dtype=np.float64).flatten()
+    up = np.asarray(up, dtype=np.float64)
+
+    t_start = float(traj_time[0])
+    t_end = float(traj_time[-1])
+    duration = t_end - t_start
+
+    def drone_at(sim_t: float) -> np.ndarray:
+        """Linearly interpolate the drone position at simulation time `sim_t`."""
+        return np.array(
+            [np.interp(sim_t, traj_time, positions[:, k]) for k in range(3)]
+        )
+
+    def _loop():
+        t0 = _time.time()
+        while True:
+            wall = (_time.time() - t0) % duration
+            sim_t = t_start + wall
+            theta = 2 * np.pi * (wall / period_s)
+
+            target = drone_at(sim_t)
+            pos = target + np.array(
+                [radius * np.cos(theta), radius * np.sin(theta), height]
+            )
+            _set_camera(server, pos, _look_at_wxyz(pos, target, up), target)
             _time.sleep(1.0 / fps)
 
     threading.Thread(target=_loop, daemon=True).start()
@@ -93,7 +165,14 @@ if __name__ == "__main__":
     )
 
     # Cinematic orbit around the polytope target cluster.
-    orbit_camera(traj_server)
+    # orbit_camera(traj_server)
+
+    # Camera that orbits the drone, keeping it centered in frame.
+    drone_tracking_camera(
+        traj_server,
+        results.trajectory["position"],
+        results.trajectory["time"],
+    )
 
     # Keep both servers running
     traj_server.sleep_forever()

--- a/examples/animations/dr_vp_polytope.py
+++ b/examples/animations/dr_vp_polytope.py
@@ -14,6 +14,12 @@ The script prints a viser URL and waits. Open the URL in a browser — as soon
 as the client connects, the render begins. Requires ``ffmpeg`` on ``PATH``;
 ``openscvx`` does not depend on it.
 
+Three camera modes are available — set ``CAMERA_MODE`` below:
+
+- ``"chase"``   — over-the-shoulder behind the drone, looking at the polytope.
+- ``"onboard"`` — rigidly mounted to the drone's sensor frame (FPV view).
+- ``"overview"`` — static elevated camera framing the full track.
+
 Tweak ``OUTPUT_PATH`` / ``WIDTH`` / ``HEIGHT`` / ``FPS`` below for different
 output variants.
 """
@@ -33,8 +39,11 @@ from examples.animations._render import render_animation_to_video
 from examples.drone.dr_vp_polytope import plotting_dict, problem
 from examples.plotting_viser import create_animated_plotting_server
 
+# Camera mode: "chase" | "onboard" | "overview"
+CAMERA_MODE = "chase"
+
 # --- Render settings ---------------------------------------------------------
-OUTPUT_PATH = os.path.join(current_dir, "dr_vp_polytope.mp4")
+OUTPUT_PATH = os.path.join(current_dir, f"dr_vp_polytope_{CAMERA_MODE}.mp4")
 WIDTH = 1080
 HEIGHT = 1080
 FPS = 60
@@ -50,8 +59,20 @@ STRIDE = 6
 PROPAGATION_HZ = FPS * STRIDE
 
 # --- Camera settings ---------------------------------------------------------
+# Chase mode
 CHASE_DISTANCE = 15.0  # camera sits this far past the drone along polytope->drone ray
 VERTICAL_OFFSET = 2.0  # lift so the drone isn't a 1-pixel occlusion of the polytope
+
+# Onboard mode
+ONBOARD_FORWARD_OFFSET = 0.0  # shift camera forward along boresight to clear body-frame axes
+
+# Overview mode — spherical coordinates from the trajectory centroid.
+# Azimuth: angle in the XY plane from +X, CCW (radians).
+# Elevation: angle above the horizon (radians). pi/2 = straight down.
+OVERVIEW_AZIMUTH = np.radians(135.0)
+OVERVIEW_ELEVATION = np.radians(25.0)
+OVERVIEW_RADIUS_MARGIN = 0.75  # multiplier on the auto-computed radius
+OVERVIEW_FOV_DEG = 60.0
 
 
 def _look_at_wxyz(pos: np.ndarray, target: np.ndarray, up: np.ndarray) -> np.ndarray:
@@ -115,6 +136,84 @@ def polytope_follow_pose(
     return cam_pos, wxyz, polytope_center
 
 
+def onboard_pose(
+    drone: np.ndarray,
+    attitude_wxyz: np.ndarray,
+    R_sb: np.ndarray,
+    *,
+    forward_offset: float = ONBOARD_FORWARD_OFFSET,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return ``(cam_pos, cam_wxyz, look_at)`` for a sensor-mounted FPV camera.
+
+    Places the camera at the drone's position (shifted slightly forward along
+    the sensor boresight to avoid being occluded by the body-frame coordinate
+    axes) with orientation matching the sensor frame — i.e. looking along the
+    sensor boresight (+Z in sensor frame, mapped through R_sb and the body
+    attitude to world coordinates). This is exactly what the viewplanning
+    constraint keeps pointed at the target polytope.
+    """
+    # R_body_to_world from the attitude quaternion (w, x, y, z)
+    w, x, y, z = attitude_wxyz
+    R_bw = np.array([
+        [1 - 2*(y*y + z*z), 2*(x*y - z*w), 2*(x*z + y*w)],
+        [2*(x*y + z*w), 1 - 2*(x*x + z*z), 2*(y*z - x*w)],
+        [2*(x*z - y*w), 2*(y*z + x*w), 1 - 2*(x*x + y*y)],
+    ], dtype=np.float64)
+
+    # Sensor-to-world: columns are the sensor axes in world coords.
+    # R_sb is body-to-sensor, so R_sb.T is sensor-to-body.
+    R_sensor_to_world = R_bw @ R_sb.T
+
+    # Viser uses OpenCV convention (+X right, +Y DOWN, +Z forward).
+    # The sensor frame has +Y UP, so we rotate 180° around the boresight (Z)
+    # to flip both X and Y, converting to the convention viser expects.
+    R_opencv_from_sensor = np.diag([-1.0, -1.0, 1.0])
+    R_cam_to_world = R_sensor_to_world @ R_opencv_from_sensor
+
+    wxyz = vtf.SO3.from_matrix(R_cam_to_world).wxyz
+    # Boresight is sensor +Z expressed in world frame (unchanged by the flip).
+    boresight_world = R_sensor_to_world[:, 2]
+    cam_pos = drone + forward_offset * boresight_world
+    look_at = cam_pos + 10.0 * boresight_world
+    return cam_pos, wxyz, look_at
+
+
+def overview_pose(
+    positions: np.ndarray,
+    *,
+    azimuth: float = OVERVIEW_AZIMUTH,
+    elevation: float = OVERVIEW_ELEVATION,
+    radius_margin: float = OVERVIEW_RADIUS_MARGIN,
+    fov_deg: float = OVERVIEW_FOV_DEG,
+    up=(0.0, 0.0, 1.0),
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return a static ``(cam_pos, cam_wxyz, look_at)`` that frames the full track.
+
+    The camera is placed at a point on a sphere around the trajectory centroid,
+    parameterized by ``azimuth`` (angle in XY from +X, CCW) and ``elevation``
+    (angle above the horizon). The radius is auto-computed so the full
+    trajectory fits within ``fov_deg``, then scaled by ``radius_margin``.
+    """
+    up = np.asarray(up, dtype=np.float64)
+    center = positions.mean(axis=0)
+    # Max distance from centroid to any trajectory point (3D).
+    max_extent = np.max(np.linalg.norm(positions - center, axis=1))
+    # Radius so the full extent subtends half the FOV.
+    half_fov_rad = np.radians(fov_deg / 2.0)
+    radius = max_extent / np.sin(half_fov_rad) * radius_margin
+
+    # Spherical -> Cartesian offset from centroid.
+    cos_el = np.cos(elevation)
+    cam_pos = center + radius * np.array([
+        cos_el * np.cos(azimuth),
+        cos_el * np.sin(azimuth),
+        np.sin(elevation),
+    ])
+    look_at = center.copy()
+    wxyz = _look_at_wxyz(cam_pos, look_at, up)
+    return cam_pos, wxyz, look_at
+
+
 if __name__ == "__main__":
     problem.settings.prp.dt = 1.0 / PROPAGATION_HZ
     problem.initialize()
@@ -125,6 +224,8 @@ if __name__ == "__main__":
     # Center of the viewplanning polytope (mean of its vertices).
     polytope_center = np.asarray(results["init_poses"]).mean(axis=0)
     positions = np.asarray(results.trajectory["position"], dtype=np.float64)
+    attitude = np.asarray(results.trajectory["attitude"], dtype=np.float64)
+    R_sb = np.asarray(results["R_sb"], dtype=np.float64)
 
     # Build the scene in manual-step mode — no GUI playback loop, no wall-clock
     # thread; we'll drive every frame ourselves from the render loop.
@@ -140,8 +241,27 @@ if __name__ == "__main__":
         viewcone_ring_only=True,
     )
 
-    def camera_pose_fn(frame_idx: int):
-        return polytope_follow_pose(positions[frame_idx], polytope_center)
+    # Sensor FOV derived from the viewplanning cone half-angle parameter.
+    # alpha_x defines the half-angle as pi/alpha_x radians; full vertical FOV
+    # is 2 * pi/alpha_x converted to degrees.
+    alpha_x = results.get("alpha_x")
+    sensor_fov_deg = float(np.degrees(2 * np.pi / alpha_x)) if alpha_x is not None else None
+
+    # Select camera pose function based on mode.
+    render_fov: float | None = None
+    if CAMERA_MODE == "chase":
+        def camera_pose_fn(frame_idx: int):
+            return polytope_follow_pose(positions[frame_idx], polytope_center)
+    elif CAMERA_MODE == "onboard":
+        render_fov = sensor_fov_deg + 5
+        def camera_pose_fn(frame_idx: int):
+            return onboard_pose(positions[frame_idx], attitude[frame_idx], R_sb)
+    elif CAMERA_MODE == "overview":
+        static_pose = overview_pose(positions)
+        def camera_pose_fn(frame_idx: int):
+            return static_pose
+    else:
+        raise ValueError(f"Unknown CAMERA_MODE: {CAMERA_MODE!r}")
 
     render_animation_to_video(
         handle,
@@ -152,4 +272,5 @@ if __name__ == "__main__":
         fps=FPS,
         crf=CRF,
         stride=STRIDE,
+        fov_deg=render_fov,
     )

--- a/examples/animations/dr_vp_polytope.py
+++ b/examples/animations/dr_vp_polytope.py
@@ -1,15 +1,25 @@
-"""Cinematic animation of the drone-racing-with-polytope-viewplanning example.
+"""Cinematic offline render of the drone-racing-with-polytope-viewplanning example.
 
 The trajectory optimization problem itself lives in
-`examples/drone/dr_vp_polytope.py`; this file imports that `problem` (and the
-associated `plotting_dict`), solves it, and then drives a viser scene with a
-cinematic camera orbit suitable for landing-page / presentation captures.
+``examples/drone/dr_vp_polytope.py``; this file imports that ``problem`` (and
+the associated ``plotting_dict``), solves it, and drives a viser scene
+frame-by-frame while piping raw RGB into ffmpeg to produce an mp4 suitable for
+landing-page / presentation captures.
+
+Run it with::
+
+    python examples/animations/dr_vp_polytope.py
+
+The script prints a viser URL and waits. Open the URL in a browser — as soon
+as the client connects, the render begins. Requires ``ffmpeg`` on ``PATH``;
+``openscvx`` does not depend on it.
+
+Tweak ``OUTPUT_PATH`` / ``WIDTH`` / ``HEIGHT`` / ``FPS`` below for different
+output variants.
 """
 
 import os
 import sys
-import threading
-import time as _time
 
 import numpy as np
 import viser.transforms as vtf
@@ -19,146 +29,82 @@ current_dir = os.path.dirname(os.path.abspath(__file__))
 grandparent_dir = os.path.dirname(os.path.dirname(current_dir))
 sys.path.append(grandparent_dir)
 
+from examples.animations._render import render_animation_to_video
 from examples.drone.dr_vp_polytope import plotting_dict, problem
-from examples.plotting_viser import (
-    create_animated_plotting_server,
-    create_scp_animated_plotting_server,
-)
+from examples.plotting_viser import create_animated_plotting_server
+
+# --- Render settings ---------------------------------------------------------
+OUTPUT_PATH = os.path.join(current_dir, "dr_vp_polytope.mp4")
+WIDTH = 1280
+HEIGHT = 720
+FPS = 30
+CRF = 16  # lower = crisper; 16 is visually near-lossless
+BACKGROUND_COLOR = (25, 25, 30)  # dark scene background (RGB 0..255)
+
+# --- Camera settings ---------------------------------------------------------
+CHASE_DISTANCE = 15.0  # camera sits this far past the drone along polytope->drone ray
+VERTICAL_OFFSET = 2.0  # lift so the drone isn't a 1-pixel occlusion of the polytope
 
 
 def _look_at_wxyz(pos: np.ndarray, target: np.ndarray, up: np.ndarray) -> np.ndarray:
-    """Quaternion (w,x,y,z) for a camera at `pos` looking at `target`.
+    """Quaternion (w,x,y,z) for a camera at ``pos`` looking at ``target``.
 
     Uses the OpenCV camera convention that viser expects: +X right, +Y down,
-    +Z forward. See `examples/animations/camera_control_notes.md`.
+    +Z forward. See ``examples/animations/camera_control_notes.md``.
     """
     forward = target - pos
     forward /= np.linalg.norm(forward)
     right = np.cross(forward, up)
-    right /= np.linalg.norm(right)
+    right_norm = np.linalg.norm(right)
+    if right_norm < 1e-6:
+        # Gimbal lock: forward is (nearly) parallel to up. Pick an arbitrary
+        # world axis that isn't, so the camera stays defined. The chosen axis
+        # determines the "roll" of the camera at the singularity — not great
+        # cinematically, but prevents a NaN crash.
+        fallback = np.array([1.0, 0.0, 0.0]) if abs(forward[0]) < 0.9 else np.array([0.0, 1.0, 0.0])
+        right = np.cross(forward, fallback)
+        right_norm = np.linalg.norm(right)
+    right /= right_norm
     cam_down = np.cross(forward, right)  # = -world_up projected perp to forward
     R_world_cam = np.stack([right, cam_down, forward], axis=1)
     return vtf.SO3.from_matrix(R_world_cam).wxyz
 
 
-def _set_camera(server, pos: np.ndarray, wxyz: np.ndarray, look_at: np.ndarray) -> None:
-    """Atomically push a camera pose to every connected client."""
-    for _, client in server.get_clients().items():
-        with client.atomic():
-            client.camera.position = pos
-            client.camera.wxyz = wxyz
-            client.camera.look_at = look_at
-
-
-def orbit_camera(
-    server,
-    center=(100.0, -50.0, 20.0),
-    radius=60.0,
-    height=25.0,
-    period_s=12.0,
-    fps=60,
-    up=(0.0, 0.0, 1.0),
-):
-    """Continuously orbit every connected client's camera around a fixed `center`.
-
-    Useful for surveying a static scene (e.g. the polytope target cluster).
-    For a camera that follows the drone, see `polytope_follow_camera`.
-    """
-    center = np.asarray(center, dtype=np.float64)
-    up = np.asarray(up, dtype=np.float64)
-
-    def _loop():
-        t0 = _time.time()
-        while True:
-            theta = 2 * np.pi * ((_time.time() - t0) % period_s) / period_s
-            pos = center + np.array(
-                [radius * np.cos(theta), radius * np.sin(theta), height]
-            )
-            _set_camera(server, pos, _look_at_wxyz(pos, center, up), center)
-            _time.sleep(1.0 / fps)
-
-    threading.Thread(target=_loop, daemon=True).start()
-
-
-def polytope_follow_camera(
-    server,
-    positions: np.ndarray,
-    traj_time: np.ndarray,
+def polytope_follow_pose(
+    drone: np.ndarray,
     polytope_center: np.ndarray,
-    chase_distance: float = 15.0,
-    vertical_offset: float = 2.0,
-    fps: int = 60,
+    *,
+    chase_distance: float = CHASE_DISTANCE,
+    vertical_offset: float = VERTICAL_OFFSET,
     up=(0.0, 0.0, 1.0),
-):
-    """Chase camera that rides behind the drone and frames the polytope targets.
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return ``(cam_pos, cam_wxyz, look_at)`` for a chase camera behind the drone.
 
-    At each frame the camera sits on the ray from `polytope_center` through the
-    drone, extended `chase_distance` units past the drone, then lifted by
-    `vertical_offset` along world-up so the drone isn't a single-pixel occlusion
-    of the targets. The camera always looks at `polytope_center`, so the viewer
-    sees the drone silhouetted against the target cluster — which is exactly
-    the geometry the viewplanning constraint is enforcing (the drone's sensor
-    boresight points along `drone -> polytope_center`).
+    The camera sits on the ray from ``polytope_center`` through ``drone``,
+    extended ``chase_distance`` units past the drone, then lifted along world
+    up by ``vertical_offset`` so the drone silhouettes (but doesn't pixel-occlude)
+    the target cluster. It always looks at ``polytope_center``.
 
-    Because the camera pose is a pure function of the drone's position, there
-    is no independent clock and no drift concern: the camera is wherever the
-    drone is, period. If playback is paused or scrubbed in the Animation panel,
-    the camera simply stops moving along with the scene.
-
-    Args:
-        server: The viser server returned by `create_animated_plotting_server`.
-        positions: (N, 3) drone position trajectory in world coordinates.
-        traj_time: (N,) timestamps matching `positions`, monotonically increasing.
-        polytope_center: (3,) world-coordinate center of the viewplanning polytope.
-        chase_distance: How far past the drone (along the polytope->drone ray)
-            to place the camera. Larger values = wider shot.
-        vertical_offset: World-up offset added to the camera position so the
-            drone is framed above/below the polytope center rather than directly
-            in front of it.
-        fps: Camera update rate.
-        up: World up direction (default z-up).
+    This is exactly the geometry the viewplanning constraint is enforcing:
+    the drone's sensor boresight points along ``drone -> polytope_center``,
+    so the chase camera naturally frames "what the drone is looking at" from
+    over-the-shoulder.
     """
-    positions = np.asarray(positions, dtype=np.float64)
-    traj_time = np.asarray(traj_time, dtype=np.float64).flatten()
+    drone = np.asarray(drone, dtype=np.float64)
     polytope_center = np.asarray(polytope_center, dtype=np.float64)
     up = np.asarray(up, dtype=np.float64)
-    lift = vertical_offset * up
 
-    t_start = float(traj_time[0])
-    t_end = float(traj_time[-1])
-    duration = t_end - t_start
+    ray = drone - polytope_center
+    ray_norm = np.linalg.norm(ray)
+    if ray_norm < 1e-6:
+        # Degenerate: drone sitting exactly at the polytope center. Shouldn't
+        # happen on a viewplanning trajectory, but don't divide by zero.
+        cam_pos = drone + vertical_offset * up
+    else:
+        cam_pos = drone + chase_distance * (ray / ray_norm) + vertical_offset * up
 
-    def drone_at(sim_t: float) -> np.ndarray:
-        """Linearly interpolate the drone position at simulation time `sim_t`."""
-        return np.array(
-            [np.interp(sim_t, traj_time, positions[:, k]) for k in range(3)]
-        )
-
-    def _loop():
-        t0 = _time.time()
-        while True:
-            sim_t = t_start + ((_time.time() - t0) % duration)
-            drone = drone_at(sim_t)
-
-            ray = drone - polytope_center
-            ray_norm = np.linalg.norm(ray)
-            # Degenerate case: drone exactly at polytope center. Shouldn't
-            # happen for a viewplanning trajectory, but guard anyway.
-            if ray_norm < 1e-6:
-                _time.sleep(1.0 / fps)
-                continue
-            ray_hat = ray / ray_norm
-
-            cam_pos = drone + chase_distance * ray_hat + lift
-            _set_camera(
-                server,
-                cam_pos,
-                _look_at_wxyz(cam_pos, polytope_center, up),
-                polytope_center,
-            )
-            _time.sleep(1.0 / fps)
-
-    threading.Thread(target=_loop, daemon=True).start()
+    wxyz = _look_at_wxyz(cam_pos, polytope_center, up)
+    return cam_pos, wxyz, polytope_center
 
 
 if __name__ == "__main__":
@@ -167,33 +113,31 @@ if __name__ == "__main__":
     results = problem.post_process()
     results.update(plotting_dict)
 
-    # Create both visualization servers (viser auto-assigns ports)
-    traj_server = create_animated_plotting_server(
+    # Center of the viewplanning polytope (mean of its vertices).
+    polytope_center = np.asarray(results["init_poses"]).mean(axis=0)
+    positions = np.asarray(results.trajectory["position"], dtype=np.float64)
+
+    # Build the scene in manual-step mode — no GUI playback loop, no wall-clock
+    # thread; we'll drive every frame ourselves from the render loop.
+    handle = create_animated_plotting_server(
         results,
         thrust_key="thrust_force",
         viewcone_scale=10.0,
         show_control_plot="thrust_force",
         show_control_norm_plot="thrust_force",
-    )
-    scp_server = create_scp_animated_plotting_server(
-        results,
-        attitude_stride=3,
-        frame_duration_ms=200,
+        controls="manual",
     )
 
-    # Center of the viewplanning polytope (mean of its vertices).
-    polytope_center = np.asarray(results["init_poses"]).mean(axis=0)
+    def camera_pose_fn(frame_idx: int):
+        return polytope_follow_pose(positions[frame_idx], polytope_center)
 
-    # Cinematic orbit around the polytope target cluster.
-    # orbit_camera(traj_server, center=tuple(polytope_center))
-
-    # Chase camera that rides behind the drone and frames the polytope.
-    polytope_follow_camera(
-        traj_server,
-        results.trajectory["position"],
-        results.trajectory["time"],
-        polytope_center=polytope_center,
+    render_animation_to_video(
+        handle,
+        OUTPUT_PATH,
+        camera_pose_fn,
+        width=WIDTH,
+        height=HEIGHT,
+        fps=FPS,
+        crf=CRF,
+        background_color=BACKGROUND_COLOR,
     )
-
-    # Keep both servers running
-    traj_server.sleep_forever()

--- a/examples/animations/dr_vp_polytope.py
+++ b/examples/animations/dr_vp_polytope.py
@@ -1,0 +1,99 @@
+"""Cinematic animation of the drone-racing-with-polytope-viewplanning example.
+
+The trajectory optimization problem itself lives in
+`examples/drone/dr_vp_polytope.py`; this file imports that `problem` (and the
+associated `plotting_dict`), solves it, and then drives a viser scene with a
+cinematic camera orbit suitable for landing-page / presentation captures.
+"""
+
+import os
+import sys
+import threading
+import time as _time
+
+import numpy as np
+import viser.transforms as vtf
+
+# Add the project root so `examples.*` imports resolve.
+current_dir = os.path.dirname(os.path.abspath(__file__))
+grandparent_dir = os.path.dirname(os.path.dirname(current_dir))
+sys.path.append(grandparent_dir)
+
+from examples.drone.dr_vp_polytope import plotting_dict, problem
+from examples.plotting_viser import (
+    create_animated_plotting_server,
+    create_scp_animated_plotting_server,
+)
+
+
+def orbit_camera(
+    server,
+    center=(100.0, -50.0, 20.0),
+    radius=60.0,
+    height=25.0,
+    period_s=12.0,
+    fps=60,
+    up=(0.0, 0.0, 1.0),
+):
+    """Continuously orbit every connected client's camera around `center`.
+
+    See `examples/animations/camera_control_notes.md` for the underlying
+    viser API and the rationale for setting both `position` and `wxyz`
+    atomically (assigning `look_at` alone does not reorient the camera).
+    """
+    center = np.asarray(center, dtype=np.float64)
+    up = np.asarray(up, dtype=np.float64)
+
+    def _loop():
+        t0 = _time.time()
+        while True:
+            theta = 2 * np.pi * ((_time.time() - t0) % period_s) / period_s
+            pos = center + np.array(
+                [radius * np.cos(theta), radius * np.sin(theta), height]
+            )
+
+            # viser uses the OpenCV camera convention: +X right, +Y down,
+            # +Z forward (toward the look target).
+            forward = center - pos
+            forward /= np.linalg.norm(forward)
+            right = np.cross(forward, up)
+            right /= np.linalg.norm(right)
+            cam_down = np.cross(forward, right)  # = -world_up projected perp to forward
+            R_world_cam = np.stack([right, cam_down, forward], axis=1)
+            wxyz = vtf.SO3.from_matrix(R_world_cam).wxyz
+
+            for _, client in server.get_clients().items():
+                with client.atomic():
+                    client.camera.position = pos
+                    client.camera.wxyz = wxyz
+                    client.camera.look_at = center
+            _time.sleep(1.0 / fps)
+
+    threading.Thread(target=_loop, daemon=True).start()
+
+
+if __name__ == "__main__":
+    problem.initialize()
+    problem.solve()
+    results = problem.post_process()
+    results.update(plotting_dict)
+
+    # Create both visualization servers (viser auto-assigns ports)
+    traj_server = create_animated_plotting_server(
+        results,
+        thrust_key="thrust_force",
+        viewcone_scale=10.0,
+        show_control_plot="thrust_force",
+        show_control_norm_plot="thrust_force",
+    )
+    scp_server = create_scp_animated_plotting_server(
+        results,
+        attitude_stride=3,
+        frame_duration_ms=200,
+    )
+
+    # Cinematic orbit around the polytope target cluster.
+    orbit_camera(traj_server)
+
+    # Keep both servers running
+    traj_server.sleep_forever()

--- a/examples/animations/dr_vp_polytope.py
+++ b/examples/animations/dr_vp_polytope.py
@@ -28,13 +28,13 @@ import os
 import sys
 
 import numpy as np
-import viser.transforms as vtf
 
 # Add the project root so `examples.*` imports resolve.
 current_dir = os.path.dirname(os.path.abspath(__file__))
 grandparent_dir = os.path.dirname(os.path.dirname(current_dir))
 sys.path.append(grandparent_dir)
 
+from examples.animations._camera import chase_pose, onboard_pose, overview_pose
 from examples.animations._render import render_animation_to_video
 from examples.drone.dr_vp_polytope import plotting_dict, problem
 from examples.plotting_viser import create_animated_plotting_server
@@ -65,6 +65,7 @@ VERTICAL_OFFSET = 2.0  # lift so the drone isn't a 1-pixel occlusion of the poly
 
 # Onboard mode
 ONBOARD_FORWARD_OFFSET = 0.0  # shift camera forward along boresight to clear body-frame axes
+ONBOARD_FOV_PADDING = 5.0  # degrees added to sensor FOV so the viewcone ring is visible
 
 # Overview mode — spherical coordinates from the trajectory centroid.
 # Azimuth: angle in the XY plane from +X, CCW (radians).
@@ -73,145 +74,6 @@ OVERVIEW_AZIMUTH = np.radians(135.0)
 OVERVIEW_ELEVATION = np.radians(25.0)
 OVERVIEW_RADIUS_MARGIN = 0.75  # multiplier on the auto-computed radius
 OVERVIEW_FOV_DEG = 60.0
-
-
-def _look_at_wxyz(pos: np.ndarray, target: np.ndarray, up: np.ndarray) -> np.ndarray:
-    """Quaternion (w,x,y,z) for a camera at ``pos`` looking at ``target``.
-
-    Uses the OpenCV camera convention that viser expects: +X right, +Y down,
-    +Z forward. See ``examples/animations/camera_control_notes.md``.
-    """
-    forward = target - pos
-    forward /= np.linalg.norm(forward)
-    right = np.cross(forward, up)
-    right_norm = np.linalg.norm(right)
-    if right_norm < 1e-6:
-        # Gimbal lock: forward is (nearly) parallel to up. Pick an arbitrary
-        # world axis that isn't, so the camera stays defined. The chosen axis
-        # determines the "roll" of the camera at the singularity — not great
-        # cinematically, but prevents a NaN crash.
-        fallback = np.array([1.0, 0.0, 0.0]) if abs(forward[0]) < 0.9 else np.array([0.0, 1.0, 0.0])
-        right = np.cross(forward, fallback)
-        right_norm = np.linalg.norm(right)
-    right /= right_norm
-    cam_down = np.cross(forward, right)  # = -world_up projected perp to forward
-    R_world_cam = np.stack([right, cam_down, forward], axis=1)
-    return vtf.SO3.from_matrix(R_world_cam).wxyz
-
-
-def polytope_follow_pose(
-    drone: np.ndarray,
-    polytope_center: np.ndarray,
-    *,
-    chase_distance: float = CHASE_DISTANCE,
-    vertical_offset: float = VERTICAL_OFFSET,
-    up=(0.0, 0.0, 1.0),
-) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Return ``(cam_pos, cam_wxyz, look_at)`` for a chase camera behind the drone.
-
-    The camera sits on the ray from ``polytope_center`` through ``drone``,
-    extended ``chase_distance`` units past the drone, then lifted along world
-    up by ``vertical_offset`` so the drone silhouettes (but doesn't pixel-occlude)
-    the target cluster. It always looks at ``polytope_center``.
-
-    This is exactly the geometry the viewplanning constraint is enforcing:
-    the drone's sensor boresight points along ``drone -> polytope_center``,
-    so the chase camera naturally frames "what the drone is looking at" from
-    over-the-shoulder.
-    """
-    drone = np.asarray(drone, dtype=np.float64)
-    polytope_center = np.asarray(polytope_center, dtype=np.float64)
-    up = np.asarray(up, dtype=np.float64)
-
-    ray = drone - polytope_center
-    ray_norm = np.linalg.norm(ray)
-    if ray_norm < 1e-6:
-        # Degenerate: drone sitting exactly at the polytope center. Shouldn't
-        # happen on a viewplanning trajectory, but don't divide by zero.
-        cam_pos = drone + vertical_offset * up
-    else:
-        cam_pos = drone + chase_distance * (ray / ray_norm) + vertical_offset * up
-
-    wxyz = _look_at_wxyz(cam_pos, polytope_center, up)
-    return cam_pos, wxyz, polytope_center
-
-
-def onboard_pose(
-    drone: np.ndarray,
-    attitude_wxyz: np.ndarray,
-    R_sb: np.ndarray,
-    *,
-    forward_offset: float = ONBOARD_FORWARD_OFFSET,
-) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Return ``(cam_pos, cam_wxyz, look_at)`` for a sensor-mounted FPV camera.
-
-    Places the camera at the drone's position (shifted slightly forward along
-    the sensor boresight to avoid being occluded by the body-frame coordinate
-    axes) with orientation matching the sensor frame — i.e. looking along the
-    sensor boresight (+Z in sensor frame, mapped through R_sb and the body
-    attitude to world coordinates). This is exactly what the viewplanning
-    constraint keeps pointed at the target polytope.
-    """
-    # R_body_to_world from the attitude quaternion (w, x, y, z)
-    w, x, y, z = attitude_wxyz
-    R_bw = np.array([
-        [1 - 2*(y*y + z*z), 2*(x*y - z*w), 2*(x*z + y*w)],
-        [2*(x*y + z*w), 1 - 2*(x*x + z*z), 2*(y*z - x*w)],
-        [2*(x*z - y*w), 2*(y*z + x*w), 1 - 2*(x*x + y*y)],
-    ], dtype=np.float64)
-
-    # Sensor-to-world: columns are the sensor axes in world coords.
-    # R_sb is body-to-sensor, so R_sb.T is sensor-to-body.
-    R_sensor_to_world = R_bw @ R_sb.T
-
-    # Viser uses OpenCV convention (+X right, +Y DOWN, +Z forward).
-    # The sensor frame has +Y UP, so we rotate 180° around the boresight (Z)
-    # to flip both X and Y, converting to the convention viser expects.
-    R_opencv_from_sensor = np.diag([-1.0, -1.0, 1.0])
-    R_cam_to_world = R_sensor_to_world @ R_opencv_from_sensor
-
-    wxyz = vtf.SO3.from_matrix(R_cam_to_world).wxyz
-    # Boresight is sensor +Z expressed in world frame (unchanged by the flip).
-    boresight_world = R_sensor_to_world[:, 2]
-    cam_pos = drone + forward_offset * boresight_world
-    look_at = cam_pos + 10.0 * boresight_world
-    return cam_pos, wxyz, look_at
-
-
-def overview_pose(
-    positions: np.ndarray,
-    *,
-    azimuth: float = OVERVIEW_AZIMUTH,
-    elevation: float = OVERVIEW_ELEVATION,
-    radius_margin: float = OVERVIEW_RADIUS_MARGIN,
-    fov_deg: float = OVERVIEW_FOV_DEG,
-    up=(0.0, 0.0, 1.0),
-) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Return a static ``(cam_pos, cam_wxyz, look_at)`` that frames the full track.
-
-    The camera is placed at a point on a sphere around the trajectory centroid,
-    parameterized by ``azimuth`` (angle in XY from +X, CCW) and ``elevation``
-    (angle above the horizon). The radius is auto-computed so the full
-    trajectory fits within ``fov_deg``, then scaled by ``radius_margin``.
-    """
-    up = np.asarray(up, dtype=np.float64)
-    center = positions.mean(axis=0)
-    # Max distance from centroid to any trajectory point (3D).
-    max_extent = np.max(np.linalg.norm(positions - center, axis=1))
-    # Radius so the full extent subtends half the FOV.
-    half_fov_rad = np.radians(fov_deg / 2.0)
-    radius = max_extent / np.sin(half_fov_rad) * radius_margin
-
-    # Spherical -> Cartesian offset from centroid.
-    cos_el = np.cos(elevation)
-    cam_pos = center + radius * np.array([
-        cos_el * np.cos(azimuth),
-        cos_el * np.sin(azimuth),
-        np.sin(elevation),
-    ])
-    look_at = center.copy()
-    wxyz = _look_at_wxyz(cam_pos, look_at, up)
-    return cam_pos, wxyz, look_at
 
 
 if __name__ == "__main__":
@@ -251,13 +113,23 @@ if __name__ == "__main__":
     render_fov: float | None = None
     if CAMERA_MODE == "chase":
         def camera_pose_fn(frame_idx: int):
-            return polytope_follow_pose(positions[frame_idx], polytope_center)
+            return chase_pose(
+                positions[frame_idx], polytope_center,
+                chase_distance=CHASE_DISTANCE, vertical_offset=VERTICAL_OFFSET,
+            )
     elif CAMERA_MODE == "onboard":
-        render_fov = sensor_fov_deg + 5
+        render_fov = sensor_fov_deg + ONBOARD_FOV_PADDING
         def camera_pose_fn(frame_idx: int):
-            return onboard_pose(positions[frame_idx], attitude[frame_idx], R_sb)
+            return onboard_pose(
+                positions[frame_idx], attitude[frame_idx], R_sb,
+                forward_offset=ONBOARD_FORWARD_OFFSET,
+            )
     elif CAMERA_MODE == "overview":
-        static_pose = overview_pose(positions)
+        static_pose = overview_pose(
+            positions,
+            azimuth=OVERVIEW_AZIMUTH, elevation=OVERVIEW_ELEVATION,
+            radius_margin=OVERVIEW_RADIUS_MARGIN, fov_deg=OVERVIEW_FOV_DEG,
+        )
         def camera_pose_fn(frame_idx: int):
             return static_pose
     else:

--- a/examples/animations/dr_vp_polytope.py
+++ b/examples/animations/dr_vp_polytope.py
@@ -39,7 +39,6 @@ WIDTH = 1280
 HEIGHT = 720
 FPS = 30
 CRF = 16  # lower = crisper; 16 is visually near-lossless
-BACKGROUND_COLOR = (25, 25, 30)  # dark scene background (RGB 0..255)
 
 # --- Camera settings ---------------------------------------------------------
 CHASE_DISTANCE = 15.0  # camera sits this far past the drone along polytope->drone ray
@@ -126,6 +125,7 @@ if __name__ == "__main__":
         show_control_plot="thrust_force",
         show_control_norm_plot="thrust_force",
         controls="manual",
+        show_grid=False,
     )
 
     def camera_pose_fn(frame_idx: int):
@@ -139,5 +139,4 @@ if __name__ == "__main__":
         height=HEIGHT,
         fps=FPS,
         crf=CRF,
-        background_color=BACKGROUND_COLOR,
     )

--- a/examples/animations/dr_vp_polytope.py
+++ b/examples/animations/dr_vp_polytope.py
@@ -35,8 +35,8 @@ grandparent_dir = os.path.dirname(os.path.dirname(current_dir))
 sys.path.append(grandparent_dir)
 
 from examples.animations._camera import chase_pose, onboard_pose, overview_pose
-from examples.animations._sensor_view import render_camera_panel_to_video
 from examples.animations._render import render_animation_to_video
+from examples.animations._sensor_view import render_camera_panel_to_video
 from examples.drone.dr_vp_polytope import plotting_dict, problem
 from examples.plotting_viser import create_animated_plotting_server
 

--- a/examples/animations/dr_vp_polytope.py
+++ b/examples/animations/dr_vp_polytope.py
@@ -35,8 +35,8 @@ from examples.plotting_viser import create_animated_plotting_server
 
 # --- Render settings ---------------------------------------------------------
 OUTPUT_PATH = os.path.join(current_dir, "dr_vp_polytope.mp4")
-WIDTH = 720
-HEIGHT = 720
+WIDTH = 1080
+HEIGHT = 1080
 FPS = 60
 CRF = 16  # lower = crisper; 16 is visually near-lossless
 
@@ -136,7 +136,8 @@ if __name__ == "__main__":
         show_control_norm_plot="thrust_force",
         controls="manual",
         show_grid=False,
-        trail_point_size=0.075
+        trail_point_size=0.075,
+        viewcone_ring_only=True,
     )
 
     def camera_pose_fn(frame_idx: int):

--- a/examples/animations/dr_vp_polytope.py
+++ b/examples/animations/dr_vp_polytope.py
@@ -35,10 +35,19 @@ from examples.plotting_viser import create_animated_plotting_server
 
 # --- Render settings ---------------------------------------------------------
 OUTPUT_PATH = os.path.join(current_dir, "dr_vp_polytope.mp4")
-WIDTH = 1280
+WIDTH = 720
 HEIGHT = 720
-FPS = 30
+FPS = 60
 CRF = 16  # lower = crisper; 16 is visually near-lossless
+
+# Oversampling factor for the propagation: how many trajectory samples we
+# propagate per rendered video frame. STRIDE=1 means one sample per frame (the
+# trail polyline looks chunky when the drone is fast). STRIDE=4 means the
+# propagation runs at 4x the video rate, so the trail is drawn from 4x denser
+# samples — smoother curves at speed — while `render_animation_to_video` strides
+# through every 4th sample to keep the video at realtime FPS.
+STRIDE = 4
+PROPAGATION_HZ = FPS * STRIDE
 
 # --- Camera settings ---------------------------------------------------------
 CHASE_DISTANCE = 15.0  # camera sits this far past the drone along polytope->drone ray
@@ -107,6 +116,7 @@ def polytope_follow_pose(
 
 
 if __name__ == "__main__":
+    problem.settings.prp.dt = 1.0 / PROPAGATION_HZ
     problem.initialize()
     problem.solve()
     results = problem.post_process()
@@ -139,4 +149,5 @@ if __name__ == "__main__":
         height=HEIGHT,
         fps=FPS,
         crf=CRF,
+        stride=STRIDE,
     )

--- a/examples/animations/dr_vp_polytope.py
+++ b/examples/animations/dr_vp_polytope.py
@@ -49,8 +49,8 @@ CAMERA_MODE = "chase"
 RENDER_CAMERA_PANEL = True
 
 # --- Render settings ---------------------------------------------------------
-OUTPUT_PATH = os.path.join(current_dir, f"dr_vp_polytope_{CAMERA_MODE}.mp4")
-CAMERA_PANEL_PATH = os.path.join(current_dir, "dr_vp_polytope_camera.mp4")
+OUTPUT_PATH = os.path.join(current_dir, "mp4", f"dr_vp_polytope_{CAMERA_MODE}.mp4")
+CAMERA_PANEL_PATH = os.path.join(current_dir, "mp4", "dr_vp_polytope_camera.mp4")
 WIDTH = 1080
 HEIGHT = 1080
 FPS = 30

--- a/examples/animations/dr_vp_polytope.py
+++ b/examples/animations/dr_vp_polytope.py
@@ -46,7 +46,7 @@ CRF = 16  # lower = crisper; 16 is visually near-lossless
 # propagation runs at 4x the video rate, so the trail is drawn from 4x denser
 # samples — smoother curves at speed — while `render_animation_to_video` strides
 # through every 4th sample to keep the video at realtime FPS.
-STRIDE = 4
+STRIDE = 6
 PROPAGATION_HZ = FPS * STRIDE
 
 # --- Camera settings ---------------------------------------------------------
@@ -136,6 +136,7 @@ if __name__ == "__main__":
         show_control_norm_plot="thrust_force",
         controls="manual",
         show_grid=False,
+        trail_point_size=0.075
     )
 
     def camera_pose_fn(frame_idx: int):

--- a/examples/animations/logo.py
+++ b/examples/animations/logo.py
@@ -43,7 +43,7 @@ from examples.plotting_viser import create_animated_plotting_server
 CAMERA_MODE = "overview"
 
 # --- Render settings ---------------------------------------------------------
-OUTPUT_PATH = os.path.join(current_dir, f"logo_{CAMERA_MODE}.mp4")
+OUTPUT_PATH = os.path.join(current_dir, "mp4", f"logo_{CAMERA_MODE}.mp4")
 WIDTH = 1080
 HEIGHT = 1080
 FPS = 60

--- a/examples/animations/logo.py
+++ b/examples/animations/logo.py
@@ -1,0 +1,164 @@
+"""Cinematic offline render of the ACL-logo-tracing drone example.
+
+The trajectory optimization problem itself lives in
+``examples/drone/logo.py``; this file imports that ``problem`` (and
+the associated ``plotting_dict``), solves it, and drives a viser scene
+frame-by-frame while piping raw RGB into ffmpeg to produce an mp4.
+
+Run it with::
+
+    python examples/animations/logo.py
+
+The script prints a viser URL and waits. Open the URL in a browser — as soon
+as the client connects, the render begins. Requires ``ffmpeg`` on ``PATH``;
+``openscvx`` does not depend on it.
+
+Two camera modes are available — set ``CAMERA_MODE`` below:
+
+- ``"overview"`` — static elevated camera framing the full trajectory so we can
+  watch the drone draw out the logo.
+- ``"chase"``   — over-the-shoulder behind the drone, focused on the current
+  SVG path target so we can see the motion up close.
+
+Tweak ``OUTPUT_PATH`` / ``WIDTH`` / ``HEIGHT`` / ``FPS`` below for different
+output variants.
+"""
+
+import os
+import sys
+
+import numpy as np
+
+# Add the project root so `examples.*` imports resolve.
+current_dir = os.path.dirname(os.path.abspath(__file__))
+grandparent_dir = os.path.dirname(os.path.dirname(current_dir))
+sys.path.append(grandparent_dir)
+
+from examples.animations._camera import chase_pose, overview_pose
+from examples.animations._render import render_animation_to_video
+from examples.drone.logo import get_kp_pose, plotting_dict, problem, total_time
+from examples.plotting_viser import create_animated_plotting_server
+
+# Camera mode: "chase" | "overview"
+CAMERA_MODE = "chase"
+
+# --- Render settings ---------------------------------------------------------
+OUTPUT_PATH = os.path.join(current_dir, f"logo_{CAMERA_MODE}.mp4")
+WIDTH = 1080
+HEIGHT = 1080
+FPS = 60
+CRF = 16  # lower = crisper; 16 is visually near-lossless
+
+# Oversampling: propagate at FPS*STRIDE Hz for smooth trails, then stride
+# through every STRIDE-th sample so the video plays at realtime.
+STRIDE = 4
+PROPAGATION_HZ = FPS * STRIDE
+
+# --- Camera settings ---------------------------------------------------------
+# Chase mode
+CHASE_DISTANCE = 8.0  # camera distance past the drone along target->drone ray
+VERTICAL_OFFSET = 2.0  # lift above the drone
+
+# Overview mode — spherical coordinates from the trajectory centroid.
+OVERVIEW_AZIMUTH = np.radians(30.0)
+OVERVIEW_ELEVATION = np.radians(30.0)
+OVERVIEW_RADIUS_MARGIN = 0.85
+OVERVIEW_FOV_DEG = 55.0
+
+
+if __name__ == "__main__":
+    problem.settings.prp.dt = 1.0 / PROPAGATION_HZ
+    problem.initialize()
+    problem.solve()
+    results = problem.post_process()
+    results.update_plotting_data(**plotting_dict)
+
+    positions = np.asarray(results.trajectory["position"], dtype=np.float64)
+    traj_time = np.asarray(results.trajectory["time"], dtype=np.float64).flatten()
+    n_frames = len(positions)
+
+    # Centroid of the SVG path target trajectory — the chase camera focuses here
+    # so the framing stays stable instead of jerking with the moving target.
+    target_positions = np.array(
+        [np.asarray(get_kp_pose(float(traj_time[i]) / total_time)) for i in range(n_frames)],
+        dtype=np.float64,
+    )
+    target_centroid = target_positions.mean(axis=0)
+
+    # Compute the logo drawing plane and the traced path (boresight ∩ plane),
+    # exactly as the logo __main__ block does. Without these keys the plotting
+    # server skips the cyan traced-path trail and the animated pointer dot.
+    p0 = np.asarray(get_kp_pose(0.0))
+    p1 = np.asarray(get_kp_pose(0.33))
+    p2 = np.asarray(get_kp_pose(0.67))
+    v1, v2 = p1 - p0, p2 - p0
+    plane_normal = np.cross(v1, v2)
+    nrm = np.linalg.norm(plane_normal)
+    plane_normal = plane_normal / nrm if nrm > 1e-10 else np.array([1.0, 0.0, 0.0])
+    plane_point = p0
+
+    def _ray_plane(origin, direction, p_plane, n_plane):
+        denom = np.dot(direction, n_plane)
+        if abs(denom) < 1e-10:
+            return None
+        t = np.dot(p_plane - origin, n_plane) / denom
+        return origin + t * direction if t >= 0 else None
+
+    traced_path = []
+    for i in range(n_frames):
+        rel = target_positions[i] - positions[i]
+        rel_dir = rel / np.linalg.norm(rel)
+        pt = _ray_plane(positions[i], rel_dir, plane_point, plane_normal)
+        traced_path.append(pt if pt is not None else target_positions[i])
+
+    results["traced_path_on_plane"] = np.array(traced_path, dtype=np.float64)
+    results["logo_plane_point"] = plane_point
+    results["logo_plane_normal"] = plane_normal
+
+    # Build the scene in manual-step mode.
+    handle = create_animated_plotting_server(
+        results,
+        thrust_key="thrust_force",
+        controls="manual",
+        show_grid=False,
+        trail_point_size=0.1,
+        target_radius=0.3,
+    )
+
+    # Select camera pose function based on mode.
+    if CAMERA_MODE == "overview":
+        traced = np.array(traced_path, dtype=np.float64)
+        static_pose = overview_pose(
+            traced,
+            azimuth=OVERVIEW_AZIMUTH,
+            elevation=OVERVIEW_ELEVATION,
+            radius_margin=OVERVIEW_RADIUS_MARGIN,
+            fov_deg=OVERVIEW_FOV_DEG,
+        )
+
+        def camera_pose_fn(frame_idx: int):
+            return static_pose
+
+    elif CAMERA_MODE == "chase":
+
+        def camera_pose_fn(frame_idx: int):
+            return chase_pose(
+                positions[frame_idx],
+                target_centroid,
+                chase_distance=CHASE_DISTANCE,
+                vertical_offset=VERTICAL_OFFSET,
+            )
+
+    else:
+        raise ValueError(f"Unknown CAMERA_MODE: {CAMERA_MODE!r}")
+
+    render_animation_to_video(
+        handle,
+        OUTPUT_PATH,
+        camera_pose_fn,
+        width=WIDTH,
+        height=HEIGHT,
+        fps=FPS,
+        crf=CRF,
+        stride=STRIDE,
+    )

--- a/examples/animations/logo.py
+++ b/examples/animations/logo.py
@@ -40,7 +40,7 @@ from examples.drone.logo import get_kp_pose, plotting_dict, problem, total_time
 from examples.plotting_viser import create_animated_plotting_server
 
 # Camera mode: "chase" | "overview"
-CAMERA_MODE = "chase"
+CAMERA_MODE = "overview"
 
 # --- Render settings ---------------------------------------------------------
 OUTPUT_PATH = os.path.join(current_dir, f"logo_{CAMERA_MODE}.mp4")
@@ -71,7 +71,15 @@ if __name__ == "__main__":
     problem.initialize()
     problem.solve()
     results = problem.post_process()
-    results.update_plotting_data(**plotting_dict)
+    results.update_plotting_data(
+        **{
+            **plotting_dict,
+            # Hide elements that clutter the cinematic render — keep only the
+            # boresight intersection trail (the red "drawing" on the logo plane).
+            "moving_subject": False,
+            "relative_vector": False,
+        }
+    )
 
     positions = np.asarray(results.trajectory["position"], dtype=np.float64)
     traj_time = np.asarray(results.trajectory["time"], dtype=np.float64).flatten()
@@ -85,9 +93,9 @@ if __name__ == "__main__":
     )
     target_centroid = target_positions.mean(axis=0)
 
-    # Compute the logo drawing plane and the traced path (boresight ∩ plane),
-    # exactly as the logo __main__ block does. Without these keys the plotting
-    # server skips the cyan traced-path trail and the animated pointer dot.
+    # Define the logo drawing plane so the boresight-plane intersection works.
+    # We intentionally skip traced_path_on_plane (static cyan path + green dot)
+    # and the other diagnostic overlays to keep the render clean.
     p0 = np.asarray(get_kp_pose(0.0))
     p1 = np.asarray(get_kp_pose(0.33))
     p2 = np.asarray(get_kp_pose(0.67))
@@ -95,24 +103,7 @@ if __name__ == "__main__":
     plane_normal = np.cross(v1, v2)
     nrm = np.linalg.norm(plane_normal)
     plane_normal = plane_normal / nrm if nrm > 1e-10 else np.array([1.0, 0.0, 0.0])
-    plane_point = p0
-
-    def _ray_plane(origin, direction, p_plane, n_plane):
-        denom = np.dot(direction, n_plane)
-        if abs(denom) < 1e-10:
-            return None
-        t = np.dot(p_plane - origin, n_plane) / denom
-        return origin + t * direction if t >= 0 else None
-
-    traced_path = []
-    for i in range(n_frames):
-        rel = target_positions[i] - positions[i]
-        rel_dir = rel / np.linalg.norm(rel)
-        pt = _ray_plane(positions[i], rel_dir, plane_point, plane_normal)
-        traced_path.append(pt if pt is not None else target_positions[i])
-
-    results["traced_path_on_plane"] = np.array(traced_path, dtype=np.float64)
-    results["logo_plane_point"] = plane_point
+    results["logo_plane_point"] = p0
     results["logo_plane_normal"] = plane_normal
 
     # Build the scene in manual-step mode.
@@ -127,9 +118,8 @@ if __name__ == "__main__":
 
     # Select camera pose function based on mode.
     if CAMERA_MODE == "overview":
-        traced = np.array(traced_path, dtype=np.float64)
         static_pose = overview_pose(
-            traced,
+            target_positions,
             azimuth=OVERVIEW_AZIMUTH,
             elevation=OVERVIEW_ELEVATION,
             radius_margin=OVERVIEW_RADIUS_MARGIN,

--- a/examples/animations/obstacle_avoidance_vmap.py
+++ b/examples/animations/obstacle_avoidance_vmap.py
@@ -49,7 +49,7 @@ from examples.plotting_viser import create_animated_plotting_server
 CAMERA_MODE = "overview"
 
 # --- Render settings ---------------------------------------------------------
-OUTPUT_PATH = os.path.join(current_dir, f"obstacle_avoidance_vmap_{CAMERA_MODE}.mp4")
+OUTPUT_PATH = os.path.join(current_dir, "mp4", f"obstacle_avoidance_vmap_{CAMERA_MODE}.mp4")
 WIDTH = 1080
 HEIGHT = 1080
 FPS = 60

--- a/examples/animations/obstacle_avoidance_vmap.py
+++ b/examples/animations/obstacle_avoidance_vmap.py
@@ -1,0 +1,151 @@
+"""Cinematic offline render of the vmap obstacle-avoidance example.
+
+The trajectory optimization problem itself lives in
+``examples/drone/obstacle_avoidance_vmap.py``; this file imports that
+``problem`` (plus obstacle metadata), solves it, and drives a viser scene
+frame-by-frame while piping raw RGB into ffmpeg to produce an mp4.
+
+Run it with::
+
+    python examples/animations/obstacle_avoidance_vmap.py
+
+The script prints a viser URL and waits. Open the URL in a browser — as soon
+as the client connects, the render begins. Requires ``ffmpeg`` on ``PATH``;
+``openscvx`` does not depend on it.
+
+Two camera modes are available — set ``CAMERA_MODE`` below:
+
+- ``"chase"``    — over-the-shoulder behind the double-integrator body, looking
+  toward the goal so you watch it thread the obstacle field.
+- ``"overview"`` — static elevated camera framing the full trajectory and every
+  obstacle sphere.
+
+Tweak ``OUTPUT_PATH`` / ``WIDTH`` / ``HEIGHT`` / ``FPS`` below for different
+output variants.
+"""
+
+import os
+import sys
+
+import numpy as np
+
+# Add the project root so `examples.*` imports resolve.
+current_dir = os.path.dirname(os.path.abspath(__file__))
+grandparent_dir = os.path.dirname(os.path.dirname(current_dir))
+sys.path.append(grandparent_dir)
+
+from examples.animations._camera import chase_pose, overview_pose
+from examples.animations._render import render_animation_to_video
+from examples.drone.obstacle_avoidance_vmap import (
+    n_obstacles,
+    obstacle_centers,
+    obstacle_radii,
+    position,
+    problem,
+)
+from examples.plotting_viser import create_animated_plotting_server
+
+# Camera mode: "chase" | "overview"
+CAMERA_MODE = "overview"
+
+# --- Render settings ---------------------------------------------------------
+OUTPUT_PATH = os.path.join(current_dir, f"obstacle_avoidance_vmap_{CAMERA_MODE}.mp4")
+WIDTH = 1080
+HEIGHT = 1080
+FPS = 60
+CRF = 16  # lower = crisper; 16 is visually near-lossless
+
+# Oversampling: propagate at FPS*STRIDE Hz for smooth trails, then stride
+# through every STRIDE-th sample so the video plays at realtime.
+STRIDE = 4
+PROPAGATION_HZ = FPS * STRIDE
+
+# --- Camera settings ---------------------------------------------------------
+# Chase mode
+CHASE_DISTANCE = 8.0  # camera sits this far past the drone along goal->drone ray
+VERTICAL_OFFSET = 2.0  # lift so the body isn't a 1-pixel occlusion of the goal
+
+# Overview mode — spherical coordinates from the scene centroid.
+# Azimuth: angle in the XY plane from +X, CCW (radians).
+# Elevation: angle above the horizon (radians).
+OVERVIEW_AZIMUTH = np.radians(-60.0)
+OVERVIEW_ELEVATION = np.radians(25.0)
+OVERVIEW_RADIUS_MARGIN = 0.9
+OVERVIEW_FOV_DEG = 60.0
+
+
+if __name__ == "__main__":
+    problem.settings.prp.dt = 1.0 / PROPAGATION_HZ
+    problem.initialize()
+    problem.solve()
+    results = problem.post_process()
+
+    # Re-attach obstacle metadata — the base example sets this inside its own
+    # ``__main__`` block, so we have to repeat it here.
+    results.update(
+        {
+            "obstacles_centers": [c for c in obstacle_centers],
+            "obstacles_radii": [[1 / r, 1 / r, 1 / r] for r in obstacle_radii],
+            "obstacles_axes": [np.eye(3) for _ in range(n_obstacles)],
+        }
+    )
+
+    positions = np.asarray(results.trajectory["position"], dtype=np.float64)
+    goal = np.asarray(position.final, dtype=np.float64)
+
+    # Build the scene in manual-step mode — no GUI playback loop, no wall-clock
+    # thread; we drive every frame ourselves from the render loop. No viewcone /
+    # attitude because this is a point-mass double integrator.
+    handle = create_animated_plotting_server(
+        results,
+        thrust_key="force",
+        controls="manual",
+        show_grid=False,
+        trail_point_size=0.12,
+    )
+
+    # Select camera pose function based on mode.
+    if CAMERA_MODE == "chase":
+
+        def camera_pose_fn(frame_idx: int):
+            return chase_pose(
+                positions[frame_idx],
+                goal,
+                chase_distance=CHASE_DISTANCE,
+                vertical_offset=VERTICAL_OFFSET,
+            )
+
+    elif CAMERA_MODE == "overview":
+        # Frame the trajectory AND the obstacle field. Push each obstacle
+        # center out by its radius along each world axis so overview_pose's
+        # centroid/extent math accounts for obstacle volumes, not just centers.
+        axis_offsets = np.vstack([np.eye(3), -np.eye(3)])  # (6, 3)
+        obstacle_shell = (
+            obstacle_centers[:, None, :] + obstacle_radii[:, None, None] * axis_offsets[None, :, :]
+        ).reshape(-1, 3)
+        all_points = np.vstack([positions, obstacle_shell])
+
+        static_pose = overview_pose(
+            all_points,
+            azimuth=OVERVIEW_AZIMUTH,
+            elevation=OVERVIEW_ELEVATION,
+            radius_margin=OVERVIEW_RADIUS_MARGIN,
+            fov_deg=OVERVIEW_FOV_DEG,
+        )
+
+        def camera_pose_fn(frame_idx: int):
+            return static_pose
+
+    else:
+        raise ValueError(f"Unknown CAMERA_MODE: {CAMERA_MODE!r}")
+
+    render_animation_to_video(
+        handle,
+        OUTPUT_PATH,
+        camera_pose_fn,
+        width=WIDTH,
+        height=HEIGHT,
+        fps=FPS,
+        crf=CRF,
+        stride=STRIDE,
+    )

--- a/examples/plotting_viser.py
+++ b/examples/plotting_viser.py
@@ -423,7 +423,7 @@ def create_animated_plotting_server(
                         )
 
                         # Draw extended boresight to plane intersection
-                        boresight_handle = server.scene.add_line_segments(
+                        _ = server.scene.add_line_segments(
                             "/boresight_extended",
                             points=np.array([[pos[0], boresight_intersection_0]], dtype=np.float32),
                             colors=(255, 0, 0),  # Red for boresight

--- a/examples/plotting_viser.py
+++ b/examples/plotting_viser.py
@@ -275,7 +275,6 @@ def create_animated_plotting_server(
         lengths = np.array(
             [axes_length * boresight_multiplier, axes_length, axes_length], dtype=np.float32
         )
-        # viser expects colors shape (N, 2, 3) for N segments, 2 endpoints each, 3 RGB per point
         rgb_per_axis = np.array([[255, 0, 0], [0, 255, 0], [0, 0, 255]], dtype=np.uint8)
         colors = np.stack(
             [np.stack([rgb_per_axis[i], rgb_per_axis[i]], axis=0) for i in range(3)], axis=0
@@ -439,40 +438,47 @@ def create_animated_plotting_server(
                             position=boresight_intersection_0,
                         )
 
-                        # Add trail for boresight intersection point
-                        boresight_trail_handle = server.scene.add_line_segments(
+                        # Growing point-cloud trail for the boresight intersection.
+                        boresight_trail_cloud = server.scene.add_point_cloud(
                             "/boresight_intersection_trail",
-                            points=np.array([], dtype=np.float32).reshape(0, 2, 3),
-                            colors=(200, 50, 50),
-                            line_width=2.0,
+                            points=boresight_intersection_points[:1],
+                            colors=np.array([[200, 50, 50]], dtype=np.uint8),
+                            point_size=0.06,
                         )
 
                         def update_boresight(frame_idx: int) -> None:
                             idx = min(frame_idx, len(boresight_intersection_points) - 1)
-                            boresight_handle.points = np.array(
-                                [[pos[idx], boresight_intersection_points[idx]]], dtype=np.float32
+                            # Re-add boresight line (LineSegmentsHandle has no
+                            # mutable points); same scene path replaces the old.
+                            server.scene.add_line_segments(
+                                "/boresight_extended",
+                                points=np.array(
+                                    [[pos[idx], boresight_intersection_points[idx]]],
+                                    dtype=np.float32,
+                                ),
+                                colors=(255, 0, 0),
+                                line_width=3.0,
                             )
                             intersection_handle.position = boresight_intersection_points[idx]
 
-                            # Update trail to show up to current frame
-                            if idx > 0:
-                                trail_segments = np.array(
-                                    [
-                                        [
-                                            boresight_intersection_points[i],
-                                            boresight_intersection_points[i + 1],
-                                        ]
-                                        for i in range(idx)
-                                    ],
-                                    dtype=np.float32,
-                                )
-                                boresight_trail_handle.points = trail_segments
-                            else:
-                                boresight_trail_handle.points = np.array(
-                                    [], dtype=np.float32
-                                ).reshape(0, 2, 3)
+                            # Grow trail up to current frame
+                            n_trail = idx + 1
+                            boresight_trail_cloud.points = boresight_intersection_points[:n_trail]
+                            boresight_trail_cloud.colors = np.broadcast_to(
+                                np.array([[200, 50, 50]], dtype=np.uint8),
+                                (n_trail, 3),
+                            ).copy()
 
                         update_callbacks.append(update_boresight)
+
+                        # Also show the full body-frame axes at the drone position.
+                        _, update_axes = _add_attitude_axes_lines(
+                            "/body_axes",
+                            pos,
+                            attitude,
+                            axes_length=attitude_axes_length,
+                        )
+                        update_callbacks.append(update_axes)
                     else:
                         # Fallback to fixed multiplier if intersection fails
                         boresight_multiplier = 3.0
@@ -635,12 +641,12 @@ def create_animated_plotting_server(
                     position=rel_int_pos_0,
                 )
 
-                # Add trail for intersection point (grows with animation)
-                intersection_trail_handle = server.scene.add_line_segments(
+                # Growing point-cloud trail for the relative-vector intersection.
+                intersection_trail_cloud = server.scene.add_point_cloud(
                     "/relative_vector_intersection_trail",
-                    points=np.array([], dtype=np.float32).reshape(0, 2, 3),
-                    colors=(50, 200, 50),
-                    line_width=2.0,
+                    points=intersection_points[:1],
+                    colors=np.array([[50, 200, 50]], dtype=np.uint8),
+                    point_size=0.06,
                 )
 
                 # Line on plane from boresight intersection to relative-vector intersection
@@ -713,22 +719,25 @@ def create_animated_plotting_server(
                     p = intersection_points[idx].copy()
                     p[2] += 0.08
                     rel_intersection_handle.position = p
-                    if idx > 0:
-                        trail_segments = np.array(
-                            [
-                                [intersection_points[i], intersection_points[i + 1]]
-                                for i in range(idx)
-                            ],
-                            dtype=np.float32,
-                        )
-                        intersection_trail_handle.points = trail_segments
-                    else:
-                        intersection_trail_handle.points = np.array([], dtype=np.float32).reshape(
-                            0, 2, 3
-                        )
+
+                    # Grow trail up to current frame
+                    n_trail = idx + 1
+                    intersection_trail_cloud.points = intersection_points[:n_trail]
+                    intersection_trail_cloud.colors = np.broadcast_to(
+                        np.array([[50, 200, 50]], dtype=np.uint8),
+                        (n_trail, 3),
+                    ).copy()
+
                     if plane_segment_handle is not None and idx < len(boresight_pts):
-                        plane_segment_handle.points = np.array(
-                            [[boresight_pts[idx], intersection_points[idx]]], dtype=np.float32
+                        # Re-add (LineSegmentsHandle has no mutable points).
+                        server.scene.add_line_segments(
+                            "/plane_segment_boresight_to_rel",
+                            points=np.array(
+                                [[boresight_pts[idx], intersection_points[idx]]],
+                                dtype=np.float32,
+                            ),
+                            colors=(200, 200, 0),
+                            line_width=2.5,
                         )
 
                 update_callbacks.append(update_intersection)

--- a/examples/plotting_viser.py
+++ b/examples/plotting_viser.py
@@ -9,6 +9,9 @@ For real-time examples, see examples/realtime/*.py.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import Callable
+
 import matplotlib.pyplot as plt
 import numpy as np
 import viser
@@ -41,6 +44,39 @@ from openscvx.plotting.viser import (
 )
 
 # =============================================================================
+# Manual-stepping handle (for offline rendering)
+# =============================================================================
+
+
+@dataclass
+class AnimatedServerHandle:
+    """Handle for manually stepping an animated viser server, one frame at a time.
+
+    Returned by ``create_animated_plotting_server(..., controls="manual")``
+    instead of starting the GUI playback loop. Primitives registered on the
+    server all take ``frame_idx: int``, so calling ``handle.step(i)`` fans out
+    to every trail, marker, attitude frame, thrust vector, viewcone, etc. —
+    driving the scene without any wall-clock timer. Used by
+    ``examples/animations/_render.py`` to render frames one at a time and pipe
+    them into ffmpeg.
+    """
+
+    server: viser.ViserServer
+    traj_time: np.ndarray
+    update_callbacks: list[Callable[[int], None]]
+
+    @property
+    def n_frames(self) -> int:
+        return len(self.traj_time)
+
+    def step(self, frame_idx: int) -> None:
+        """Drive every registered primitive to show frame ``frame_idx``."""
+        idx = int(np.clip(frame_idx, 0, self.n_frames - 1))
+        for cb in self.update_callbacks:
+            cb(idx)
+
+
+# =============================================================================
 # Template Visualization Servers
 # =============================================================================
 
@@ -61,7 +97,8 @@ def create_animated_plotting_server(
     show_control_norm_plot: str | None = None,
     show_grid: bool = True,
     scene_scale: float = 1.0,
-) -> viser.ViserServer:
+    controls: str = "gui",
+) -> viser.ViserServer | AnimatedServerHandle:
     """Create an animated trajectory visualization server.
 
     This is a convenience function that composes the modular components.
@@ -107,9 +144,16 @@ def create_animated_plotting_server(
         show_grid: Whether to show the grid (default True)
         scene_scale: Divide all positions (and lengths) by this factor. Use >1 for
             large-scale trajectories (e.g., 100.0 for km-scale problems).
+        controls: ``"gui"`` (default) wires up play/pause/slider GUI and starts
+            the wall-clock playback thread, returning the raw ``ViserServer``.
+            ``"manual"`` skips the GUI/playback loop and instead returns an
+            :class:`AnimatedServerHandle` whose ``step(frame_idx)`` method drives
+            every primitive by hand — used for offline rendering (see
+            ``examples/animations/_render.py``).
 
     Returns:
-        ViserServer instance (animation runs in background thread)
+        ``ViserServer`` when ``controls="gui"``, otherwise
+        :class:`AnimatedServerHandle`.
     """
     # Extract data and convert to numpy (handles JAX arrays)
     pos = results.trajectory.get(position_key)
@@ -720,10 +764,21 @@ def create_animated_plotting_server(
             )
             update_callbacks.append(update_vline)
 
-    # Add animation controls
-    add_animation_controls(server, traj_time, update_callbacks, loop=loop_animation)
-
-    return server
+    # Wire up playback — either the wall-clock GUI loop, or a manual-step handle.
+    callbacks = [cb for cb in update_callbacks if cb is not None]
+    if controls == "gui":
+        add_animation_controls(server, traj_time, callbacks, loop=loop_animation)
+        return server
+    elif controls == "manual":
+        return AnimatedServerHandle(
+            server=server,
+            traj_time=np.asarray(traj_time, dtype=np.float64).flatten(),
+            update_callbacks=callbacks,
+        )
+    else:
+        raise ValueError(
+            f"controls must be 'gui' or 'manual', got {controls!r}"
+        )
 
 
 def create_scp_animated_plotting_server(

--- a/examples/plotting_viser.py
+++ b/examples/plotting_viser.py
@@ -92,6 +92,7 @@ def create_animated_plotting_server(
     attitude_axes_length: float = 2.0,
     show_viewcone: bool = True,
     viewcone_scale: float = 10.0,
+    viewcone_ring_only: bool = False,
     target_radius: float = 1.0,
     show_control_plot: str | None = None,
     show_control_norm_plot: str | None = None,
@@ -137,6 +138,7 @@ def create_animated_plotting_server(
         attitude_axes_length: Length of body frame axes
         show_viewcone: If True and R_sb is in results, show camera viewcone
         viewcone_scale: Size/depth of viewcone mesh
+        viewcone_ring_only: If True, render viewcone as a base-ring outline only
         target_radius: Radius of target marker spheres
         show_control_plot: If provided with a control name, displays component plot
             showing each control component vs time with animated markers
@@ -509,22 +511,26 @@ def create_animated_plotting_server(
 
         # Add viewcone mesh if R_sb is available and enabled
         if show_viewcone and R_sb is not None and attitude is not None:
-            # Compute viewcone color from viridis colormap (fallback if matplotlib missing)
-            global plt
-            if plt is None:
-                try:  # pragma: no cover
-                    import matplotlib.pyplot as _plt
-
-                    plt = _plt
-                except Exception:
-                    plt = None
-
-            if plt is not None:
-                cmap = plt.get_cmap("viridis")
-                rgb = cmap(0.4)[:3]
-                viewcone_color = tuple(int(c * 255) for c in rgb)
+            if viewcone_ring_only:
+                # Match thrust vector styling so ring + thrust read as one element.
+                viewcone_color = (255, 100, 100)
             else:
-                viewcone_color = (80, 180, 200)
+                # Compute viewcone color from viridis colormap (fallback if matplotlib missing)
+                global plt
+                if plt is None:
+                    try:  # pragma: no cover
+                        import matplotlib.pyplot as _plt
+
+                        plt = _plt
+                    except Exception:
+                        plt = None
+
+                if plt is not None:
+                    cmap = plt.get_cmap("viridis")
+                    rgb = cmap(0.4)[:3]
+                    viewcone_color = tuple(int(c * 255) for c in rgb)
+                else:
+                    viewcone_color = (80, 180, 200)
 
             _, update_viewcone = add_viewcone(
                 server,
@@ -537,6 +543,7 @@ def create_animated_plotting_server(
                 R_sb=R_sb,
                 color=viewcone_color,
                 wireframe=False,
+                ring_only=viewcone_ring_only,
                 opacity=0.4,
             )
             update_callbacks.append(update_viewcone)

--- a/examples/plotting_viser.py
+++ b/examples/plotting_viser.py
@@ -784,9 +784,7 @@ def create_animated_plotting_server(
             update_callbacks=callbacks,
         )
     else:
-        raise ValueError(
-            f"controls must be 'gui' or 'manual', got {controls!r}"
-        )
+        raise ValueError(f"controls must be 'gui' or 'manual', got {controls!r}")
 
 
 def create_scp_animated_plotting_server(

--- a/examples/plotting_viser.py
+++ b/examples/plotting_viser.py
@@ -95,6 +95,7 @@ def create_animated_plotting_server(
     target_radius: float = 1.0,
     show_control_plot: str | None = None,
     show_control_norm_plot: str | None = None,
+    trail_point_size: float = 0.15,
     show_grid: bool = True,
     scene_scale: float = 1.0,
     controls: str = "gui",
@@ -331,7 +332,7 @@ def create_animated_plotting_server(
     if pos is not None:
         add_ghost_trajectory(server, pos, colors)
 
-        _, update_trail = add_animated_trail(server, pos, colors)
+        _, update_trail = add_animated_trail(server, pos, colors, point_size=trail_point_size)
         update_callbacks.append(update_trail)
 
         # Use position marker for point-mass, attitude frame for 6DOF

--- a/openscvx/plotting/viser/animated.py
+++ b/openscvx/plotting/viser/animated.py
@@ -425,6 +425,8 @@ def add_viewcone(
     color: tuple[int, int, int] = (35, 138, 141),  # Viridis at t~0.33 (teal)
     opacity: float = 0.4,
     wireframe: bool = False,
+    ring_only: bool = False,
+    line_width: float = 4.0,
     n_segments: int = 32,
 ) -> tuple[viser.MeshHandle | None, UpdateCallback | None]:
     """Add an animated viewcone mesh that matches p-norm constraints.
@@ -452,6 +454,9 @@ def add_viewcone(
         color: RGB color tuple
         opacity: Mesh opacity (0-1), ignored if wireframe=True
         wireframe: If True, render as wireframe instead of solid
+        ring_only: If True, render only the base ring as a closed line loop
+            instead of the full cone mesh.
+        line_width: Line width for the ring (only used when ``ring_only=True``).
         n_segments: Number of segments for cone smoothness
 
     Returns:
@@ -471,7 +476,6 @@ def add_viewcone(
         half_angle_x, half_angle_y, scale, norm_type, n_segments
     )
     n_base_verts = len(base_vertices) - 1  # Exclude apex
-    faces = _generate_viewcone_faces(n_base_verts)
 
     # Sensor-to-body rotation (transpose of body-to-sensor)
     R_sensor_to_body = R_sb.T if R_sb is not None else np.eye(3)
@@ -489,19 +493,40 @@ def add_viewcone(
         world_vertices = (R_sensor_to_world @ base_vertices.T).T + pos[frame_idx]
         return world_vertices.astype(np.float32)
 
-    # Create initial mesh
     initial_vertices = transform_vertices(0)
-    handle = server.scene.add_mesh_simple(
-        "/viewcone_mesh",
-        vertices=initial_vertices,
-        faces=faces,
-        color=color,
-        wireframe=wireframe,
-        opacity=opacity if not wireframe else 1.0,
-    )
 
-    def update(frame_idx: int) -> None:
-        handle.vertices = transform_vertices(frame_idx)
+    if ring_only:
+        # Render only the base ring as a closed line loop. Base vertices are
+        # indices 1..n_base_verts (index 0 is the apex). Build pairs of
+        # consecutive points, wrapping the last back to the first.
+        def _ring_segments(verts: np.ndarray) -> np.ndarray:
+            ring = verts[1:]  # skip apex
+            starts = ring
+            ends = np.roll(ring, -1, axis=0)
+            return np.stack([starts, ends], axis=1)  # (n_base_verts, 2, 3)
+
+        handle = server.scene.add_line_segments(
+            "/viewcone_ring",
+            points=_ring_segments(initial_vertices),
+            colors=color,
+            line_width=line_width,
+        )
+
+        def update(frame_idx: int) -> None:
+            handle.points = _ring_segments(transform_vertices(frame_idx))
+    else:
+        faces = _generate_viewcone_faces(n_base_verts)
+        handle = server.scene.add_mesh_simple(
+            "/viewcone_mesh",
+            vertices=initial_vertices,
+            faces=faces,
+            color=color,
+            wireframe=wireframe,
+            opacity=opacity if not wireframe else 1.0,
+        )
+
+        def update(frame_idx: int) -> None:
+            handle.vertices = transform_vertices(frame_idx)
 
     return handle, update
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -20,6 +20,8 @@ IGNORED_FILES = ["__init__.py", "plotting.py"]
 
 # Examples excluded from CI (e.g. exceeds runner memory)
 EXCLUDED_EXAMPLES = {
+    "animations/*.py",
+    "arm/7_dof_arm_collision.py",
     "drone/logo.py",
 }
 
@@ -87,8 +89,8 @@ def discover_examples():
         # Get relative path for naming
         rel_path = py_file.relative_to(examples_dir)
 
-        # Skip explicitly excluded examples
-        if str(rel_path) in EXCLUDED_EXAMPLES:
+        # Skip explicitly excluded examples (glob patterns, e.g. "animations/*.py")
+        if any(rel_path.match(pat) for pat in EXCLUDED_EXAMPLES):
             continue
 
         module_name = str(rel_path.with_suffix("")).replace("/", ".")


### PR DESCRIPTION
## Summary

- Adds offline mp4 rendering for four examples (`logo`, `dr_vp_polytope`, `obstacle_avoidance_vmap`, `7_dof_arm`) for use in the landing page / presentations.
- Introduces reusable render infrastructure under `examples/animations/`:
  - `_camera.py` — pure pose helpers (`chase_pose`, `onboard_pose`, `overview_pose`).
  - `_render.py` — pipes raw RGB from `client.get_render()` straight into ffmpeg; composites alpha onto viser's `dark[9]` background so frames match the live view.
  - `_sensor_view.py` — matplotlib/Agg render of the 2D camera panel, frame-aligned with the viser mp4 for side-by-side compositing.
- Adds `controls="manual"` to `create_animated_plotting_server`, returning an `AnimatedServerHandle` that exposes `step(frame_idx)` so the renderer can drive every primitive without the GUI playback loop.
- Adds `viewcone_ring_only` to `add_viewcone` for a cleaner cinematic viewcone.
- Misc: `trail_point_size` knob, time-based (not ratio-based) node-marker timing in the camera panel, boresight/intersection trails reworked as growing point clouds.
- mp4 outputs land in `examples/animations/mp4/` (gitignored).

## Usage

```bash
python examples/animations/dr_vp_polytope.py
# → prints a viser URL; open it in a browser and rendering begins automatically.
# → output: examples/animations/mp4/dr_vp_polytope_chase.mp4
```

Set `CAMERA_MODE` at the top of each script (`"chase" | "onboard" | "overview"` where applicable). Requires `ffmpeg` on `PATH` — not added as a package dependency.

> [!TIP]
> To composite the viser render with the 2D camera panel side-by-side:
> 
> ```bash
> ffmpeg -i left.mp4 -i right.mp4 -filter_complex hstack -c:v libx264 -crf 16 out.mp4
> ```
