### PR TITLE
Fix/jaxlie import

### DIFF
--- a/openscvx/init/inverse_kinematics.py
+++ b/openscvx/init/inverse_kinematics.py
@@ -22,7 +22,6 @@ from typing import Sequence, Tuple, Union
 
 import jax
 import jax.numpy as jnp
-import jaxlie
 import numpy as np
 
 from openscvx.init.interpolation import linspace, slerp
@@ -71,6 +70,7 @@ def _so3_log(R):
 @jax.jit
 def _poe_fk_pose(screw_axes, T_home, angles):
     """PoE FK returning (4, 4) end-effector transform."""
+    import jaxlie
 
     def step(T, xi_angle):
         xi, angle = xi_angle[:6], xi_angle[6]
@@ -181,6 +181,13 @@ def ik_interpolation(
                 T_home=T_home,
             )
     """
+    try:
+        import jaxlie  # noqa: F401
+    except ImportError as e:
+        raise ImportError(
+            "ik_interpolation requires jaxlie. Install with: pip install openscvx[lie]"
+        ) from e
+
     positions = [np.asarray(kf[0], dtype=np.float64) for kf in keyframes]
     quaternions = [np.asarray(kf[1], dtype=np.float64) for kf in keyframes]
 

--- a/openscvx/symbolic/expr/lie/__init__.py
+++ b/openscvx/symbolic/expr/lie/__init__.py
@@ -62,10 +62,7 @@ try:
 
     from .se3 import SE3Exp, SE3Log
     from .so3 import SO3Exp, SO3Log
-
-    _JAXLIE_AVAILABLE = True
 except ImportError:
-    _JAXLIE_AVAILABLE = False
 
     def _make_stub(name: str):
         """Create a stub class that raises ImportError on instantiation."""

--- a/openscvx/symbolic/expr/lie/__init__.py
+++ b/openscvx/symbolic/expr/lie/__init__.py
@@ -53,8 +53,13 @@ References:
 # Core operators - no dependencies
 from .adjoint import Adjoint, AdjointDual, SE3Adjoint, SE3AdjointDual
 
-# jaxlie-backed operators - optional dependency
+# jaxlie-backed operators - optional dependency.
+# These AST nodes don't import jaxlie themselves (lowering does), so we probe
+# for jaxlie explicitly to gate construction with a clear install hint instead
+# of letting users build nodes that blow up later inside the lowerer.
 try:
+    import jaxlie  # noqa: F401
+
     from .se3 import SE3Exp, SE3Log
     from .so3 import SO3Exp, SO3Log
 


### PR DESCRIPTION
- `openscvx/init/inverse_kinematics.py` no longer imports jaxlie at module top-level -> Moved into `_poe_fk_pose`'s body, with an upfront probe in `ik_interpolation` that raises a friendly pip install openscvx[lie] error -> Fixes #469
- Fixed other minor issues with `lie/__init__.py` importing