### PR TITLE
Feature/lazy variable guess initialization

### DIFF
--- a/openscvx/problem.py
+++ b/openscvx/problem.py
@@ -516,6 +516,11 @@ class Problem:
         workflows where the initial trajectory guess is updated between solves (e.g., shifting
         the previous solution).
 
+        Any state or control whose guess was set as a callable is re-resolved
+        here, so that callables which capture mutable state (e.g.
+        ``lambda tau: state.initial + ...``) reflect the current problem
+        configuration on every sync.
+
         Note:
             This only updates the unified representation. The AlgorithmState is
             created from these values in reset() or initialize(), so this must
@@ -523,6 +528,13 @@ class Problem:
         """
         if self._lowered is None:
             return
+
+        from openscvx.symbolic.preprocessing import resolve_guesses
+
+        N = self.symbolic.N
+        # Re-resolve callable guesses against the current N. States/controls
+        # whose guess is an explicit array are left untouched.
+        resolve_guesses(self.symbolic.states, self.symbolic.controls, N)
 
         # Sync optimization state guesses
         for state in self.symbolic.states:

--- a/openscvx/problem.py
+++ b/openscvx/problem.py
@@ -532,9 +532,11 @@ class Problem:
         from openscvx.symbolic.preprocessing import resolve_guesses
 
         N = self.symbolic.N
-        # Re-resolve callable guesses against the current N. States/controls
-        # whose guess is an explicit array are left untouched.
-        resolve_guesses(self.symbolic.states, self.symbolic.controls, N)
+        # Re-resolve callable guesses against the current N. ``states_prop``
+        # is a superset of ``states`` (includes propagation-only extras), so
+        # this covers opt and prop in one pass. States/controls whose guess
+        # is an explicit array are left untouched.
+        resolve_guesses(self.symbolic.states_prop, self.symbolic.controls, N)
 
         # Sync optimization state guesses
         for state in self.symbolic.states:

--- a/openscvx/symbolic/augmentation.py
+++ b/openscvx/symbolic/augmentation.py
@@ -655,29 +655,24 @@ def augment_dynamics_with_ctcs(
     else:
         time_dilation.max = np.array([3.0 * time_final])
 
-    # Use user-provided time_dilation guess if available,
-    # otherwise compute from time.guess via finite differences
-    if is_time and time_state.time_dilation_guess is not None:
+    if is_time:
+        # Contract: resolve_guesses must run before augmentation so that
+        # Time.time_dilation_guess is a concrete array by this point.
+        if time_state.time_dilation_guess is None:
+            raise ValueError(
+                "Time.time_dilation_guess is not set. Call "
+                "openscvx.symbolic.preprocessing.resolve_guesses(states, controls, N) "
+                "before augment_dynamics_with_ctcs."
+            )
         time_dilation.guess = time_state.time_dilation_guess
     else:
-        # The relationship is: dt/dtau = time_dilation, where tau is normalized time [0,1]
-        # With N nodes, dtau = 1/(N-1) between consecutive nodes
+        # Legacy path: a plain State named "time" has no time_dilation_guess
+        # attribute. Derive dt/dtau from its guess directly.
         if time_state.guess is None:
             raise ValueError("time state must have a guess set before augmentation")
+        from openscvx.symbolic.preprocessing import _finite_diff_dt_dtau
 
-        if N > 1:
-            time_guess = time_state.guess.flatten()  # Shape (N,)
-            time_dilation_guess = np.zeros(N)
-            dtau = 1.0 / (N - 1)  # Normalized time step between nodes
-            # Compute finite difference: time_dilation[k] = (time[k+1] - time[k]) / dtau
-            for k in range(N - 1):
-                time_dilation_guess[k] = (time_guess[k + 1] - time_guess[k]) / dtau
-            # For the last node, use the previous value (extrapolate)
-            time_dilation_guess[N - 1] = time_dilation_guess[N - 2]
-            time_dilation.guess = time_dilation_guess.reshape(-1, 1)
-        else:
-            # Single node case: use time_final as guess
-            time_dilation.guess = np.ones([N, 1]) * time_final
+        time_dilation.guess = _finite_diff_dt_dtau(time_state.guess.flatten(), time_final)
 
     # Store a back-reference so that later mutations to the Time object
     # (e.g. time.time_dilation_min = ...) propagate to the live control.

--- a/openscvx/symbolic/builder.py
+++ b/openscvx/symbolic/builder.py
@@ -381,6 +381,11 @@ def preprocess_symbolic_problem(
             parameters=parameters,
         )
 
+        # Resolve guesses for propagation-only states. Opt states/controls
+        # are already resolved (PHASE 1) and re-resolve idempotently; the
+        # dispatch namespace lets prop callables reference any opt variable.
+        resolve_guesses(states_prop, controls_prop, N)
+
     # ==================== PHASE 6: Apply Time-Dilation Multiplication ===========
     #
     # Multiply all dynamics by the time-dilation control symbolically.

--- a/openscvx/symbolic/builder.py
+++ b/openscvx/symbolic/builder.py
@@ -47,7 +47,7 @@ from openscvx.symbolic.expr.time import Time
 from openscvx.symbolic.preprocessing import (
     collect_and_assign_slices,
     convert_dynamics_dict_to_expr,
-    fill_default_guesses,
+    resolve_guesses,
     validate_and_normalize_constraint_nodes,
     validate_boundary_conditions,
     validate_bounds,
@@ -57,6 +57,7 @@ from openscvx.symbolic.preprocessing import (
     validate_dynamics_dimension,
     validate_guesses,
     validate_input_types,
+    validate_no_reserved_guess_names,
     validate_propagation_input_types,
     validate_shapes,
     validate_variable_names,
@@ -206,13 +207,7 @@ def preprocess_symbolic_problem(
     # Validate user-provided variables have required attributes
     validate_boundary_conditions(states)
     validate_bounds(states + controls)
-
-    # Fill in default guesses for user-provided states
-    # (augmented states get their guesses set by augmentation code)
-    fill_default_guesses(states, N)
-
-    # Validate that all user-provided variables have guesses
-    validate_guesses(states + controls)
+    validate_no_reserved_guess_names(states + controls)
 
     # ==================== PHASE 1: Time Handling ====================
 
@@ -224,9 +219,12 @@ def preprocess_symbolic_problem(
         states = list(states) + [time]
         time_state = time
 
-    # Fill in default guess if needed (for Time instances)
-    if isinstance(time_state, Time) and time_state.guess is None:
-        time_state.guess = time_state._generate_default_guess(N)
+    # Resolve callable guesses (and install defaults) now that Time is in
+    # the variable set. Must run before augmentation reads time_state.guess.
+    resolve_guesses(states, controls, N)
+
+    # Validate that all user-provided variables now have guesses
+    validate_guesses(states + controls)
 
     # Add CTCS constraints for time bounds
     from openscvx.symbolic.expr import CTCS

--- a/openscvx/symbolic/expr/control.py
+++ b/openscvx/symbolic/expr/control.py
@@ -76,11 +76,14 @@ class Control(Variable):
 
         ``.guess`` also accepts a callable ``f(variables, ...) -> array``
         resolved once the discretization size is known. Parameter names are
-        matched against the problem's states/controls; the reserved name
-        ``tau`` (a normalized ``[0, 1]`` grid of length N) is also available::
+        matched against the problem's states/controls (each parameter
+        receives the matched State/Control object — read ``.guess`` for the
+        resolved array). The reserved name ``tau`` is the one special
+        parameter, receiving a normalized ``[0, 1]`` ndarray grid of length
+        N::
 
             thrust = Control("thrust", shape=(3,))
-            thrust.guess = lambda pos: np.gradient(pos, axis=0)  # depends on pos
+            thrust.guess = lambda pos: np.gradient(pos.guess, axis=0)
     """
 
     def __init__(

--- a/openscvx/symbolic/expr/control.py
+++ b/openscvx/symbolic/expr/control.py
@@ -73,6 +73,14 @@ class Control(Variable):
             steer.min = [-1, -1]
             steer.max = [1, 1]
             steer.guess = np.linspace([0, 0], [0, 1], 50)  # Gradual acceleration
+
+        ``.guess`` also accepts a callable ``f(variables, ...) -> array``
+        resolved once the discretization size is known. Parameter names are
+        matched against the problem's states/controls; the reserved name
+        ``tau`` (a normalized ``[0, 1]`` grid of length N) is also available::
+
+            thrust = Control("thrust", shape=(3,))
+            thrust.guess = lambda pos: np.gradient(pos, axis=0)  # depends on pos
     """
 
     def __init__(

--- a/openscvx/symbolic/expr/state.py
+++ b/openscvx/symbolic/expr/state.py
@@ -199,11 +199,13 @@ class State(Variable):
         Trajectory guesses default to a linear interpolation from ``initial`` to
         ``final``. Override eagerly with an array, or lazily with a callable
         ``f(variables, ...) -> array`` whose parameter names are matched against
-        the problem's other states/controls; the reserved name ``tau`` (a
-        normalized ``[0, 1]`` grid of length N) is also available::
+        the problem's other states/controls (each parameter receives the matched
+        State/Control object — read ``.guess`` for the resolved array). The
+        reserved name ``tau`` is the one special parameter, receiving a
+        normalized ``[0, 1]`` ndarray grid of length N::
 
             vel = State("vel", (3,))
-            vel.guess = lambda pos: np.gradient(pos, axis=0)  # depends on resolved pos
+            vel.guess = lambda pos: np.gradient(pos.guess, axis=0)
     """
 
     def __init__(

--- a/openscvx/symbolic/expr/state.py
+++ b/openscvx/symbolic/expr/state.py
@@ -195,6 +195,15 @@ class State(Variable):
             pos.max = [10, 10, 200]
             pos.initial = [0, ("free", 1), 50]  # x fixed, y free, z fixed
             pos.final = [10, ("free", 5), ("maximize", 150)]  # Maximize final altitude
+
+        Trajectory guesses default to a linear interpolation from ``initial`` to
+        ``final``. Override eagerly with an array, or lazily with a callable
+        ``f(variables, ...) -> array`` whose parameter names are matched against
+        the problem's other states/controls; the reserved name ``tau`` (a
+        normalized ``[0, 1]`` grid of length N) is also available::
+
+            vel = State("vel", (3,))
+            vel.guess = lambda pos: np.gradient(pos, axis=0)  # depends on resolved pos
     """
 
     def __init__(

--- a/openscvx/symbolic/expr/time.py
+++ b/openscvx/symbolic/expr/time.py
@@ -99,10 +99,12 @@ class Time(State):
                 shape ``(N,)`` or ``(N, 1)``, or a callable
                 ``f(variables, ...) -> array`` that returns one once N is
                 known. Parameter names are matched against the problem's
-                states and controls; the reserved name ``tau`` (a normalized
-                ``[0, 1]`` grid) is also available for shape-only callables.
-                If not provided, a linear interpolation from initial to final
-                is generated.
+                states and controls (each parameter receives the matched
+                State/Control object — read ``.guess`` for the resolved
+                array). The reserved name ``tau`` is the one special
+                parameter, receiving a normalized ``[0, 1]`` ndarray grid.
+                If not provided, a linear interpolation from initial to
+                final is generated.
             time_dilation_min: Absolute minimum bound for time dilation.
                 Defaults to `0.3 * time_final` if not set.
             time_dilation_max: Absolute maximum bound for time dilation.
@@ -240,8 +242,9 @@ class Time(State):
         """Set the time dilation guess. Accepts an array of shape ``(N,)`` or
         ``(N, 1)``, or a callable ``f(variables, ...) -> array`` using the
         same name-dispatch rules as ``Variable.guess`` (parameters match the
-        problem's states/controls; the reserved name ``tau`` is the
-        normalized ``[0, 1]`` grid)."""
+        problem's states/controls and receive the matched State/Control
+        object — read ``.guess`` for the resolved array; the reserved name
+        ``tau`` is the normalized ``[0, 1]`` ndarray grid)."""
         if callable(val) and not isinstance(val, np.ndarray):
             self._time_dilation_guess_callable_params = _inspect_guess_callable(
                 val, "time_dilation_guess", "Time"
@@ -271,7 +274,7 @@ class Time(State):
         ]
 
     def _resolve_time_dilation_guess(
-        self, N: int, tau: np.ndarray, resolved_vars: Dict[str, np.ndarray]
+        self, N: int, tau: np.ndarray, resolved_vars: Dict[str, "Variable"]
     ) -> None:
         """Resolve the time-dilation guess callable, if any, into an ``(N, 1)`` array."""
         if self._time_dilation_guess_callable is None:

--- a/openscvx/symbolic/expr/time.py
+++ b/openscvx/symbolic/expr/time.py
@@ -1,10 +1,14 @@
-from typing import Any, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 from pydantic import ConfigDict, field_validator
 
 from openscvx.symbolic.expr.state import State, StateSpec
-from openscvx.symbolic.expr.variable import Variable
+from openscvx.symbolic.expr.variable import (
+    RESERVED_GUESS_PARAMS,
+    Variable,
+    _inspect_guess_callable,
+)
 
 
 class Time(State):
@@ -91,9 +95,14 @@ class Time(State):
             final: Final time. Same format as initial.
             min: Minimum time bound.
             max: Maximum time bound.
-            guess: Initial guess for the time trajectory. 1D array of shape
-                (N,) or 2D of shape (N, 1). If not provided, a linear
-                interpolation from initial to final is generated.
+            guess: Initial guess for the time trajectory. Either an array of
+                shape ``(N,)`` or ``(N, 1)``, or a callable
+                ``f(variables, ...) -> array`` that returns one once N is
+                known. Parameter names are matched against the problem's
+                states and controls; the reserved name ``tau`` (a normalized
+                ``[0, 1]`` grid) is also available for shape-only callables.
+                If not provided, a linear interpolation from initial to final
+                is generated.
             time_dilation_min: Absolute minimum bound for time dilation.
                 Defaults to `0.3 * time_final` if not set.
             time_dilation_max: Absolute maximum bound for time dilation.
@@ -110,6 +119,8 @@ class Time(State):
         self._time_dilation_min = None
         self._time_dilation_max = None
         self._time_dilation_guess = None
+        self._time_dilation_guess_callable: Optional[Callable] = None
+        self._time_dilation_guess_callable_params: Optional[List[Tuple[str, bool]]] = None
         self._time_dilation_control = None  # set by augmentation for live propagation
 
         # Wrap scalars into the array forms that State/Variable setters expect.
@@ -125,11 +136,8 @@ class Time(State):
 
         super().__init__("time", shape=(1,), min=min, max=max, initial=initial, final=final)
 
-        # guess: normalize 1D → 2D before assigning
         if guess is not None:
-            guess = np.asarray(guess, dtype=float)
-            if guess.ndim == 1:
-                guess = guess.reshape(-1, 1)
+            # The setter handles arrays (with 1D → 2D reshape) and callables uniformly.
             self.guess = guess
         if time_dilation_min is not None:
             self.time_dilation_min = time_dilation_min
@@ -167,12 +175,37 @@ class Time(State):
         State.final.fset(self, val)
 
     @Variable.guess.setter
-    def guess(self, arr):
-        """Set the time guess. Accepts 1D (N,) or 2D (N, 1) arrays."""
-        arr = np.asarray(arr, dtype=float)
+    def guess(self, val):
+        """Set the time guess. Accepts 1D ``(N,)`` or 2D ``(N, 1)`` arrays,
+        or a callable that returns either form."""
+        if callable(val) and not isinstance(val, np.ndarray):
+            Variable.guess.fset(self, val)
+            return
+        arr = np.asarray(val, dtype=float)
         if arr.ndim == 1:
             arr = arr.reshape(-1, 1)
         Variable.guess.fset(self, arr)
+
+    def _assign_guess_array(self, arr) -> None:
+        """Time accepts ``(N,)`` or ``(N, 1)`` arrays — coerce before validating."""
+        arr = np.asarray(arr, dtype=float)
+        if arr.ndim == 1:
+            arr = arr.reshape(-1, 1)
+        super()._assign_guess_array(arr)
+
+    def _install_default_guess_callable(self) -> None:
+        """Install a default ``tau``-driven linspace from initial to final time.
+
+        Called by preprocessing when the user has not supplied a guess.
+        Captures current ``_initial`` / ``_final`` by closure so a later
+        change still flows through on re-resolution.
+        """
+        time_self = self
+
+        def _default_time_guess(tau):
+            return np.linspace(time_self._initial[0], time_self._final[0], len(tau))
+
+        self.guess = _default_time_guess
 
     @property
     def time_dilation_min(self) -> Optional[float]:
@@ -203,12 +236,74 @@ class Time(State):
         return self._time_dilation_guess
 
     @time_dilation_guess.setter
-    def time_dilation_guess(self, arr):
-        arr = np.asarray(arr, dtype=float)
+    def time_dilation_guess(self, val):
+        """Set the time dilation guess. Accepts an array of shape ``(N,)`` or
+        ``(N, 1)``, or a callable ``f(variables, ...) -> array`` using the
+        same name-dispatch rules as ``Variable.guess`` (parameters match the
+        problem's states/controls; the reserved name ``tau`` is the
+        normalized ``[0, 1]`` grid)."""
+        if callable(val) and not isinstance(val, np.ndarray):
+            self._time_dilation_guess_callable_params = _inspect_guess_callable(
+                val, "time_dilation_guess", "Time"
+            )
+            self._time_dilation_guess_callable = val
+            self._time_dilation_guess = None
+            return
+
+        arr = np.asarray(val, dtype=float)
         if arr.ndim == 1:
             arr = arr.reshape(-1, 1)
         if arr.ndim != 2 or arr.shape[1] != 1:
             raise ValueError(f"time_dilation_guess expected shape (N, 1), got {arr.shape}")
+        self._time_dilation_guess = arr
+        self._time_dilation_guess_callable = None
+        self._time_dilation_guess_callable_params = None
+        self._sync_time_dilation_control()
+
+    def _time_dilation_dependencies(self) -> List[str]:
+        """State/control names that the time-dilation guess callable depends on."""
+        if self._time_dilation_guess_callable_params is None:
+            return []
+        return [
+            name
+            for name, has_default in self._time_dilation_guess_callable_params
+            if name not in RESERVED_GUESS_PARAMS and not has_default
+        ]
+
+    def _resolve_time_dilation_guess(
+        self, N: int, tau: np.ndarray, resolved_vars: Dict[str, np.ndarray]
+    ) -> None:
+        """Resolve the time-dilation guess callable, if any, into an ``(N, 1)`` array."""
+        if self._time_dilation_guess_callable is None:
+            return
+
+        kwargs: Dict[str, Any] = {}
+        for name, has_default in self._time_dilation_guess_callable_params or []:
+            if name == "tau":
+                kwargs[name] = tau
+            elif name in resolved_vars:
+                kwargs[name] = resolved_vars[name]
+            elif has_default:
+                continue
+            else:
+                raise ValueError(
+                    f"Time 'time_dilation_guess': callable parameter '{name}' is not "
+                    f"a reserved name (tau) and does not match any state or control."
+                )
+
+        try:
+            result = self._time_dilation_guess_callable(**kwargs)
+        except Exception as e:
+            raise type(e)(f"Time 'time_dilation_guess': callable raised: {e}") from e
+
+        arr = np.asarray(result, dtype=float)
+        if arr.ndim == 1:
+            arr = arr.reshape(-1, 1)
+        if arr.shape != (N, 1):
+            raise ValueError(
+                f"Time 'time_dilation_guess': callable returned shape {arr.shape}, "
+                f"expected ({N}, 1)."
+            )
         self._time_dilation_guess = arr
         self._sync_time_dilation_control()
 
@@ -223,18 +318,6 @@ class Time(State):
             ctrl.max = np.array([self._time_dilation_max])
         if self._time_dilation_guess is not None:
             ctrl.guess = self._time_dilation_guess
-
-    def _generate_default_guess(self, N: int) -> np.ndarray:
-        """Generate linear interpolation guess from initial to final time.
-
-        Args:
-            N: Number of discretization nodes.
-
-        Returns:
-            Array of shape (N, 1) with linear interpolation.
-        """
-        # _initial and _final hold the numeric values (State parses tuples)
-        return np.linspace(self._initial[0], self._final[0], N).reshape(-1, 1)
 
     def __repr__(self):
         parts = []

--- a/openscvx/symbolic/expr/variable.py
+++ b/openscvx/symbolic/expr/variable.py
@@ -278,6 +278,11 @@ class Variable(Leaf):
         validated immediately so errors point at the user's lambda rather
         than at preprocessing.
 
+        When a callable is set, the resolved array on ``.guess`` is derived
+        — it is recomputed on every solve / sync, so in-place edits won't
+        stick. Reassign ``.guess`` (with an array or a new callable) to
+        change what's used.
+
         Args:
             val: 2D array of shape ``(N, n)`` where ``n`` matches the variable
                 dimension, OR a callable returning such an array.

--- a/openscvx/symbolic/expr/variable.py
+++ b/openscvx/symbolic/expr/variable.py
@@ -1,10 +1,56 @@
 import hashlib
-from typing import List, Optional, Tuple
+import inspect
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import numpy as np
 from pydantic import BaseModel, ConfigDict
 
 from .expr import Leaf
+
+# Reserved parameter names usable in guess callables. Currently only
+# ``tau`` (normalized [0, 1] grid). Any state/control with one of these
+# names would shadow the reserved meaning; preprocessing validates that.
+RESERVED_GUESS_PARAMS: frozenset = frozenset({"tau"})
+
+
+def _inspect_guess_callable(fn: Callable, owner_name: str, owner_class: str):
+    """Inspect a guess callable's signature, rejecting unsupported forms.
+
+    Returns the list of (name, has_default) tuples for parameters the
+    dispatcher will try to fill in. Errors are raised eagerly at assignment
+    time so they point at the user's callable, not at preprocessing.
+    """
+    try:
+        sig = inspect.signature(fn)
+    except (TypeError, ValueError) as e:
+        raise ValueError(
+            f"{owner_class} '{owner_name}': could not introspect guess callable "
+            f"signature ({e}). If you used a decorator, ensure it preserves the "
+            "wrapped signature (e.g. functools.wraps)."
+        ) from e
+
+    params: List[Tuple[str, bool]] = []
+    for name, p in sig.parameters.items():
+        if p.kind is inspect.Parameter.VAR_POSITIONAL:
+            raise ValueError(
+                f"{owner_class} '{owner_name}': guess callable uses '*{name}', which "
+                "is incompatible with name-based dispatch. Declare each parameter "
+                "explicitly."
+            )
+        if p.kind is inspect.Parameter.VAR_KEYWORD:
+            raise ValueError(
+                f"{owner_class} '{owner_name}': guess callable uses '**{name}', which "
+                "is incompatible with name-based dispatch. Declare each parameter "
+                "explicitly."
+            )
+        if p.kind is inspect.Parameter.POSITIONAL_ONLY:
+            raise ValueError(
+                f"{owner_class} '{owner_name}': guess callable parameter '{name}' is "
+                "positional-only; the dispatcher calls by keyword. Remove the '/' "
+                "marker or rewrite as a regular parameter."
+            )
+        params.append((name, p.default is not inspect.Parameter.empty))
+    return params
 
 
 class Variable(Leaf):
@@ -51,6 +97,8 @@ class Variable(Leaf):
         self._min = None
         self._max = None
         self._guess = None
+        self._guess_callable: Optional[Callable] = None
+        self._guess_callable_params: Optional[List[Tuple[str, bool]]] = None
 
     def __repr__(self) -> str:
         return f"Var({self.name!r})"
@@ -207,27 +255,60 @@ class Variable(Leaf):
         return self._guess
 
     @guess.setter
-    def guess(self, arr):
+    def guess(self, val):
         """Set the initial guess for the variable trajectory.
 
-        The guess should be a 2D array where each row represents the variable value
-        at a particular time point or trajectory node.
+        Accepts either:
+
+        - A 2D array of shape ``(N, n)`` — assigned directly.
+        - A callable ``f(variables, ...) -> array``, deferred until the
+          discretization size is known. Each parameter name is dispatched
+          against the other states and controls in the problem (so e.g.
+          ``lambda pos: np.gradient(pos, axis=0)`` declares "this guess
+          depends on the resolved ``pos`` guess"). The reserved name
+          ``tau`` is the one special parameter — it receives a normalized
+          ``[0, 1]`` grid of length N for shape-only callables that don't
+          reference any other variable. Resolution happens inside problem
+          build / sync, so the array form of ``.guess`` reads back as
+          ``None`` until then.
+
+        Assigning either form clears the other. Callable signatures are
+        validated immediately so errors point at the user's lambda rather
+        than at preprocessing.
 
         Args:
-            arr: 2D array of shape (n_points, n_vars) where n_vars matches the
-                variable dimension. Can be fewer points than the final trajectory -
-                the solver will interpolate as needed.
+            val: 2D array of shape ``(N, n)`` where ``n`` matches the variable
+                dimension, OR a callable returning such an array.
 
         Raises:
-            ValueError: If the array is not 2D or if the second dimension doesn't
-                match the variable dimension
+            ValueError: If the array is not 2D, the second dimension doesn't
+                match the variable dimension, or the callable signature uses
+                ``*args`` / ``**kwargs`` / positional-only parameters.
 
         Example:
                 pos = Variable("pos", shape=(3,))
-                # Create a straight-line trajectory from origin to target
-                n_points = 50
-                pos.guess = np.linspace([0, 0, 0], [10, 5, 3], n_points)
+                # Eager array form
+                pos.guess = np.linspace([0, 0, 0], [10, 5, 3], 50)
+                # Lazy form referencing another state
+                vel = Variable("vel", shape=(3,))
+                vel.guess = lambda pos: np.gradient(pos, axis=0)
+                # Lazy form using the reserved tau grid (no cross-var dep)
+                pos.guess = lambda tau: np.outer(tau, [10, 5, 3])
         """
+        if callable(val) and not isinstance(val, np.ndarray):
+            self._guess_callable_params = _inspect_guess_callable(
+                val, self.name, self.__class__.__name__
+            )
+            self._guess_callable = val
+            self._guess = None
+            return
+
+        self._assign_guess_array(val)
+        self._guess_callable = None
+        self._guess_callable_params = None
+
+    def _assign_guess_array(self, arr) -> None:
+        """Validate and store an explicit guess array. Shared by setter and resolver."""
         arr = np.asarray(arr, dtype=float)
         if arr.ndim != 2:
             raise ValueError(
@@ -240,6 +321,62 @@ class Variable(Leaf):
                 f" {self.shape[0]}, got {arr.shape[1]}"
             )
         self._guess = arr
+
+    def _guess_dependencies(self) -> List[str]:
+        """Names this variable's guess callable depends on, excluding reserved
+        names and parameters with defaults. Empty if no callable is set.
+        """
+        if self._guess_callable_params is None:
+            return []
+        return [
+            name
+            for name, has_default in self._guess_callable_params
+            if name not in RESERVED_GUESS_PARAMS and not has_default
+        ]
+
+    def _resolve_guess(self, N: int, tau: np.ndarray, resolved_vars: Dict[str, np.ndarray]) -> None:
+        """Resolve a deferred guess callable into a concrete ``(N, n)`` array.
+
+        No-op if no callable was registered (an explicit array stays in place).
+        Dispatches parameters by name: ``tau`` gets the normalized grid, names
+        matching known states/controls get their resolved guess arrays. Params
+        with defaults are skipped permissively when no match is found.
+        """
+        if self._guess_callable is None:
+            return
+
+        kwargs: Dict[str, Any] = {}
+        for name, has_default in self._guess_callable_params or []:
+            if name == "tau":
+                kwargs[name] = tau
+            elif name in resolved_vars:
+                kwargs[name] = resolved_vars[name]
+            elif has_default:
+                continue
+            else:
+                raise ValueError(
+                    f"{self.__class__.__name__} '{self.name}': guess callable parameter "
+                    f"'{name}' is not a reserved name (tau) and does not match any "
+                    f"state or control in the problem."
+                )
+
+        try:
+            result = self._guess_callable(**kwargs)
+        except Exception as e:
+            raise type(e)(
+                f"{self.__class__.__name__} '{self.name}': guess callable raised: {e}"
+            ) from e
+
+        arr = np.asarray(result, dtype=float)
+        # Subclasses (e.g. Time) may override array shape coercion; route
+        # through the same helper they use for the array path.
+        try:
+            self._assign_guess_array(arr)
+        except ValueError as e:
+            raise ValueError(
+                f"{self.__class__.__name__} '{self.name}': guess callable returned shape "
+                f"{arr.shape}, expected ({N}, {self.shape[0]})."
+            ) from e
 
     def append(
         self,

--- a/openscvx/symbolic/expr/variable.py
+++ b/openscvx/symbolic/expr/variable.py
@@ -265,14 +265,16 @@ class Variable(Leaf):
         - A 2D array of shape ``(N, n)`` — assigned directly.
         - A callable ``f(variables, ...) -> array``, deferred until the
           discretization size is known. Each parameter name is dispatched
-          against the other states and controls in the problem (so e.g.
-          ``lambda pos: np.gradient(pos, axis=0)`` declares "this guess
-          depends on the resolved ``pos`` guess"). The reserved name
+          against the other states and controls in the problem and receives
+          the **State/Control object itself**, so the callable reads
+          ``.guess`` to access the resolved array (e.g.
+          ``lambda pos: np.gradient(pos.guess, axis=0)`` declares "this
+          guess depends on the resolved ``pos`` guess"). The reserved name
           ``tau`` is the one special parameter — it receives a normalized
-          ``[0, 1]`` grid of length N for shape-only callables that don't
-          reference any other variable. Resolution happens inside problem
-          build / sync, so the array form of ``.guess`` reads back as
-          ``None`` until then.
+          ``[0, 1]`` ndarray grid of length N for shape-only callables that
+          don't reference any other variable. Resolution happens inside
+          problem build / sync, so the array form of ``.guess`` reads back
+          as ``None`` until then.
 
         Assigning either form clears the other. Callable signatures are
         validated immediately so errors point at the user's lambda rather
@@ -296,9 +298,10 @@ class Variable(Leaf):
                 pos = Variable("pos", shape=(3,))
                 # Eager array form
                 pos.guess = np.linspace([0, 0, 0], [10, 5, 3], 50)
-                # Lazy form referencing another state
+                # Lazy form referencing another state — pos is the State
+                # object; read pos.guess for the resolved array
                 vel = Variable("vel", shape=(3,))
-                vel.guess = lambda pos: np.gradient(pos, axis=0)
+                vel.guess = lambda pos: np.gradient(pos.guess, axis=0)
                 # Lazy form using the reserved tau grid (no cross-var dep)
                 pos.guess = lambda tau: np.outer(tau, [10, 5, 3])
         """
@@ -341,13 +344,14 @@ class Variable(Leaf):
             if name not in RESERVED_GUESS_PARAMS and not has_default
         ]
 
-    def _resolve_guess(self, N: int, tau: np.ndarray, resolved_vars: Dict[str, np.ndarray]) -> None:
+    def _resolve_guess(self, N: int, tau: np.ndarray, resolved_vars: Dict[str, "Variable"]) -> None:
         """Resolve a deferred guess callable into a concrete ``(N, n)`` array.
 
         No-op if no callable was registered (an explicit array stays in place).
         Dispatches parameters by name: ``tau`` gets the normalized grid, names
-        matching known states/controls get their resolved guess arrays. Params
-        with defaults are skipped permissively when no match is found.
+        matching known states/controls get the Variable object itself (the
+        callable reads ``.guess`` to access the resolved array). Params with
+        defaults are skipped permissively when no match is found.
         """
         if self._guess_callable is None:
             return

--- a/openscvx/symbolic/expr/variable.py
+++ b/openscvx/symbolic/expr/variable.py
@@ -237,14 +237,16 @@ class Variable(Leaf):
 
     @property
     def guess(self) -> Optional[np.ndarray]:
-        """Get the initial guess for the variable trajectory.
+        """Get the resolved initial guess for the variable trajectory.
 
         The guess provides a starting point for the optimizer. A good initial guess
         can significantly improve convergence speed and help avoid local minima.
 
         Returns:
-            2D array of shape (n_points, n_vars) representing the variable trajectory
-            over time, or None if no guess is provided.
+            2D array of shape ``(N, n)`` representing the variable trajectory,
+            or ``None`` if no guess has been set, or if a callable was assigned
+            but has not yet been resolved (resolution happens during problem
+            build and on each ``Problem.sync`` / ``solve`` / ``reset``).
 
         Example:
                 x = Variable("x", shape=(2,))

--- a/openscvx/symbolic/preprocessing.py
+++ b/openscvx/symbolic/preprocessing.py
@@ -699,6 +699,36 @@ def _install_default_state_guess(state: State) -> None:
     state.guess = _default_state_guess
 
 
+def _finite_diff_dt_dtau(time_arr: np.ndarray, time_final: float) -> np.ndarray:
+    """Compute dt/dtau as an ``(N, 1)`` array from a 1D ``time`` trajectory.
+
+    Forward differences with the last node copied from its neighbor. Falls
+    back to ``time_final`` for the degenerate single-node case.
+    """
+    n = len(time_arr)
+    if n <= 1:
+        return np.full((n, 1), float(time_final))
+    dtau = 1.0 / (n - 1)
+    td = np.empty(n)
+    td[:-1] = (time_arr[1:] - time_arr[:-1]) / dtau
+    td[-1] = td[-2]
+    return td.reshape(-1, 1)
+
+
+def _install_default_time_dilation_guess(time_state) -> None:
+    """Install a default ``time_dilation_guess`` derived from ``time.guess``.
+
+    Captures ``time_state`` by closure so a later re-resolve (e.g. after
+    ``time.initial`` is mutated and ``time.guess`` re-resolves) re-derives
+    a consistent dt/dtau seed.
+    """
+
+    def _default_time_dilation_guess(tau, _t=time_state):
+        return _finite_diff_dt_dtau(_t._guess.flatten(), _t._final[0])
+
+    time_state.time_dilation_guess = _default_time_dilation_guess
+
+
 def validate_no_reserved_guess_names(variables: List[Variable]) -> None:
     """Ensure no state/control name shadows a reserved guess-callable parameter.
 
@@ -802,10 +832,16 @@ def resolve_guesses(states: List[State], controls: List["Control"], N: int) -> N
             f"One of these variables transitively references itself."
         )
 
-    # 5. Resolve Time's deferred time_dilation_guess callable, if present.
+    # 5. Resolve Time's deferred time_dilation_guess callable. If neither an
+    # array nor a callable was supplied, install a default that
+    # finite-differences ``time.guess`` (captured by closure so re-resolves
+    # track mutations to ``time.guess``).
     for state in states:
-        if isinstance(state, Time):
-            state._resolve_time_dilation_guess(N, tau, resolved_vars)
+        if not isinstance(state, Time):
+            continue
+        if state._time_dilation_guess is None and state._time_dilation_guess_callable is None:
+            _install_default_time_dilation_guess(state)
+        state._resolve_time_dilation_guess(N, tau, resolved_vars)
 
 
 def validate_boundary_conditions(states: List[State]) -> None:

--- a/openscvx/symbolic/preprocessing.py
+++ b/openscvx/symbolic/preprocessing.py
@@ -683,28 +683,129 @@ def convert_dynamics_dict_to_expr(
     return dynamics_converted, dynamics_concat
 
 
-def fill_default_guesses(states: List[State], N: int) -> None:
-    """Fill in default linspace guesses for states with guess=None.
+def _install_default_state_guess(state: State) -> None:
+    """Install a ``tau``-driven linspace from ``state.initial`` to ``state.final``.
 
-    For states with both initial and final conditions set, generates a linear
-    interpolation from initial to final values.
+    Used as the fallback when the user supplied neither an array nor a callable
+    guess but did supply both boundary conditions. Captures the boundary values
+    by closure so that re-resolution after a boundary mutation picks up the new
+    values automatically.
+    """
+    init = np.asarray(state.initial, dtype=float).copy()
+    final = np.asarray(state.final, dtype=float).copy()
 
-    This function modifies states in-place.
+    def _default_state_guess(tau, _init=init, _final=final):
+        return np.linspace(_init, _final, len(tau))
+
+    state.guess = _default_state_guess
+
+
+def validate_no_reserved_guess_names(variables: List[Variable]) -> None:
+    """Ensure no state/control name shadows a reserved guess-callable parameter.
+
+    Raises:
+        ValueError: if any variable's name collides with a reserved name like ``tau``.
+    """
+    from openscvx.symbolic.expr.variable import RESERVED_GUESS_PARAMS
+
+    for var in variables:
+        if var.name in RESERVED_GUESS_PARAMS:
+            raise ValueError(
+                f"{type(var).__name__} '{var.name}' shadows a reserved guess-callable "
+                f"parameter name. Reserved names: {sorted(RESERVED_GUESS_PARAMS)}. "
+                f"Rename the {type(var).__name__.lower()}."
+            )
+
+
+def resolve_guesses(states: List[State], controls: List["Control"], N: int) -> None:
+    """Resolve all callable guesses on states and controls into concrete arrays.
+
+    Installs default callables for states with boundary conditions but no guess,
+    then runs a topological sort over the variables whose guesses are deferred
+    callables and resolves them in dependency order. Cross-variable references
+    in callables (e.g. ``lambda time: ...``) are dispatched by parameter name;
+    the reserved name ``tau`` receives a normalized ``[0, 1]`` grid of length N.
+
+    Variables already holding an explicit array are treated as pre-resolved.
+
+    For Time, a deferred ``time_dilation_guess`` callable is also resolved here
+    so that downstream augmentation reads a concrete array.
 
     Args:
-        states: List of State objects to fill guesses for
-        N: Number of discretization nodes
-    """
-    from openscvx.init import linspace
+        states: All state variables (including Time, which may already be in the list).
+        controls: All control variables.
+        N: Number of discretization nodes.
 
+    Raises:
+        ValueError: on cycle detection, missing dependencies, or shape mismatches.
+    """
+    from openscvx.symbolic.expr.time import Time
+
+    tau = np.linspace(0.0, 1.0, N)
+    all_vars: List[Variable] = list(states) + list(controls)
+
+    # 1. Install fallback default callables.
     for state in states:
-        if state.guess is None and state.initial is not None and state.final is not None:
-            # state.initial and state.final are already numpy arrays of values
-            # (the setter handles parsing tuples like ("free", value))
-            state.guess = linspace(
-                keyframes=[state.initial, state.final],
-                nodes=[0, N - 1],
+        if state.guess is None and state._guess_callable is None:
+            if isinstance(state, Time):
+                state._install_default_guess_callable()
+            elif state.initial is not None and state.final is not None:
+                _install_default_state_guess(state)
+
+    # 2. Bucket variables. Pre-resolved (array) entries seed the resolved map;
+    # the rest go into the dependency graph.
+    name_to_var: Dict[str, Variable] = {v.name: v for v in all_vars}
+    resolved_vars: Dict[str, np.ndarray] = {}
+    pending: List[Variable] = []
+    for v in all_vars:
+        if v._guess_callable is None:
+            if v._guess is not None:
+                resolved_vars[v.name] = v._guess
+        else:
+            pending.append(v)
+
+    pending_names = {v.name for v in pending}
+    # Edges: pending var → set of pending dependency names.
+    # (Deps that are already resolved or are unknown-but-defaulted don't block.)
+    blockers: Dict[str, Set[str]] = {}
+    for v in pending:
+        deps = v._guess_dependencies()
+        unknown = [d for d in deps if d not in name_to_var]
+        if unknown:
+            raise ValueError(
+                f"{type(v).__name__} '{v.name}': guess callable parameter "
+                f"{unknown[0]!r} is not a reserved name (tau) and does not match "
+                f"any state or control in the problem."
             )
+        blockers[v.name] = {d for d in deps if d in pending_names}
+
+    # 3. Kahn's algorithm.
+    ready = [v for v in pending if not blockers[v.name]]
+    resolved_pending: Set[str] = set()
+    while ready:
+        v = ready.pop()
+        v._resolve_guess(N, tau, resolved_vars)
+        resolved_vars[v.name] = v._guess
+        resolved_pending.add(v.name)
+        for other in pending:
+            if other.name in resolved_pending or other in ready:
+                continue
+            blockers[other.name].discard(v.name)
+            if not blockers[other.name]:
+                ready.append(other)
+
+    # 4. Anything still pending is part of a cycle.
+    cycle = [v.name for v in pending if v.name not in resolved_pending]
+    if cycle:
+        raise ValueError(
+            f"Cycle detected in guess-callable dependencies: {cycle}. "
+            f"One of these variables transitively references itself."
+        )
+
+    # 5. Resolve Time's deferred time_dilation_guess callable, if present.
+    for state in states:
+        if isinstance(state, Time):
+            state._resolve_time_dilation_guess(N, tau, resolved_vars)
 
 
 def validate_boundary_conditions(states: List[State]) -> None:

--- a/openscvx/symbolic/preprocessing.py
+++ b/openscvx/symbolic/preprocessing.py
@@ -699,6 +699,21 @@ def _install_default_state_guess(state: State) -> None:
     state.guess = _default_state_guess
 
 
+def _install_default_prop_guess(state: State) -> None:
+    """Broadcast ``state.initial`` across N nodes.
+
+    Fallback for propagation-only states (e.g. distance, fuel) that have an
+    ``initial`` but no ``final`` — there's no meaningful endpoint to linspace
+    to, so we just hold ``initial`` constant. Captured by closure so mutations
+    to ``initial`` flow through on re-resolution.
+    """
+
+    def _default_prop_guess(tau, _state=state):
+        return np.tile(_state.initial, (len(tau), 1))
+
+    state.guess = _default_prop_guess
+
+
 def _finite_diff_dt_dtau(time_arr: np.ndarray, time_final: float) -> np.ndarray:
     """Compute dt/dtau as an ``(N, 1)`` array from a 1D ``time`` trajectory.
 
@@ -780,6 +795,9 @@ def resolve_guesses(states: List[State], controls: List["Control"], N: int) -> N
                 state._install_default_guess_callable()
             elif state.initial is not None and state.final is not None:
                 _install_default_state_guess(state)
+            elif state.initial is not None:
+                # Propagation-style accumulator (initial only, no final).
+                _install_default_prop_guess(state)
 
     # 2. Bucket variables. Pre-resolved entries seed the resolved map with the
     # Variable itself (so callables receive State/Control objects and access

--- a/openscvx/symbolic/preprocessing.py
+++ b/openscvx/symbolic/preprocessing.py
@@ -751,15 +751,16 @@ def resolve_guesses(states: List[State], controls: List["Control"], N: int) -> N
             elif state.initial is not None and state.final is not None:
                 _install_default_state_guess(state)
 
-    # 2. Bucket variables. Pre-resolved (array) entries seed the resolved map;
-    # the rest go into the dependency graph.
+    # 2. Bucket variables. Pre-resolved entries seed the resolved map with the
+    # Variable itself (so callables receive State/Control objects and access
+    # ``.guess`` explicitly); the rest go into the dependency graph.
     name_to_var: Dict[str, Variable] = {v.name: v for v in all_vars}
-    resolved_vars: Dict[str, np.ndarray] = {}
+    resolved_vars: Dict[str, Variable] = {}
     pending: List[Variable] = []
     for v in all_vars:
         if v._guess_callable is None:
             if v._guess is not None:
-                resolved_vars[v.name] = v._guess
+                resolved_vars[v.name] = v
         else:
             pending.append(v)
 
@@ -784,7 +785,7 @@ def resolve_guesses(states: List[State], controls: List["Control"], N: int) -> N
     while ready:
         v = ready.pop()
         v._resolve_guess(N, tau, resolved_vars)
-        resolved_vars[v.name] = v._guess
+        resolved_vars[v.name] = v
         resolved_pending.add(v.name)
         for other in pending:
             if other.name in resolved_pending or other in ready:

--- a/openscvx/symbolic/preprocessing.py
+++ b/openscvx/symbolic/preprocessing.py
@@ -687,15 +687,14 @@ def _install_default_state_guess(state: State) -> None:
     """Install a ``tau``-driven linspace from ``state.initial`` to ``state.final``.
 
     Used as the fallback when the user supplied neither an array nor a callable
-    guess but did supply both boundary conditions. Captures the boundary values
-    by closure so that re-resolution after a boundary mutation picks up the new
-    values automatically.
+    guess but did supply both boundary conditions. Captures the State object
+    itself (not snapshotted values) so that mutations to ``initial``/``final``
+    between solves — e.g. MPC-style warm-starts — flow through on the next
+    re-resolution.
     """
-    init = np.asarray(state.initial, dtype=float).copy()
-    final = np.asarray(state.final, dtype=float).copy()
 
-    def _default_state_guess(tau, _init=init, _final=final):
-        return np.linspace(_init, _final, len(tau))
+    def _default_state_guess(tau, _state=state):
+        return np.linspace(_state.initial, _state.final, len(tau))
 
     state.guess = _default_state_guess
 

--- a/tests/symbolic/expr/test_guess_callable.py
+++ b/tests/symbolic/expr/test_guess_callable.py
@@ -312,6 +312,90 @@ def test_time_dilation_default_tracks_time_guess_on_re_resolve():
 
 
 # ===========================================================================
+# Propagation-only state guesses
+# ===========================================================================
+
+
+def test_prop_state_default_broadcast_initial():
+    """A propagation-style state (initial only, no final) gets a default
+    that broadcasts initial across N — no explicit guess needed."""
+    N = 6
+    distance = State("distance", shape=(1,))
+    distance.initial = np.array([0.0])
+
+    resolve_guesses([distance], [], N)
+
+    assert distance.guess.shape == (N, 1)
+    np.testing.assert_array_equal(distance.guess, np.zeros((N, 1)))
+
+
+def test_prop_state_callable_referencing_opt_state():
+    """A propagation-only state can reference an optimization state via the
+    dispatch namespace when both are passed to resolve_guesses together."""
+    N = 5
+    pos = State("pos", shape=(1,))
+    pos.initial = [0.0]
+    pos.final = [10.0]
+
+    energy = State("energy", shape=(1,))
+    energy.initial = np.array([0.0])
+    energy.guess = lambda pos: pos.guess**2
+
+    resolve_guesses([pos, energy], [], N)
+
+    np.testing.assert_array_almost_equal(
+        energy.guess.flatten(),
+        np.linspace(0.0, 10.0, N) ** 2,
+    )
+
+
+def test_prop_state_callable_through_full_problem():
+    """End-to-end: a propagation-only state with a callable guess resolves
+    correctly through Problem build (covers the PHASE-5 resolve_guesses call)."""
+    import openscvx as ox
+
+    N = 8
+
+    pos = ox.State("pos", shape=(1,))
+    pos.min = np.array([-10.0])
+    pos.max = np.array([10.0])
+    pos.initial = np.array([0.0])
+    pos.final = np.array([5.0])
+
+    u = ox.Control("u", shape=(1,))
+    u.min = np.array([-1.0])
+    u.max = np.array([1.0])
+    u.guess = np.zeros((N, 1))
+
+    # Propagation-only state with a lambda referencing pos.
+    distance = ox.State("distance", shape=(1,))
+    distance.initial = np.array([0.0])
+    distance.min = np.array([0.0])
+    distance.max = np.array([100.0])
+    distance.guess = lambda pos: np.abs(pos.guess)
+
+    time = ox.Time(initial=0.0, final=10.0, min=0.0, max=20.0)
+
+    problem = ox.Problem(
+        dynamics={"pos": u},
+        dynamics_prop={"distance": u},
+        states=[pos],
+        states_prop=[distance],
+        controls=[u],
+        time=time,
+        constraints=[],
+        N=N,
+    )
+
+    distance_state = next(s for s in problem.symbolic.states_prop if s.name == "distance")
+    assert distance_state.guess.shape == (N, 1)
+    np.testing.assert_array_almost_equal(
+        distance_state.guess.flatten(),
+        np.abs(np.linspace(0.0, 5.0, N)),
+    )
+
+
+# ===========================================================================
 # End-to-end: Problem build with callable guesses
 # ===========================================================================
 

--- a/tests/symbolic/expr/test_guess_callable.py
+++ b/tests/symbolic/expr/test_guess_callable.py
@@ -192,6 +192,28 @@ def test_callable_reflects_mutated_state_on_re_resolve():
     np.testing.assert_array_almost_equal(pos.guess[0], [5.0])
 
 
+def test_default_state_guess_reflects_mutated_initial_final():
+    """The fallback default callable (installed when the user provides neither
+    an array nor a callable) must read State.initial/final live, so that an
+    MPC-style mutation between solves shows up on the next resolve."""
+    N = 5
+    pos = State("pos", shape=(2,))
+    pos.initial = [0.0, 0.0]
+    pos.final = [10.0, 10.0]
+    # No explicit guess — fallback default callable will be installed.
+
+    resolve_guesses([pos], [], N)
+    np.testing.assert_array_almost_equal(pos.guess[0], [0.0, 0.0])
+    np.testing.assert_array_almost_equal(pos.guess[-1], [10.0, 10.0])
+
+    pos.initial = [2.0, 2.0]
+    pos.final = [12.0, 12.0]
+    resolve_guesses([pos], [], N)
+
+    np.testing.assert_array_almost_equal(pos.guess[0], [2.0, 2.0])
+    np.testing.assert_array_almost_equal(pos.guess[-1], [12.0, 12.0])
+
+
 # ===========================================================================
 # User-wrapped ox.init.linspace via lambda
 # ===========================================================================

--- a/tests/symbolic/expr/test_guess_callable.py
+++ b/tests/symbolic/expr/test_guess_callable.py
@@ -290,6 +290,27 @@ def test_time_dilation_callable_guess():
     np.testing.assert_array_almost_equal(t.time_dilation_guess.flatten(), 8.0 * np.ones(N))
 
 
+def test_time_dilation_default_tracks_time_guess_on_re_resolve():
+    """No user-supplied time_dilation_guess: resolve_guesses installs a default
+    that finite-differences time.guess. After mutating time.final and
+    re-resolving, the derived time-dilation must reflect the new slope."""
+    N = 5
+    t = Time(initial=0.0, final=10.0, min=0.0, max=20.0)
+    assert t.time_dilation_guess is None
+
+    resolve_guesses([t], [], N)
+
+    # Default time.guess is linspace(0, 10, N), so dt/dtau = 10 across the grid.
+    assert t.time_dilation_guess.shape == (N, 1)
+    np.testing.assert_array_almost_equal(t.time_dilation_guess.flatten(), np.full(N, 10.0))
+
+    # MPC-style mutation: shrink the horizon.
+    t.final = 4.0
+    resolve_guesses([t], [], N)
+
+    np.testing.assert_array_almost_equal(t.time_dilation_guess.flatten(), np.full(N, 4.0))
+
+
 # ===========================================================================
 # End-to-end: Problem build with callable guesses
 # ===========================================================================

--- a/tests/symbolic/expr/test_guess_callable.py
+++ b/tests/symbolic/expr/test_guess_callable.py
@@ -1,0 +1,318 @@
+"""Tests for callable (deferred) guess specification on Variable / State / Control / Time."""
+
+import numpy as np
+import pytest
+
+from openscvx.symbolic.expr.control import Control
+from openscvx.symbolic.expr.state import State
+from openscvx.symbolic.expr.time import Time
+from openscvx.symbolic.preprocessing import resolve_guesses
+
+# ===========================================================================
+# Setter behavior
+# ===========================================================================
+
+
+def test_callable_setter_stores_callable_clears_array():
+    x = State("x", shape=(2,))
+    x.initial = [0.0, 0.0]
+    x.final = [1.0, 1.0]
+    x.guess = np.zeros((5, 2))  # explicit array first
+    assert x.guess is not None
+
+    x.guess = lambda tau: np.outer(tau, [1.0, 1.0])
+
+    assert x._guess_callable is not None
+    assert x._guess is None  # array path cleared
+
+
+def test_array_setter_clears_prior_callable():
+    """Bug guard: if a callable was assigned, then later an array, the array must stick."""
+    x = State("x", shape=(1,))
+    x.initial = [0.0]
+    x.final = [1.0]
+
+    x.guess = lambda tau: tau.reshape(-1, 1)
+    explicit = np.linspace(0.0, 1.0, 7).reshape(-1, 1) * 99.0
+    x.guess = explicit
+
+    assert x._guess_callable is None
+    np.testing.assert_array_equal(x.guess, explicit)
+
+    # Re-running resolution must not overwrite the explicit array.
+    resolve_guesses([x], [], 7)
+    np.testing.assert_array_equal(x.guess, explicit)
+
+
+# ===========================================================================
+# Eager signature validation at assignment time
+# ===========================================================================
+
+
+def test_callable_with_var_args_rejected_eagerly():
+    x = State("x", shape=(1,))
+    with pytest.raises(ValueError, match=r"\*args|VAR_POSITIONAL|\*"):
+        x.guess = lambda *args: np.zeros((5, 1))
+
+
+def test_callable_with_var_kwargs_rejected_eagerly():
+    x = State("x", shape=(1,))
+    with pytest.raises(ValueError, match=r"\*\*"):
+        x.guess = lambda **kwargs: np.zeros((5, 1))
+
+
+def test_callable_with_positional_only_rejected_eagerly():
+    x = State("x", shape=(1,))
+
+    def bad(tau, /):  # positional-only
+        return tau.reshape(-1, 1)
+
+    with pytest.raises(ValueError, match="positional-only"):
+        x.guess = bad
+
+
+# ===========================================================================
+# Reserved-name (tau) dispatch
+# ===========================================================================
+
+
+def test_resolve_uses_tau_grid():
+    N = 11
+    x = State("x", shape=(2,))
+    x.initial = [0.0, 0.0]
+    x.final = [1.0, 1.0]
+    x.guess = lambda tau: np.outer(tau, [10.0, 20.0])
+
+    resolve_guesses([x], [], N)
+
+    assert x.guess.shape == (N, 2)
+    np.testing.assert_array_almost_equal(x.guess[0], [0.0, 0.0])
+    np.testing.assert_array_almost_equal(x.guess[-1], [10.0, 20.0])
+    np.testing.assert_array_almost_equal(x.guess[N // 2], [5.0, 10.0])
+
+
+def test_control_callable_resolves():
+    N = 8
+    u = Control("u", shape=(2,))
+    u.guess = lambda tau: np.tile([0.5, -0.5], (len(tau), 1))
+
+    resolve_guesses([], [u], N)
+
+    assert u.guess.shape == (N, 2)
+    np.testing.assert_array_equal(u.guess[0], [0.5, -0.5])
+
+
+# ===========================================================================
+# Cross-variable references
+# ===========================================================================
+
+
+def test_cross_var_dependency_resolves_in_order():
+    """A guess that names another variable receives that variable's resolved array."""
+    N = 6
+    pos = State("pos", shape=(1,))
+    pos.initial = [0.0]
+    pos.final = [10.0]
+    # No explicit guess on pos -> default callable installed by resolver.
+
+    vel = State("vel", shape=(1,))
+    vel.initial = [0.0]
+    vel.final = [0.0]
+    # vel is finite-difference of pos
+    vel.guess = lambda pos: np.gradient(pos.flatten()).reshape(-1, 1)
+
+    resolve_guesses([pos, vel], [], N)
+
+    expected_pos = np.linspace(0.0, 10.0, N).reshape(-1, 1)
+    np.testing.assert_array_almost_equal(pos.guess, expected_pos)
+    np.testing.assert_array_almost_equal(
+        vel.guess.flatten(),
+        np.gradient(expected_pos.flatten()),
+    )
+
+
+def test_unknown_dependency_name_raises():
+    N = 5
+    x = State("x", shape=(1,))
+    x.guess = lambda velocity: velocity  # no such state
+
+    with pytest.raises(ValueError, match=r"velocity"):
+        resolve_guesses([x], [], N)
+
+
+def test_default_argument_skipped_permissively():
+    """A param with a default that matches no reserved/var name is left at its default."""
+    N = 4
+    x = State("x", shape=(1,))
+    x.guess = lambda tau, scale=3.0: scale * tau.reshape(-1, 1)
+
+    resolve_guesses([x], [], N)
+
+    assert x.guess.shape == (N, 1)
+    np.testing.assert_array_almost_equal(x.guess.flatten(), 3.0 * np.linspace(0.0, 1.0, N))
+
+
+# ===========================================================================
+# Cycle detection
+# ===========================================================================
+
+
+def test_cycle_detected_with_named_vars():
+    N = 5
+    a = State("a", shape=(1,))
+    b = State("b", shape=(1,))
+    a.guess = lambda b: b
+    b.guess = lambda a: a
+
+    with pytest.raises(ValueError, match="Cycle detected"):
+        resolve_guesses([a, b], [], N)
+
+
+# ===========================================================================
+# Live MPC re-evaluation
+# ===========================================================================
+
+
+def test_callable_reflects_mutated_state_on_re_resolve():
+    """A closure capturing state.initial picks up new values on re-resolve."""
+    N = 5
+    pos = State("pos", shape=(1,))
+    pos.initial = [0.0]
+    pos.final = [10.0]
+    pos.guess = lambda tau, _self=pos: np.linspace(
+        _self.initial[0], _self.final[0], len(tau)
+    ).reshape(-1, 1)
+
+    resolve_guesses([pos], [], N)
+    np.testing.assert_array_almost_equal(pos.guess[0], [0.0])
+
+    pos.initial = [5.0]  # MPC-style mutation
+    # Re-resolve must reflect new initial.
+    pos._resolve_guess(N, np.linspace(0, 1, N), {})
+    np.testing.assert_array_almost_equal(pos.guess[0], [5.0])
+
+
+# ===========================================================================
+# User-wrapped ox.init.linspace via lambda
+# ===========================================================================
+
+
+def test_user_wrapped_linspace():
+    """The Phase-1 'wrap an ox.init helper in a lambda' pattern works under dispatch."""
+    from openscvx.init import linspace
+
+    N = 9
+    x = State("x", shape=(2,))
+    x.guess = lambda tau: linspace(
+        keyframes=[np.zeros(2), np.array([5.0, -5.0])],
+        nodes=[0, len(tau) - 1],
+    )
+
+    resolve_guesses([x], [], N)
+
+    assert x.guess.shape == (N, 2)
+    np.testing.assert_array_almost_equal(x.guess[0], [0.0, 0.0])
+    np.testing.assert_array_almost_equal(x.guess[-1], [5.0, -5.0])
+
+
+# ===========================================================================
+# Reserved name (tau) cannot be a state/control name
+# ===========================================================================
+
+
+def test_state_named_tau_rejected_at_validation():
+    from openscvx.symbolic.preprocessing import validate_no_reserved_guess_names
+
+    bad = State("tau", shape=(1,))
+    with pytest.raises(ValueError, match="reserved"):
+        validate_no_reserved_guess_names([bad])
+
+
+# ===========================================================================
+# Time integration
+# ===========================================================================
+
+
+def test_time_callable_guess():
+    N = 7
+    t = Time(initial=0.0, final=20.0, min=0.0, max=30.0)
+    t.guess = lambda tau: 20.0 * tau  # 1D, will be auto-reshaped
+
+    resolve_guesses([t], [], N)
+
+    assert t.guess.shape == (N, 1)
+    np.testing.assert_array_almost_equal(t.guess[0], [0.0])
+    np.testing.assert_array_almost_equal(t.guess[-1], [20.0])
+
+
+def test_time_default_when_no_guess_set():
+    """Time with no guess gets a tau-driven default linspace via resolve_guesses."""
+    N = 5
+    t = Time(initial=2.0, final=12.0, min=0.0, max=20.0)
+    assert t.guess is None
+
+    resolve_guesses([t], [], N)
+
+    np.testing.assert_array_almost_equal(t.guess.flatten(), np.linspace(2.0, 12.0, N))
+
+
+def test_time_dilation_callable_guess():
+    N = 6
+    t = Time(initial=0.0, final=10.0, min=0.0, max=20.0)
+    t.time_dilation_guess = lambda tau: 8.0 * np.ones_like(tau)
+
+    resolve_guesses([t], [], N)
+
+    assert t.time_dilation_guess.shape == (N, 1)
+    np.testing.assert_array_almost_equal(t.time_dilation_guess.flatten(), 8.0 * np.ones(N))
+
+
+# ===========================================================================
+# End-to-end: Problem build with callable guesses
+# ===========================================================================
+
+
+def test_problem_builds_with_callable_guesses():
+    """Building a full Problem with callable guesses on state, control, and time
+    must succeed and produce concrete arrays everywhere downstream code reads them."""
+    import openscvx as ox
+
+    N = 10
+
+    pos = ox.State("pos", shape=(2,))
+    pos.min = np.array([-10.0, -10.0])
+    pos.max = np.array([10.0, 10.0])
+    pos.initial = np.array([0.0, 0.0])
+    pos.final = np.array([5.0, 5.0])
+    # Lazy state guess via tau (no init+final default needed)
+    pos.guess = lambda tau: np.outer(tau, [5.0, 5.0])
+
+    vel = ox.Control("vel", shape=(2,))
+    vel.min = np.array([-2.0, -2.0])
+    vel.max = np.array([2.0, 2.0])
+    # Cross-variable dispatch: depend on the resolved pos guess.
+    vel.guess = lambda pos: np.gradient(pos, axis=0)
+
+    time = ox.Time(
+        initial=0.0,
+        final=("minimize", 5.0),
+        min=0.0,
+        max=10.0,
+        guess=lambda tau: 5.0 * tau,
+    )
+
+    problem = ox.Problem(
+        dynamics={"pos": vel},
+        states=[pos],
+        controls=[vel],
+        time=time,
+        constraints=[],
+        N=N,
+    )
+
+    assert pos.guess is not None and pos.guess.shape == (N, 2)
+    assert vel.guess is not None and vel.guess.shape == (N, 2)
+    time_state = next(s for s in problem.symbolic.states if s.name == "time")
+    assert time_state.guess.shape == (N, 1)
+    np.testing.assert_array_almost_equal(time_state.guess[0], [0.0])
+    np.testing.assert_array_almost_equal(time_state.guess[-1], [5.0])

--- a/tests/symbolic/expr/test_guess_callable.py
+++ b/tests/symbolic/expr/test_guess_callable.py
@@ -108,7 +108,8 @@ def test_control_callable_resolves():
 
 
 def test_cross_var_dependency_resolves_in_order():
-    """A guess that names another variable receives that variable's resolved array."""
+    """A guess that names another variable receives that variable (State/Control)
+    object — the callable reads ``.guess`` to access the resolved array."""
     N = 6
     pos = State("pos", shape=(1,))
     pos.initial = [0.0]
@@ -119,7 +120,7 @@ def test_cross_var_dependency_resolves_in_order():
     vel.initial = [0.0]
     vel.final = [0.0]
     # vel is finite-difference of pos
-    vel.guess = lambda pos: np.gradient(pos.flatten()).reshape(-1, 1)
+    vel.guess = lambda pos: np.gradient(pos.guess.flatten()).reshape(-1, 1)
 
     resolve_guesses([pos, vel], [], N)
 
@@ -161,8 +162,8 @@ def test_cycle_detected_with_named_vars():
     N = 5
     a = State("a", shape=(1,))
     b = State("b", shape=(1,))
-    a.guess = lambda b: b
-    b.guess = lambda a: a
+    a.guess = lambda b: b.guess
+    b.guess = lambda a: a.guess
 
     with pytest.raises(ValueError, match="Cycle detected"):
         resolve_guesses([a, b], [], N)
@@ -312,8 +313,8 @@ def test_problem_builds_with_callable_guesses():
     vel = ox.Control("vel", shape=(2,))
     vel.min = np.array([-2.0, -2.0])
     vel.max = np.array([2.0, 2.0])
-    # Cross-variable dispatch: depend on the resolved pos guess.
-    vel.guess = lambda pos: np.gradient(pos, axis=0)
+    # Cross-variable dispatch: pos is the State; read pos.guess for the array.
+    vel.guess = lambda pos: np.gradient(pos.guess, axis=0)
 
     time = ox.Time(
         initial=0.0,

--- a/tests/symbolic/expr/test_variable.py
+++ b/tests/symbolic/expr/test_variable.py
@@ -729,14 +729,14 @@ def test_time_guess_setter():
 
 
 def test_time_guess_overrides_default():
-    """Test that user-provided guess prevents _generate_default_guess."""
+    """Test that an explicit user-provided guess survives default-callable installation."""
 
     from openscvx import Time
 
     custom_guess = np.array([0, 2, 5, 8, 10]).reshape(-1, 1)
     t = Time(initial=0.0, final=10.0, min=0.0, max=20.0, guess=custom_guess)
-    # guess is already set, so _generate_default_guess should not be needed
     assert np.allclose(t.guess, custom_guess)
+    assert t._guess_callable is None
 
 
 # --- Time: Time Dilation ---

--- a/tests/symbolic/test_augmentation.py
+++ b/tests/symbolic/test_augmentation.py
@@ -1002,6 +1002,7 @@ def test_time_dilation_overrides_from_time_object():
 def test_time_dilation_partial_override():
     """Test that partial overrides work (e.g. only min, not max)."""
     from openscvx.symbolic.expr.time import Time
+    from openscvx.symbolic.preprocessing import resolve_guesses
 
     time = Time(initial=0.0, final=10.0, min=0.0, max=20.0)
     time.guess = np.linspace(0, 10, 5).reshape(-1, 1)
@@ -1016,6 +1017,7 @@ def test_time_dilation_partial_override():
 
     constraint = ctcs(x[0] <= 1.0, penalty="squared_relu")
 
+    resolve_guesses(states, controls, N)
     _, _, _, controls_aug = augment_dynamics_with_ctcs(
         xdot,
         states,
@@ -1032,6 +1034,7 @@ def test_time_dilation_partial_override():
 def test_time_dilation_live_propagation():
     """Test that mutating Time.time_dilation_* after augmentation propagates to the control."""
     from openscvx.symbolic.expr.time import Time
+    from openscvx.symbolic.preprocessing import resolve_guesses
 
     time = Time(initial=0.0, final=10.0, min=0.0, max=20.0)
     time.guess = np.linspace(0, 10, 5).reshape(-1, 1)
@@ -1043,6 +1046,7 @@ def test_time_dilation_live_propagation():
 
     constraint = ctcs(x[0] <= 1.0, penalty="squared_relu")
 
+    resolve_guesses(states, [], N)
     _, _, _, controls_aug = augment_dynamics_with_ctcs(
         x,
         states,

--- a/tests/symbolic/test_preprocessing.py
+++ b/tests/symbolic/test_preprocessing.py
@@ -13,7 +13,7 @@ from openscvx.symbolic.expr import (
 from openscvx.symbolic.preprocessing import (
     collect_and_assign_slices,
     convert_dynamics_dict_to_expr,
-    fill_default_guesses,
+    resolve_guesses,
     validate_boundary_conditions,
     validate_bounds,
     validate_constraints_at_root,
@@ -817,30 +817,28 @@ def test_cross_node_constraint_both_sides():
 
 
 # =============================================================================
-# fill_default_guesses Tests
+# resolve_guesses Tests (default-callable installation path)
 # =============================================================================
 
 
-def test_fill_default_guesses_state_linspace():
+def test_resolve_guesses_state_linspace():
     """Test that state guesses are filled with linspace from initial to final."""
     N = 11  # Use 11 so middle index (5) is exactly at midpoint
     x = State("x", shape=(3,))
     x.initial = np.array([0.0, 1.0, 2.0])
     x.final = np.array([10.0, 11.0, 12.0])
 
-    fill_default_guesses([x], N)
+    resolve_guesses([x], [], N)
 
     assert x.guess is not None
     assert x.guess.shape == (N, 3)
-    # Check first and last rows match initial and final
     np.testing.assert_array_almost_equal(x.guess[0], [0.0, 1.0, 2.0])
     np.testing.assert_array_almost_equal(x.guess[-1], [10.0, 11.0, 12.0])
-    # Check it's actually a linspace (middle index should be exactly at midpoint)
     np.testing.assert_array_almost_equal(x.guess[N // 2], [5.0, 6.0, 7.0])
 
 
-def test_fill_default_guesses_preserves_existing():
-    """Test that existing guesses are not overwritten."""
+def test_resolve_guesses_preserves_existing_array():
+    """An explicitly assigned array guess survives resolution untouched."""
     N = 10
     x = State("x", shape=(2,))
     x.initial = np.array([0.0, 0.0])
@@ -848,31 +846,28 @@ def test_fill_default_guesses_preserves_existing():
     custom_guess = np.ones((N, 2)) * 99.0
     x.guess = custom_guess
 
-    fill_default_guesses([x], N)
+    resolve_guesses([x], [], N)
 
-    # Guess should be unchanged
     np.testing.assert_array_equal(x.guess, custom_guess)
 
 
-def test_fill_default_guesses_with_free_boundary_conditions():
-    """Test that states with free boundary conditions use the guess values."""
+def test_resolve_guesses_with_free_boundary_conditions():
+    """Free boundary conditions still seed the linspace from their guess values."""
     N = 10
     x = State("x", shape=(3,))
-    # Mixed: first fixed, second free, third fixed
     x.initial = [0.0, ("free", 5.0), 2.0]
     x.final = [10.0, ("free", 15.0), 12.0]
 
-    fill_default_guesses([x], N)
+    resolve_guesses([x], [], N)
 
     assert x.guess is not None
     assert x.guess.shape == (N, 3)
-    # The setter extracts values from tuples, so initial=[0, 5, 2], final=[10, 15, 12]
     np.testing.assert_array_almost_equal(x.guess[0], [0.0, 5.0, 2.0])
     np.testing.assert_array_almost_equal(x.guess[-1], [10.0, 15.0, 12.0])
 
 
-def test_fill_default_guesses_multiple_states():
-    """Test filling guesses for multiple states at once."""
+def test_resolve_guesses_multiple_states():
+    """Resolve default callables for several states in one pass."""
     N = 5
     x1 = State("x1", shape=(2,))
     x1.initial = np.array([0.0, 0.0])
@@ -882,14 +877,12 @@ def test_fill_default_guesses_multiple_states():
     x2.initial = np.array([10.0])
     x2.final = np.array([20.0])
 
-    fill_default_guesses([x1, x2], N)
+    resolve_guesses([x1, x2], [], N)
 
-    # Check x1
     assert x1.guess.shape == (N, 2)
     np.testing.assert_array_almost_equal(x1.guess[0], [0.0, 0.0])
     np.testing.assert_array_almost_equal(x1.guess[-1], [4.0, 8.0])
 
-    # Check x2
     assert x2.guess.shape == (N, 1)
     np.testing.assert_array_almost_equal(x2.guess[0], [10.0])
     np.testing.assert_array_almost_equal(x2.guess[-1], [20.0])

--- a/tests/test_brachistochrone.py
+++ b/tests/test_brachistochrone.py
@@ -873,7 +873,7 @@ def test_propagation():
     controls = [theta]
 
     # Define propagation-only state for tracking total distance traveled
-    # Note: propagation states need explicit guesses since fill_default_guesses
+    # Note: propagation states need explicit guesses since resolve_guesses
     # only runs on main optimization states
     distance = ox.State("distance", shape=(1,))
     distance.initial = np.array([0.0])

--- a/tests/test_brachistochrone.py
+++ b/tests/test_brachistochrone.py
@@ -872,14 +872,13 @@ def test_propagation():
     states = [position, velocity]
     controls = [theta]
 
-    # Define propagation-only state for tracking total distance traveled
-    # Note: propagation states need explicit guesses since resolve_guesses
-    # only runs on main optimization states
+    # Define propagation-only state for tracking total distance traveled.
+    # No explicit guess needed — resolve_guesses installs a broadcast-initial
+    # default for accumulator-style states (initial only, no final).
     distance = ox.State("distance", shape=(1,))
     distance.initial = np.array([0.0])
     distance.min = np.array([0.0])
     distance.max = np.array([100.0])
-    distance.guess = np.zeros((n, 1))
 
     # Extra propagation states: only the NEW states, not optimization states
     states_prop_extra = [distance]


### PR DESCRIPTION
## Summary

- `.guess` continues to accept arrays for the common case — the existing eager form is unchanged. Callables are an additive opt-in for cases that need lazy evaluation: N-agnostic problem definitions, cross-variable dependencies, or MPC warm-starts. Fixes #473
- When provided, callable parameter names dispatch automatically:
  - The reserved name `tau` receives a normalized `[0, 1]` grid of length `N`
  - Any other parameter is matched against a state/control in the problem and receives that `Variable` (read `.guess` for the resolved array).
- Resolution is topo-sorted with cycle detection, runs in `resolve_guesses(states, controls, N)` before augmentation, and re-runs on every `Problem.sync` / `solve` / `reset` — closures over `state.initial` reflect mutations live.
- Fallback defaults (linear `initial→final` for states with both, broadcast `initial` for propagation-only accumulators, finite-difference dt/dtau for `time_dilation_guess`) are themselves callables — one resolution mechanism, no separate code path.
- Callable signatures are inspected eagerly at assignment, so `*args` / `**kwargs` / positional-only get rejected pointing at the user's lambda, not at preprocessing.

## Usage

Arrays still work exactly as before — most users won't need to change anything:

```python
pos.guess = np.linspace([0, 0, 0], [10, 5, 2], N)
```

The lazy form is there when you need it. Distribution-driven time guess — e.g. cosine clustering at the endpoints for a hypersensitive problem (see #472):

```python
time = ox.Time(
    initial=0.0,
    final=1000.0,
    min=0.0,
    max=1000.0,
    time_dilation_min=1e-4,
    time_dilation_max=1e4,
    guess=lambda tau: 1000.0 * 0.5 * (1.0 - np.cos(np.pi * tau)),
)
```

No `time_dilation_guess` needed — the default closure finite-differences `time.guess` on every resolve.

Cross-variable guesses dispatched by parameter name:

```python
pos = ox.State("pos", shape=(3,))
pos.initial = [0.0, 0.0, 0.0]
pos.final   = [10.0, 5.0, 2.0]
# Shape-only: tau is the normalized [0, 1] grid of length N.
pos.guess   = lambda tau: np.outer(tau, [10.0, 5.0, 2.0])

vel = ox.State("vel", shape=(3,))
# Cross-var: `pos` is the State object, resolved before `vel`. Read .guess for the array.
vel.guess   = lambda pos: np.gradient(pos.guess, axis=0)

thrust = ox.Control("thrust", shape=(3,))
# Multi-var: F = m * dv/dt — `time` is the Time state, dispatched the same way.
thrust.guess = lambda vel, time: m * np.gradient(vel.guess, time.guess[:, 0], axis=0)
```

MPC warm-start — closure captures the State, so mutating `pos.initial` between solves flows through automatically:

```python
pos.guess = lambda tau, _self=pos: np.linspace(
    _self.initial, _self.final, len(tau)
)

# Between solves:
pos.initial = measured_state
problem.sync()   # re-resolves pos.guess against the new initial
```

## Out of scope

- YAML/dict serialization of callables (`VariableSpec` / `TimeSpec` still accept arrays only).
