### PR TITLE
block xla caching in init until ready

### DIFF
--- a/examples/abstract/brachistochrone.py
+++ b/examples/abstract/brachistochrone.py
@@ -88,7 +88,7 @@ problem = Problem(
     algorithm={
         "autotuner": "ConstantProximalWeight",
         "lam_prox": 1e0,
-        "lam_cost": 1e-1,
+        "lam_cost": 6e-1,
         # Tighter SCP stopping: reduces platform-dependent early exit vs analytical cycloid
         "ep_tr": 1e-5,
         "ep_vb": 1e-5,

--- a/examples/abstract/brachistochrone.py
+++ b/examples/abstract/brachistochrone.py
@@ -89,10 +89,24 @@ problem = Problem(
         "autotuner": "ConstantProximalWeight",
         "lam_prox": 1e0,
         "lam_cost": 1e-1,
+        # Tighter SCP stopping: reduces platform-dependent early exit vs analytical cycloid
+        "ep_tr": 1e-5,
+        "ep_vb": 1e-5,
+        "ep_vc": 1e-9,
+    },
+    solver={
+        "solver_args": {
+            "enforce_dpp": True,
+            "abstol": 1e-8,
+            "reltol": 1e-10,
+            },
     },
 )
 
-problem.settings.prp.dt = 0.01
+# Dense output grid + tight IVP tolerances for trajectory vs analytical validation
+problem.settings.prp.dt = 0.005
+problem.settings.prp.atol = 1e-8
+problem.settings.prp.rtol = 1e-10
 
 plotting_dict = {}
 

--- a/examples/abstract/brachistochrone.py
+++ b/examples/abstract/brachistochrone.py
@@ -99,7 +99,7 @@ problem = Problem(
             "enforce_dpp": True,
             "abstol": 1e-8,
             "reltol": 1e-10,
-            },
+        },
     },
 )
 

--- a/examples/abstract/brachistochrone.py
+++ b/examples/abstract/brachistochrone.py
@@ -29,7 +29,7 @@ from examples.plotting import (
 from openscvx import Problem
 
 n = 2
-total_time = 2.0
+total_time = 1.9
 g = 9.81
 
 # Define state components
@@ -102,11 +102,6 @@ problem = Problem(
             },
     },
 )
-
-# Dense output grid + tight IVP tolerances for trajectory vs analytical validation
-problem.settings.prp.dt = 0.005
-problem.settings.prp.atol = 1e-8
-problem.settings.prp.rtol = 1e-10
 
 plotting_dict = {}
 

--- a/examples/abstract/brachistochrone.py
+++ b/examples/abstract/brachistochrone.py
@@ -84,6 +84,7 @@ problem = Problem(
     time=time,
     constraints=constraint_exprs,
     N=n,
+    float_dtype="float64",
     algorithm={
         "autotuner": "ConstantProximalWeight",
         "lam_prox": 1e0,

--- a/examples/abstract/brachistochrone.py
+++ b/examples/abstract/brachistochrone.py
@@ -29,7 +29,7 @@ from examples.plotting import (
 from openscvx import Problem
 
 n = 2
-total_time = 1.9
+total_time = 2.0
 g = 9.81
 
 # Define state components
@@ -84,7 +84,6 @@ problem = Problem(
     time=time,
     constraints=constraint_exprs,
     N=n,
-    licq_max=1e-8,
     algorithm={
         "autotuner": "ConstantProximalWeight",
         "lam_prox": 1e0,

--- a/examples/rocket/6DoF_pdg.py
+++ b/examples/rocket/6DoF_pdg.py
@@ -218,6 +218,11 @@ problem = Problem(
     discretizer={
         "diffrax_kwargs": {"stepsize_controller": dfx.StepTo(np.linspace(0.0, 1 / (n - 1), 3))}
     },
+    solver={
+        "cvxpygen": True,
+        "cvx_solver": "qocogen",
+        "solver_args": {},
+    }
 )
 
 problem.settings.dev.printing = False

--- a/examples/rocket/6DoF_pdg.py
+++ b/examples/rocket/6DoF_pdg.py
@@ -4,11 +4,6 @@
 
 This example was adapted from the SCvxGEN repository by Abhi Kamath, https://scvxgen.mintlify.app/introduction.
 """
-
-import jax
-
-jax.config.update("jax_enable_x64", True)
-
 import os
 import sys
 
@@ -28,34 +23,30 @@ from openscvx import Problem
 
 n = 5
 
-# Runtime-updatable constants (see problem.parameters["name"] after building the problem)
-gI = ox.Parameter("gI", value=1.0)
-l_arm = ox.Parameter("l", value=0.25)
-J_diag = ox.Parameter(
-    "J_diag",
-    shape=(3,),
-    value=np.array([0.168 * 2e-2, 0.168, 0.168]),
-)
+# Fixed physical and scenario constants
+gI = 1.0
+l_arm = 0.25
+J_diag = np.array([0.168 * 2e-2, 0.168, 0.168])
 J_mat = ox.Diag(J_diag)
 J_inv_mat = ox.Inv(ox.Diag(J_diag))
-g0 = ox.Parameter("g0", value=1.0)
-Isp = ox.Parameter("Isp", value=30.0)
-m_dry = ox.Parameter("m_dry", value=1.0)
-v_max = ox.Parameter("v_max", value=3.0)
-w_max = ox.Parameter("w_max", value=0.3752)
-del_max = ox.Parameter("del_max", value=20.0)
-theta_max = ox.Parameter("theta_max", value=75.0)
-T_min = ox.Parameter("T_min", value=1.5)
-T_max = ox.Parameter("T_max", value=6.5)
-gamma = ox.Parameter("gamma", value=75.0)
-beta = ox.Parameter("beta", value=0.01)
-c_ax = ox.Parameter("c_ax", value=0.5)
-c_ayz = ox.Parameter("c_ayz", value=1.0)
-S_a = ox.Parameter("S_a", value=0.5)
-rho = ox.Parameter("rho", value=1.0)
-l_p = ox.Parameter("l_p", value=0.05)
-initial_position = ox.Parameter("initial_position", shape=(3,), value=np.array([7.5, 4.5, 2.5]))
-final_position = ox.Parameter("final_position", shape=(2,), value=np.array([0.0, 0.0]))
+g0 = 1.0
+Isp = 30.0
+m_dry = 1.0
+v_max = 3.0
+w_max = 0.3752
+del_max = 20.0
+theta_max = 75.0
+T_min = 1.5
+T_max = 6.5
+gamma = 75.0
+beta = 0.01
+c_ax = 0.5
+c_ayz = 1.0
+S_a = 0.5
+rho = 1.0
+l_p = 0.05
+initial_position = np.array([7.5, 4.5, 2.5])
+final_position = np.array([0.0, 0.0])
 
 # Concat (not Stack): JAX lowering stacks scalars as (3,1); Diag needs a length-3 vector (3,).
 CA = ox.Diag(ox.Concat(c_ax, c_ayz, c_ayz))
@@ -72,15 +63,15 @@ position = ox.State("position", shape=(3,))
 position.max = [10.0, 10.0, 10.0]
 position.min = [-10.0, -10.0, -10.0]
 position.initial = [
-    ox.Free(float(initial_position.value[0])),
-    ox.Free(float(initial_position.value[1])),
-    ox.Free(float(initial_position.value[2])),
+    ox.Free(float(initial_position[0])),
+    ox.Free(float(initial_position[1])),
+    ox.Free(float(initial_position[2])),
 ]
 position.final = [ox.Free(0.0), ox.Free(0.0), 0.0]
 
 velocity = ox.State("velocity", shape=(3,))
-velocity.max = [v_max.value, v_max.value, v_max.value]
-velocity.min = [-v_max.value, -v_max.value, -v_max.value]
+velocity.max = [v_max, v_max, v_max]
+velocity.min = [-v_max, -v_max, -v_max]
 velocity.initial = [-0.5, -2.8, 0.0]
 velocity.final = [-0.1, 0.0, 0.0]
 
@@ -91,17 +82,17 @@ attitude.initial = [ox.Free(0.0), ox.Free(0.0), ox.Free(0.0), ox.Free(1.0)]
 attitude.final = [0.0, 0.0, 0.0, 1.0]
 
 angular_velocity = ox.State("angular_velocity", shape=(3,))
-angular_velocity.max = [w_max.value, w_max.value, w_max.value]
-angular_velocity.min = [-w_max.value, -w_max.value, -w_max.value]
+angular_velocity.max = [w_max, w_max, w_max]
+angular_velocity.min = [-w_max, -w_max, -w_max]
 angular_velocity.initial = [1e-8, 0.0, 0.0]
 angular_velocity.final = [1e-8, 0.0, 0.0]
 
 thrust = ox.Control("thrust", shape=(3,))
-thrust.max = [T_max.value, T_max.value, T_max.value]
-thrust.min = [-T_max.value, -T_max.value, -T_max.value]
+thrust.max = [T_max, T_max, T_max]
+thrust.min = [-T_max, -T_max, -T_max]
 thrust.guess = np.linspace(
-    np.array([gI.value * mass.initial[0], 0, 0]),
-    np.array([gI.value * m_dry.value, 0, 0]),
+    np.array([gI * mass.initial[0], 0, 0]),
+    np.array([gI * m_dry, 0, 0]),
     n,
 ).reshape(-1, 3)
 
@@ -169,15 +160,15 @@ constraint_exprs.append((position[0:2] == final_position).convex().at([n - 1]))
 
 constraint_exprs.append(ox.ctcs(1.0 * (mass - m_dry) >= 0))
 constraint_exprs.append(
-    ox.ctcs(0.1 * ox.linalg.Norm(position[1:]) - ox.Tan(gamma * np.pi / 180.0) * position[0] <= 0)
+    ox.ctcs(0.1 * ox.linalg.Norm(position[1:]) - ox.Tan(ox.Constant(np.array(gamma * np.pi / 180.0))) * position[0] <= 0)
 )
 constraint_exprs.append(ox.ctcs(0.1 * ox.linalg.Norm(velocity) ** 2 - v_max**2 <= 0))
 constraint_exprs.append(
-    ox.ctcs(1.0 * ox.Cos(theta_max * np.pi / 180.0) - 1.0 + 2.0 * (q2**2 + q3**2) <= 0)
+    ox.ctcs(1.0 * ox.Cos(ox.Constant(np.array(theta_max * np.pi / 180.0))) - 1.0 + 2.0 * (q2**2 + q3**2) <= 0)
 )
 constraint_exprs.append(ox.ctcs(1.0 * ox.linalg.Norm(angular_velocity) ** 2 - w_max**2 <= 0))
 constraint_exprs.append(
-    ox.ctcs(0.1 * ox.linalg.Norm(thrust) - thrust[0] / ox.Cos(del_max * np.pi / 180.0) <= 0)
+    ox.ctcs(0.1 * ox.linalg.Norm(thrust) - thrust[0] / ox.Cos(ox.Constant(np.array(del_max * np.pi / 180.0))) <= 0)
 )
 constraint_exprs.append(ox.ctcs(0.1 * ox.linalg.Norm(thrust) ** 2 - T_max**2 <= 0))
 constraint_exprs.append(ox.ctcs(0.1 * T_min**2 - ox.linalg.Norm(thrust) ** 2 <= 0))
@@ -193,6 +184,9 @@ time = ox.Time(
     time_dilation_min=0.2 * t_final_guess,
     time_dilation_max=2.0 * t_final_guess,
 )
+
+# Please ignore this for linting
+import diffrax as dfx # noqa: F401
 
 problem = Problem(
     N=n,
@@ -210,10 +204,10 @@ problem = Problem(
         "ep_tr": 5e-3,
         "ep_vc": 1e-6,
     },
+    discretizer={"diffrax_kwargs": {"stepsize_controller": dfx.StepTo(np.linspace(0.0, 1/(n-1), 3))}},
 )
 
-problem.solver.solver_args = {"abstol": 1e-7, "reltol": 1e-7}
-
+problem.settings.dev.printing = False
 
 if __name__ == "__main__":
     problem.initialize()

--- a/examples/rocket/6DoF_pdg.py
+++ b/examples/rocket/6DoF_pdg.py
@@ -4,6 +4,7 @@
 
 This example was adapted from the SCvxGEN repository by Abhi Kamath, https://scvxgen.mintlify.app/introduction.
 """
+
 import os
 import sys
 
@@ -160,15 +161,26 @@ constraint_exprs.append((position[0:2] == final_position).convex().at([n - 1]))
 
 constraint_exprs.append(ox.ctcs(1.0 * (mass - m_dry) >= 0))
 constraint_exprs.append(
-    ox.ctcs(0.1 * ox.linalg.Norm(position[1:]) - ox.Tan(ox.Constant(np.array(gamma * np.pi / 180.0))) * position[0] <= 0)
+    ox.ctcs(
+        0.1 * ox.linalg.Norm(position[1:])
+        - ox.Tan(ox.Constant(np.array(gamma * np.pi / 180.0))) * position[0]
+        <= 0
+    )
 )
 constraint_exprs.append(ox.ctcs(0.1 * ox.linalg.Norm(velocity) ** 2 - v_max**2 <= 0))
 constraint_exprs.append(
-    ox.ctcs(1.0 * ox.Cos(ox.Constant(np.array(theta_max * np.pi / 180.0))) - 1.0 + 2.0 * (q2**2 + q3**2) <= 0)
+    ox.ctcs(
+        1.0 * ox.Cos(ox.Constant(np.array(theta_max * np.pi / 180.0))) - 1.0 + 2.0 * (q2**2 + q3**2)
+        <= 0
+    )
 )
 constraint_exprs.append(ox.ctcs(1.0 * ox.linalg.Norm(angular_velocity) ** 2 - w_max**2 <= 0))
 constraint_exprs.append(
-    ox.ctcs(0.1 * ox.linalg.Norm(thrust) - thrust[0] / ox.Cos(ox.Constant(np.array(del_max * np.pi / 180.0))) <= 0)
+    ox.ctcs(
+        0.1 * ox.linalg.Norm(thrust)
+        - thrust[0] / ox.Cos(ox.Constant(np.array(del_max * np.pi / 180.0)))
+        <= 0
+    )
 )
 constraint_exprs.append(ox.ctcs(0.1 * ox.linalg.Norm(thrust) ** 2 - T_max**2 <= 0))
 constraint_exprs.append(ox.ctcs(0.1 * T_min**2 - ox.linalg.Norm(thrust) ** 2 <= 0))
@@ -185,8 +197,7 @@ time = ox.Time(
     time_dilation_max=2.0 * t_final_guess,
 )
 
-# Please ignore this for linting
-import diffrax as dfx # noqa: F401
+import diffrax as dfx  # noqa: F401
 
 problem = Problem(
     N=n,
@@ -204,7 +215,9 @@ problem = Problem(
         "ep_tr": 5e-3,
         "ep_vc": 1e-6,
     },
-    discretizer={"diffrax_kwargs": {"stepsize_controller": dfx.StepTo(np.linspace(0.0, 1/(n-1), 3))}},
+    discretizer={
+        "diffrax_kwargs": {"stepsize_controller": dfx.StepTo(np.linspace(0.0, 1 / (n - 1), 3))}
+    },
 )
 
 problem.settings.dev.printing = False

--- a/examples/rocket/6DoF_pdg.py
+++ b/examples/rocket/6DoF_pdg.py
@@ -222,7 +222,7 @@ problem = Problem(
         "cvxpygen": True,
         "cvx_solver": "qocogen",
         "solver_args": {},
-    }
+    },
 )
 
 problem.settings.dev.printing = False

--- a/openscvx/algorithms/penalized_trust_region.py
+++ b/openscvx/algorithms/penalized_trust_region.py
@@ -6,8 +6,9 @@ optimization problems through iterative convex approximation.
 
 import time
 import warnings
-from typing import TYPE_CHECKING, Callable, Dict, List, Union
+from typing import TYPE_CHECKING, Callable, Dict, List, Tuple, Union
 
+import jax
 import numpy as np
 import numpy.linalg as la
 
@@ -188,6 +189,15 @@ class PenalizedTrustRegion(Algorithm):
             return solver.call(*args)
         return solver(*args)
 
+    @staticmethod
+    def _block_until_ready_outputs(outputs: Tuple[object, ...]) -> None:
+        """Finish any pending XLA work from discretization exports (warm-up helper)."""
+        try:
+            jax.block_until_ready(outputs)
+        except (TypeError, ValueError):
+            # Non-JAX leaves (e.g. pure NumPy); nothing to wait on.
+            pass
+
     def _recover_prior_node_from_initial(
         self,
         settings: Config,
@@ -286,7 +296,8 @@ class PenalizedTrustRegion(Algorithm):
         """Initialize PTR algorithm.
 
         Stores compiled infrastructure and performs a warm-start solve to
-        initialize DPP and JAX jacobians.
+        initialize DPP and JAX jacobians. Also runs post-subproblem discretization
+        on the throwaway CVX solution so XLA/export caches match the first ``step()``.
 
         Args:
             solver: Convex subproblem solver (e.g., CVXPySolver)
@@ -333,7 +344,41 @@ class PenalizedTrustRegion(Algorithm):
                 params,
             )
             init_state.add_impulsive_discretization(W_multi_shoot.__array__())
-        _ = self._subproblem(params, init_state, settings)
+        (
+            x_sol,
+            u_sol,
+            _costs,
+            _result_cost,
+            _J_vb_vec,
+            _J_vc_vec,
+            _J_tr_vec,
+            _prob_stat,
+            _subprop_time,
+            _vc_mat,
+            _tr_mat,
+        ) = self._subproblem(params, init_state, settings)
+
+        # Prime the same exported discretization calls used after every subproblem in
+        # step() (candidate trajectory). initialize() previously only discretized the
+        # initial guess, so the first step() in solve() could still hit an XLA cache_miss
+        # on post-CVX (x_sol, u_sol). Running that path here moves compilation into init.
+        cont_out = self._invoke_solver(
+            self._discretization_solver, x_sol, u_sol.astype(float), params
+        )
+        x_prop_c = cont_out[3]
+        u_candidate = u_sol.astype(float)
+        x0_prior_c = self._recover_prior_node_from_initial(settings, x_sol[0])
+        x_nodes_prior_c = np.vstack((x0_prior_c, np.asarray(x_prop_c)))
+        if self._discretization_solver_impulsive is not None:
+            imp_out = self._invoke_solver(
+                self._discretization_solver_impulsive,
+                x_nodes_prior_c,
+                u_candidate,
+                params,
+            )
+            self._block_until_ready_outputs(cont_out + imp_out)
+        else:
+            self._block_until_ready_outputs(cont_out)
 
     def step(
         self,

--- a/openscvx/algorithms/penalized_trust_region.py
+++ b/openscvx/algorithms/penalized_trust_region.py
@@ -193,7 +193,7 @@ class PenalizedTrustRegion(Algorithm):
     def _block_until_ready_outputs(outputs: Tuple[object, ...]) -> None:
         """Finish any pending XLA work from discretization exports (warm-up helper)."""
         jax.block_until_ready(outputs)
-        
+
     def _recover_prior_node_from_initial(
         self,
         settings: Config,
@@ -340,11 +340,7 @@ class PenalizedTrustRegion(Algorithm):
                 params,
             )
             init_state.add_impulsive_discretization(W_multi_shoot.__array__())
-        (
-            x_sol,
-            u_sol,
-            *_
-        ) = self._subproblem(params, init_state, settings)
+        (x_sol, u_sol, *_) = self._subproblem(params, init_state, settings)
 
         # Prime the same exported discretization calls used after every subproblem in
         # step() (candidate trajectory). initialize() previously only discretized the

--- a/openscvx/algorithms/penalized_trust_region.py
+++ b/openscvx/algorithms/penalized_trust_region.py
@@ -192,12 +192,8 @@ class PenalizedTrustRegion(Algorithm):
     @staticmethod
     def _block_until_ready_outputs(outputs: Tuple[object, ...]) -> None:
         """Finish any pending XLA work from discretization exports (warm-up helper)."""
-        try:
-            jax.block_until_ready(outputs)
-        except (TypeError, ValueError):
-            # Non-JAX leaves (e.g. pure NumPy); nothing to wait on.
-            pass
-
+        jax.block_until_ready(outputs)
+        
     def _recover_prior_node_from_initial(
         self,
         settings: Config,
@@ -347,15 +343,7 @@ class PenalizedTrustRegion(Algorithm):
         (
             x_sol,
             u_sol,
-            _costs,
-            _result_cost,
-            _J_vb_vec,
-            _J_vc_vec,
-            _J_tr_vec,
-            _prob_stat,
-            _subprop_time,
-            _vc_mat,
-            _tr_mat,
+            *_
         ) = self._subproblem(params, init_state, settings)
 
         # Prime the same exported discretization calls used after every subproblem in

--- a/openscvx/symbolic/hashing.py
+++ b/openscvx/symbolic/hashing.py
@@ -9,14 +9,27 @@ the same structure, the cached compiled artifacts can be reused.
 """
 
 import hashlib
+from importlib.metadata import PackageNotFoundError, version
 from typing import TYPE_CHECKING
 
 import numpy as np
 
-from openscvx._version import __version__
-
 if TYPE_CHECKING:
     from openscvx.symbolic.problem import SymbolicProblem
+
+
+def _openscvx_version() -> str:
+    """Package version for cache invalidation; works without generated _version.py."""
+    try:
+        return version("openscvx")
+    except PackageNotFoundError:
+        pass
+    try:
+        from openscvx._version import __version__ as v
+
+        return v
+    except ImportError:
+        return "0.0.0"
 
 
 def hash_symbolic_problem(problem: "SymbolicProblem") -> str:
@@ -47,7 +60,7 @@ def hash_symbolic_problem(problem: "SymbolicProblem") -> str:
     hasher = hashlib.sha256()
 
     # Include library version to invalidate cache on version changes
-    hasher.update(f"openscvx:{__version__}:".encode())
+    hasher.update(f"openscvx:{_openscvx_version()}:".encode())
 
     # Hash the dynamics
     hasher.update(b"dynamics:")

--- a/tests/expr/test_gmsr.py
+++ b/tests/expr/test_gmsr.py
@@ -296,11 +296,11 @@ class TestORLite:
         # OR_lite = 0 iff all y_i ≤ 0
         y = jnp.array([-1.0, -0.5])
         val = float(OR_lite(y, c=C))
-        assert val == pytest.approx(0.0, abs=1e-3)
+        assert val == pytest.approx(0.0, abs=1e-17)
 
     def test_positive_when_any_positive(self):
         y = jnp.array([0.5, -1.0])
-        assert float(OR_lite(y, c=C)) == pytest.approx(0.0, abs=1e-3)
+        assert float(OR_lite(y, c=C)) == pytest.approx(0.0, abs=1e-17)
 
     def test_larger_positive_means_more_violated(self):
         y_small = jnp.array([0.1, 10.0])

--- a/tests/expr/test_gmsr.py
+++ b/tests/expr/test_gmsr.py
@@ -11,6 +11,8 @@ Each function is tested for:
 """
 
 import jax
+# Use float64 for more accurate tests
+jax.config.update("jax_enable_x64", True)
 import jax.numpy as jnp
 import pytest
 

--- a/tests/expr/test_gmsr.py
+++ b/tests/expr/test_gmsr.py
@@ -11,21 +11,24 @@ Each function is tested for:
 """
 
 import jax
-# Use float64 for more accurate tests
-jax.config.update("jax_enable_x64", True)
-import jax.numpy as jnp
-import pytest
 
-from openscvx.symbolic.lowerers.jax.stl import (
+# Use float64 for more accurate tests; JAX must be configured before jnp.
+jax.config.update("jax_enable_x64", True)
+# isort: off
+import jax.numpy as jnp  # noqa: E402
+import pytest  # noqa: E402
+
+from openscvx.symbolic.lowerers.jax.stl import (  # noqa: E402
     AND,
     OR,
     AND_lite,
     OR_lite,
     _smooth_equality,
     integer_variable,
+    gmsr_IfThen as IfThen,
+    gmsr_IfThen_lite as IfThen_lite,
 )
-from openscvx.symbolic.lowerers.jax.stl import gmsr_IfThen as IfThen
-from openscvx.symbolic.lowerers.jax.stl import gmsr_IfThen_lite as IfThen_lite
+# isort: on
 
 # =============================================================================
 # Helpers

--- a/tests/symbolic/expr/test_stl.py
+++ b/tests/symbolic/expr/test_stl.py
@@ -470,7 +470,7 @@ def test_or_jax_lite_variant():
     fn = _lower_stl(Or(p1, p2, lite=True))
     # lite variant: satisfied when at least one predicate satisfied
     x_ok = jnp.array([0.5, 3.0])
-    assert float(fn(x_ok, None, None, None)) >= 0.0
+    assert float(fn(x_ok, None, None, None)) >= pytest.approx(0.0, abs=1e-17)
 
 
 # =============================================================================

--- a/tests/symbolic/expr/test_stl.py
+++ b/tests/symbolic/expr/test_stl.py
@@ -470,7 +470,7 @@ def test_or_jax_lite_variant():
     fn = _lower_stl(Or(p1, p2, lite=True))
     # lite variant: satisfied when at least one predicate satisfied
     x_ok = jnp.array([0.5, 3.0])
-    assert float(fn(x_ok, None, None, None)) >= pytest.approx(0.0, abs=1e-17)
+    assert float(fn(x_ok, None, None, None)) >= -1e-17
 
 
 # =============================================================================

--- a/tests/test_brachistochrone.py
+++ b/tests/test_brachistochrone.py
@@ -93,6 +93,11 @@ def test_example():
     """
     from examples.abstract.brachistochrone import problem
 
+    # Dense output grid + tight IVP tolerances for trajectory vs analytical validation
+    problem.settings.prp.dt = 0.005
+    problem.settings.prp.atol = 1e-8
+    problem.settings.prp.rtol = 1e-10
+
     # Disable printing for cleaner test output
     if hasattr(problem.settings, "dev"):
         problem.settings.dev.printing = False


### PR DESCRIPTION
Ensures that all JAX/XLA compilation steps are performed in `problem.initialize()`. This reduces the overhead in the `problem.solve()`. This took the main solve time for `6DoF_pdg.py` from 53ms to 12ms on an MBP M2Max.