### PR TITLE
Feature/3rd party dynamics adapter

### DIFF
--- a/examples/mjx/cartpole_mjx.py
+++ b/examples/mjx/cartpole_mjx.py
@@ -34,7 +34,6 @@ except ImportError:
     sys.exit(1)
 
 import openscvx as ox
-from openscvx.integrations import mjx_byof
 
 CARTPOLE_XML = """
 <mujoco model="cartpole">
@@ -69,36 +68,32 @@ n_u = int(mjx_model.nu)
 n = 60
 total_time = 3.0
 
-qpos = ox.State("qpos", shape=(n_q,))
+# ── MJX dynamics as a first-class adapter ─────────────────────────────────────
+# `MjxDynamics` builds default qpos / qvel / ctrl State and Control objects
+# matching the model's nq / nv / nu and routes the MJX forward dynamics into
+# the BYOF channel internally — no separate `byof=` plumbing required.
+dyn = ox.MjxDynamics(mjx_model)
+qpos, qvel = dyn.states
+(ctrl,) = dyn.controls
+
 qpos.min = np.array([-3.0, -2.0 * np.pi])
 qpos.max = np.array([3.0, 2.0 * np.pi])
 qpos.initial = np.array([0.0, np.pi])
 qpos.final = np.array([0.0, 0.0])
 
-qvel = ox.State("qvel", shape=(n_v,))
 qvel.min = np.array([-10.0, -15.0])
 qvel.max = np.array([10.0, 15.0])
 qvel.initial = np.array([0.0, 0.0])
 qvel.final = np.array([0.0, 0.0])
 
-ctrl = ox.Control("ctrl", shape=(n_u,))
 ctrl.min = np.array([-1.0])
 ctrl.max = np.array([1.0])
 ctrl.guess = np.zeros((n, n_u))
 
-states = [qpos, qvel]
-controls = [ctrl]
-
-dynamics = {
-    "qpos": qvel,
-}
-
-byof: ox.ByofSpec = {"dynamics": mjx_byof(mjx_model, qpos=qpos, qvel=qvel, ctrl=ctrl)}
-
 constraints = []
-for state in states:
+for state in dyn.states:
     constraints.extend([ox.ctcs(state <= state.max), ox.ctcs(state.min <= state)])
-for control in controls:
+for control in dyn.controls:
     constraints.extend([ox.ctcs(control <= control.max), ox.ctcs(control.min <= control)])
 
 theta_guess = np.linspace(np.pi, 0.0, n)
@@ -115,13 +110,12 @@ time = ox.Time(
 )
 
 problem = ox.Problem(
-    dynamics=dynamics,
-    states=states,
-    controls=controls,
+    dynamics=dyn,
+    states=dyn.states,
+    controls=dyn.controls,
     time=time,
     constraints=constraints,
     N=n,
-    byof=byof,
     algorithm={
         "lam_prox": 1e-1,
         "lam_cost": 1e-2,

--- a/examples/mjx/double_cartpole_mjx.py
+++ b/examples/mjx/double_cartpole_mjx.py
@@ -34,8 +34,6 @@ except ImportError:
     sys.exit(1)
 
 import openscvx as ox
-from openscvx import ByofSpec
-from openscvx.integrations import mjx_byof
 
 L1, L2 = 0.5, 0.4  # link lengths (m)
 
@@ -81,31 +79,25 @@ n_u = int(mjx_model.nu)  # 1: cart force
 n = 400
 total_time = 2.5
 
-# ── State / control definitions ───────────────────────────────────────────────
-qpos = ox.State("qpos", shape=(n_q,))
+# ── MJX dynamics adapter ──────────────────────────────────────────────────────
+dyn = ox.MjxDynamics(mjx_model)
+qpos, qvel = dyn.states
+(ctrl,) = dyn.controls
+ctrl.parameterization = "ZOH"
+
 qpos.min = np.array([-8.0, -2 * np.pi, -2 * np.pi])
 qpos.max = np.array([8.0, 2 * np.pi, 2 * np.pi])
 qpos.initial = np.array([0.0, np.pi, 0.0])  # cart at origin, link1 hanging down
 qpos.final = [ox.Free(0.0), 0.0, 0.0]  # cart free, both links upright
 
-qvel = ox.State("qvel", shape=(n_v,))
 qvel.min = np.array([-12.0, -12.0, -12.0])
 qvel.max = np.array([12.0, 12.0, 12.0])
 qvel.initial = np.zeros(n_v)
 qvel.final = [0.0, 0.0, 0.0]
 
-ctrl = ox.Control("ctrl", shape=(n_u,), parameterization="ZOH")
 ctrl.min = np.array([-2.0])
 ctrl.max = np.array([2.0])
 ctrl.guess = np.zeros((n, n_u))
-
-states = [qpos, qvel]
-controls = [ctrl]
-
-# ── Dynamics: position kinematics symbolically, velocity via MJX ──────────────
-dynamics: dict = {"qpos": qvel}  # nq == nv, valid for all-revolute/prismatic joints
-
-byof: ByofSpec = {"dynamics": mjx_byof(mjx_model, qpos=qpos, qvel=qvel, ctrl=ctrl)}
 
 # ── Constraints (CTCS on state / control bounds) ───────────────────────────────
 constraints = []
@@ -123,13 +115,12 @@ time = ox.Time(
 )
 
 problem = ox.Problem(
-    dynamics=dynamics,
-    states=states,
-    controls=controls,
+    dynamics=dyn,
+    states=dyn.states,
+    controls=dyn.controls,
     time=time,
     constraints=constraints,
     N=n,
-    byof=byof,
     algorithm={
         "lam_prox": 1e-1,
         "lam_cost": 0e0,

--- a/examples/mjx/skydio_x2_mjx.py
+++ b/examples/mjx/skydio_x2_mjx.py
@@ -51,8 +51,7 @@ from examples.plotting_viser import (
     create_animated_plotting_server,
     create_scp_animated_plotting_server,
 )
-from openscvx import ByofSpec, Problem
-from openscvx.integrations import mjx_byof
+from openscvx import Problem
 from openscvx.utils import gen_vertices, rot
 
 HOVER_CTRL = 3.2495625  # N per motor for level hover (from menagerie keyframe)
@@ -78,32 +77,27 @@ n_u = int(mjx_model.nu)  # 4 — rotor thrusts
 n = 22
 total_time = 24.0
 
-# ── State / control definitions ───────────────────────────────────────────────
-qpos = ox.State("qpos", shape=(n_q,))
+# ── MJX dynamics adapter ──────────────────────────────────────────────────────
+# The free joint has nq=7 but nv=6 (quaternion adds one extra position DOF).
+# MjxDynamics detects nq > nv and automatically routes quaternion kinematics
+# for "qpos" alongside the MJX "qvel" dynamics through the BYOF channel.
+dyn = ox.MjxDynamics(mjx_model)
+qpos, qvel = dyn.states
+(ctrl,) = dyn.controls
+
 qpos.min = np.array([-200.0, -100.0, 15.0, -1.0, -1.0, -1.0, -1.0])
 qpos.max = np.array([200.0, 100.0, 200.0, 1.0, 1.0, 1.0, 1.0])
 qpos.initial = np.concatenate([START_POS, HOVER_QUAT])
 qpos.final = [10.0, 0.0, 20.0, ("free", 1.0), ("free", 0.0), ("free", 0.0), ("free", 0.0)]
 
-qvel = ox.State("qvel", shape=(n_v,))
 qvel.min = np.array([-100.0, -100.0, -100.0, -10.0, -10.0, -10.0])
 qvel.max = np.array([100.0, 100.0, 100.0, 10.0, 10.0, 10.0])
 qvel.initial = np.zeros(n_v)
 qvel.final = [("free", 0.0)] * n_v
 
-ctrl = ox.Control("ctrl", shape=(n_u,))
 ctrl.min = np.zeros(n_u)
 ctrl.max = 13.0 * np.ones(n_u)
 ctrl.guess = HOVER_CTRL * np.ones((n, n_u))
-
-states = [qpos, qvel]
-controls = [ctrl]
-
-# ── Dynamics via BYOF ─────────────────────────────────────────────────────────
-# The free joint has nq=7 but nv=6 (quaternion adds one extra position DOF).
-# nq=7, nv=6 (free joint): mjx_byof detects nq > nv and automatically
-# includes quaternion kinematics for "qpos" alongside the MJX "qvel" dynamics.
-byof: ByofSpec = {"dynamics": mjx_byof(mjx_model, qpos=qpos, qvel=qvel, ctrl=ctrl)}
 
 # ── Gate parameters (matching examples/drone/drone_racing.py) ───────────────
 n_gates = 10
@@ -135,9 +129,9 @@ gate_centers = np.array(modified_centers)
 
 # ── Constraints ───────────────────────────────────────────────────────────────
 constraints = []
-for state in states:
+for state in dyn.states:
     constraints.extend([ox.ctcs(state <= state.max), ox.ctcs(state.min <= state)])
-for control in controls:
+for control in dyn.controls:
     constraints.extend([ox.ctcs(control <= control.max), ox.ctcs(control.min <= control)])
 
 # Enforce sequential gate traversal using nodal constraints on qpos position.
@@ -172,13 +166,12 @@ time = ox.Time(
 )
 
 problem = Problem(
-    dynamics={},  # all dynamics go through BYOF
-    states=states,
-    controls=controls,
+    dynamics=dyn,
+    states=dyn.states,
+    controls=dyn.controls,
     time=time,
     constraints=constraints,
     N=n,
-    byof=byof,
     algorithm={
         "lam_prox": 1e-1,
         "lam_cost": 1e-2,

--- a/examples/mjx/triple_cartpole_3d_mjx.py
+++ b/examples/mjx/triple_cartpole_3d_mjx.py
@@ -57,8 +57,7 @@ except ImportError:
     sys.exit(1)
 
 import openscvx as ox
-from openscvx import ByofSpec, Problem
-from openscvx.integrations import mjx_byof
+from openscvx import Problem
 
 L1, L2, L3 = 0.5, 0.4, 0.3  # link lengths (m)
 
@@ -122,8 +121,11 @@ IDX_A1, IDX_B1 = 2, 3
 IDX_A2, IDX_B2 = 4, 5
 IDX_A3, IDX_B3 = 6, 7
 
-# ── State / control definitions ───────────────────────────────────────────────
-qpos = ox.State("qpos", shape=(n_q,))
+# ── MJX dynamics adapter ──────────────────────────────────────────────────────
+dyn = ox.MjxDynamics(mjx_model)
+qpos, qvel = dyn.states
+(ctrl,) = dyn.controls
+
 qpos.min = np.array(
     [-8.0, -8.0, -2 * np.pi, -2 * np.pi, -2 * np.pi, -2 * np.pi, -2 * np.pi, -2 * np.pi]
 )
@@ -142,24 +144,14 @@ qpos.final = [
     0.0,  # link 3 upright
 ]
 
-qvel = ox.State("qvel", shape=(n_v,))
 qvel.min = np.full(n_v, -12.0)
 qvel.max = np.full(n_v, 12.0)
 qvel.initial = np.zeros(n_v)
 qvel.final = [0.0] * n_v
 
-ctrl = ox.Control("ctrl", shape=(n_u,))
 ctrl.min = np.array([-2.0, -2.0])
 ctrl.max = np.array([2.0, 2.0])
 ctrl.guess = np.zeros((n, n_u))
-
-states = [qpos, qvel]
-controls = [ctrl]
-
-# ── Dynamics: position kinematics symbolically, velocity via MJX ──────────────
-dynamics: dict = {"qpos": qvel}  # nq == nv
-
-byof: ByofSpec = {"dynamics": mjx_byof(mjx_model, qpos=qpos, qvel=qvel, ctrl=ctrl)}
 
 # ── Constraints (CTCS on state / control bounds) ─────────────────────────────
 constraints = []
@@ -179,13 +171,12 @@ time = ox.Time(
 )
 
 problem = Problem(
-    dynamics=dynamics,
-    states=states,
-    controls=controls,
+    dynamics=dyn,
+    states=dyn.states,
+    controls=dyn.controls,
     time=time,
     constraints=constraints,
     N=n,
-    byof=byof,
     algorithm={
         "lam_prox": 1e-1,
         "lam_cost": 0e0,

--- a/examples/mjx/triple_cartpole_mjx.py
+++ b/examples/mjx/triple_cartpole_mjx.py
@@ -35,8 +35,7 @@ except ImportError:
     sys.exit(1)
 
 import openscvx as ox
-from openscvx import ByofSpec, Problem
-from openscvx.integrations import mjx_byof
+from openscvx import Problem
 
 L1, L2, L3 = 0.5, 0.4, 0.3  # link lengths (m)
 
@@ -88,35 +87,28 @@ n_u = int(mjx_model.nu)  # 1: cart force
 n = 60  # more nodes → finer resolution near the unstable upright equilibrium
 total_time = 2.5
 
-# ── State / control definitions ───────────────────────────────────────────────
-qpos = ox.State("qpos", shape=(n_q,))
+# ── MJX dynamics adapter ──────────────────────────────────────────────────────
+dyn = ox.MjxDynamics(mjx_model)
+qpos, qvel = dyn.states
+(ctrl,) = dyn.controls
+
 qpos.min = np.array([-100.0, -2 * np.pi, -2 * np.pi, -2 * np.pi])
 qpos.max = np.array([100.0, 2 * np.pi, 2 * np.pi, 2 * np.pi])
 qpos.initial = np.array([0.0, np.pi, 0.0, 0.0])  # all links hanging down
 qpos.final = [ox.Free(0.0), 0.0, 0.0, 0.0]  # all links upright
 
-qvel = ox.State("qvel", shape=(n_v,))
 qvel.min = np.array([-12.0, -12.0, -12.0, -12.0])
 qvel.max = np.array([12.0, 12.0, 12.0, 12.0])
 qvel.initial = np.zeros(n_v)
 qvel.final = [0.0, 0.0, 0.0, 0.0]
 
-ctrl = ox.Control("ctrl", shape=(n_u,))
 ctrl.min = np.array([-3.0])
 ctrl.max = np.array([3.0])
 ctrl.guess = np.zeros((n, n_u))
 
-states = [qpos, qvel]
-controls = [ctrl]
-
-# ── Dynamics: position kinematics symbolically, velocity via MJX ──────────────
-dynamics: dict = {"qpos": qvel}  # nq==nv so this is always valid
-
-byof: ByofSpec = {"dynamics": mjx_byof(mjx_model, qpos=qpos, qvel=qvel, ctrl=ctrl)}
-
 # ── Constraints (CTCS on state / control bounds) ───────────────────────────────
 constraints = []
-for state in states:
+for state in dyn.states:
     constraints.extend([ox.ctcs(state <= state.max), ox.ctcs(state.min <= state)])
 
 # ── Initial guess: linearly swing θ₁ from π → 0, others stay 0 ───────────────
@@ -132,13 +124,12 @@ time = ox.Time(
 )
 
 problem = Problem(
-    dynamics=dynamics,
-    states=states,
-    controls=controls,
+    dynamics=dyn,
+    states=dyn.states,
+    controls=dyn.controls,
     time=time,
     constraints=constraints,
     N=n,
-    byof=byof,
     algorithm={
         "lam_prox": 1e0,
         "lam_cost": 0e0,

--- a/openscvx/__init__.py
+++ b/openscvx/__init__.py
@@ -25,6 +25,7 @@ from openscvx.discretization import (
     VectorizeDiscretizeLinearize,
 )
 from openscvx.expert import ByofSpec
+from openscvx.integrations import DynamicsAdapter, MjxDynamics
 from openscvx.loader import load_dict, load_json, load_yaml
 from openscvx.problem import Problem
 from openscvx.solvers import PTRSolver
@@ -176,6 +177,9 @@ __all__ = [
     "lie",
     # Expert mode types
     "ByofSpec",
+    # External-backend dynamics adapters
+    "DynamicsAdapter",
+    "MjxDynamics",
     # Discretization
     "DiscretizeLinearizeVectorize",
     "LinearizeDiscretize",

--- a/openscvx/integrations/__init__.py
+++ b/openscvx/integrations/__init__.py
@@ -1,40 +1,47 @@
-"""Adapters for MuJoCo MJX dynamics in OpenSCvx BYOF.
+"""External-backend dynamics adapters for OpenSCvx.
 
-The recommended entry-point is :func:`mjx_byof`, which returns a complete
-``byof["dynamics"]`` dict and automatically handles free-joint quaternion
-kinematics for floating-base models (drones, humanoids, etc.):
+The recommended entry-point is `MjxDynamics`, which goes directly into the
+``dynamics=`` slot of `Problem` and constructs the matching State/Control
+objects for the user. Free-joint quaternion kinematics for floating-base
+models (drones, humanoids) are detected and handled automatically::
 
-    from openscvx.integrations import mjx_byof
+    from openscvx.integrations import MjxDynamics
 
-    byof = {"dynamics": mjx_byof(mjx_model, qpos=qpos, qvel=qvel, ctrl=ctrl)}
+    dyn = MjxDynamics(mjx_model)
+    problem = ox.Problem(
+        dynamics=dyn,
+        states=dyn.states,
+        controls=dyn.controls,
+        ...
+    )
 
-For models without free joints (cartpoles, manipulators) the returned dict
-contains only ``"qvel"`` and ``dynamics={"qpos": qvel}`` should still be
-provided to :class:`~openscvx.Problem`.  For models with free joints
-(``nq > nv``) ``"qpos"`` is included automatically — no extra imports needed.
+The legacy `mjx_byof` helper is retained for users who need to supply their
+own State/Control objects (e.g. to interleave with extra custom states or
+rename them). `mjx_dynamics` is the underlying BYOF callable factory used by
+both, exposed publicly for advanced users.
 
-:func:`mjx_dynamics` is also available for advanced users who need direct
-access to the BYOF callable for the ``qvel`` (acceleration) derivative.
+All MJX symbols delegate lazily so ``mujoco.mjx`` is only imported when
+actually used. The ``menagerie`` submodule is also loaded lazily.
 
-All symbols delegate lazily so ``mujoco.mjx`` is only imported when used.
-The :mod:`menagerie` submodule is loaded lazily via attribute access.
+Example — cartpole (``nq == nv``)::
 
-Example — cartpole (nq == nv)::
+    from openscvx.integrations import MjxDynamics
 
-    from openscvx.integrations import mjx_byof
+    dyn = MjxDynamics(mjx_model)
+    problem = ox.Problem(dynamics=dyn, states=dyn.states, controls=dyn.controls, ...)
 
-    byof = {"dynamics": mjx_byof(mjx_model, qpos=qpos, qvel=qvel, ctrl=ctrl)}
-    problem = ox.Problem(dynamics={"qpos": qvel}, byof=byof, ...)
+Example — quadrotor with free joint (``nq=7``, ``nv=6``)::
 
-Example — quadrotor with free joint (nq=7, nv=6)::
+    from openscvx.integrations import MjxDynamics
 
-    from openscvx.integrations import mjx_byof
-
-    byof = {"dynamics": mjx_byof(mjx_model, qpos=qpos, qvel=qvel, ctrl=ctrl)}
-    problem = ox.Problem(dynamics={}, byof=byof, ...)
+    dyn = MjxDynamics(mjx_model)
+    problem = ox.Problem(dynamics=dyn, states=dyn.states, controls=dyn.controls, ...)
 """
 
 from typing import Any
+
+from .base import DynamicsAdapter
+from .mjx import MjxDynamics
 
 
 def mjx_byof(*args: Any, **kwargs: Any) -> Any:
@@ -59,4 +66,10 @@ def __getattr__(name: str) -> Any:
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-__all__ = ["mjx_byof", "mjx_dynamics", "menagerie"]
+__all__ = [
+    "DynamicsAdapter",
+    "MjxDynamics",
+    "mjx_byof",
+    "mjx_dynamics",
+    "menagerie",
+]

--- a/openscvx/integrations/__init__.py
+++ b/openscvx/integrations/__init__.py
@@ -15,10 +15,9 @@ models (drones, humanoids) are detected and handled automatically::
         ...
     )
 
-The legacy `mjx_byof` helper is retained for users who need to supply their
-own State/Control objects (e.g. to interleave with extra custom states or
-rename them). `mjx_dynamics` is the underlying BYOF callable factory used by
-both, exposed publicly for advanced users.
+For advanced users who need custom State/Control names (or to interleave
+them with extra custom states), `mjx_dynamics` is exposed as the underlying
+BYOF callable factory — assemble your own ``byof["dynamics"]`` dict from it.
 
 All MJX symbols delegate lazily so ``mujoco.mjx`` is only imported when
 actually used. The ``menagerie`` submodule is also loaded lazily.
@@ -44,13 +43,6 @@ from .base import DynamicsAdapter
 from .mjx import MjxDynamics
 
 
-def mjx_byof(*args: Any, **kwargs: Any) -> Any:
-    """Lazy delegate; imports ``mujoco.mjx`` on first call."""
-    from .mjx import mjx_byof as _mjx_byof
-
-    return _mjx_byof(*args, **kwargs)
-
-
 def mjx_dynamics(*args: Any, **kwargs: Any) -> Any:
     """Lazy delegate; imports ``mujoco.mjx`` on first call."""
     from .mjx import mjx_dynamics as _mjx_dynamics
@@ -69,7 +61,6 @@ def __getattr__(name: str) -> Any:
 __all__ = [
     "DynamicsAdapter",
     "MjxDynamics",
-    "mjx_byof",
     "mjx_dynamics",
     "menagerie",
 ]

--- a/openscvx/integrations/base.py
+++ b/openscvx/integrations/base.py
@@ -81,8 +81,8 @@ def _merge_byof(user_byof: dict | None, extra_byof: dict) -> dict:
             raise ValueError(
                 "DynamicsAdapter produced byof['dynamics'] entries that "
                 f"collide with user-provided byof['dynamics']: {sorted(collisions)}. "
-                "Drop the duplicate keys from your byof dict, or fall back to "
-                "the lower-level helper (e.g. mjx_byof) for full control."
+                "Drop the duplicate keys from your byof dict, or drop the adapter "
+                "and assemble byof['dynamics'] manually for full control."
             )
         merged["dynamics"] = {**user_dyn, **extra_dyn}
 

--- a/openscvx/integrations/base.py
+++ b/openscvx/integrations/base.py
@@ -1,0 +1,89 @@
+"""Base class for external-backend dynamics adapters.
+
+A `DynamicsAdapter` is the easy on-ramp for users who want to plug an
+external physics backend (MuJoCo MJX, Brax, Drake, ...) into OpenSCvx without
+manually constructing State/Control objects with matching shapes or routing
+raw JAX callables through the expert ``byof`` channel.
+
+The intended call site is::
+
+    dyn = ox.MjxDynamics(mjx_model)
+    problem = ox.Problem(
+        dynamics=dyn,
+        states=dyn.states,
+        controls=dyn.controls,
+        ...
+    )
+
+Internally, `Problem` detects the adapter, calls `DynamicsAdapter.expand`,
+and merges the resulting BYOF callables into the user's ``byof`` dict (if
+any). Everything downstream sees ordinary ``dynamics`` and ``byof`` dicts.
+"""
+
+from __future__ import annotations
+
+import copy
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Tuple
+
+if TYPE_CHECKING:
+    from openscvx.symbolic.expr.control import Control
+    from openscvx.symbolic.expr.state import State
+
+
+class DynamicsAdapter(ABC):
+    """Abstract base class for external-backend dynamics adapters.
+
+    Subclasses describe the State/Control objects they synthesize on
+    ``.states`` / ``.controls`` and implement `expand` to return the
+    two-channel ``(dynamics_dict, byof_dict)`` representation consumed by
+    `Problem`.
+
+    The split mirrors the existing two-channel API: ``dynamics_dict`` carries
+    symbolic Expr entries (e.g. ``{"qpos": qvel}``) while ``byof_dict`` carries
+    raw JAX callables under the ``"dynamics"`` key. Either or both may be
+    empty, but ``expand()`` should never silently produce overlapping keys.
+    """
+
+    states: list["State"]
+    controls: list["Control"]
+
+    @abstractmethod
+    def expand(self) -> Tuple[dict, dict]:
+        """Return ``(dynamics_dict, byof_dict)`` in OpenSCvx's internal form.
+
+        ``dynamics_dict`` maps state names to symbolic ``Expr`` derivatives
+        (the same shape as the ``dynamics=`` argument to ``Problem``).
+        ``byof_dict`` has the same shape as the ``byof=`` argument: its
+        ``"dynamics"`` key (if present) maps state names to raw JAX callables.
+        """
+
+
+def _merge_byof(user_byof: dict | None, extra_byof: dict) -> dict:
+    """Merge an adapter-synthesized BYOF dict into a user-provided one.
+
+    Only the ``"dynamics"`` sub-dict is deep-merged; other keys are taken
+    verbatim from whichever side provides them. Raises ``ValueError`` on any
+    key collision under ``"dynamics"`` — a user passing both
+    ``dynamics=ox.MjxDynamics(...)`` and ``byof={"dynamics": {"qvel": ...}}``
+    almost certainly has a bug, and silent override would mask it.
+    """
+    if not user_byof:
+        return copy.copy(extra_byof)
+
+    merged = dict(user_byof)
+    extra_dyn = extra_byof.get("dynamics", {})
+    user_dyn = user_byof.get("dynamics", {})
+
+    if extra_dyn:
+        collisions = set(user_dyn) & set(extra_dyn)
+        if collisions:
+            raise ValueError(
+                "DynamicsAdapter produced byof['dynamics'] entries that "
+                f"collide with user-provided byof['dynamics']: {sorted(collisions)}. "
+                "Drop the duplicate keys from your byof dict, or fall back to "
+                "the lower-level helper (e.g. mjx_byof) for full control."
+            )
+        merged["dynamics"] = {**user_dyn, **extra_dyn}
+
+    return merged

--- a/openscvx/integrations/mjx.py
+++ b/openscvx/integrations/mjx.py
@@ -1,28 +1,33 @@
-"""MuJoCo MJX dynamics adapters for OpenSCvx BYOF.
+"""MuJoCo MJX dynamics adapters for OpenSCvx.
 
-The recommended entry-point is :func:`mjx_byof`, which returns a complete
-``byof["dynamics"]`` dict and automatically handles free-joint quaternion
-kinematics — no separate imports required:
+The recommended entry-point is `MjxDynamics`, a `DynamicsAdapter` that goes
+directly into the ``dynamics=`` slot of `Problem` and exposes the synthesized
+State/Control objects on ``.states`` / ``.controls``::
 
-    byof = {"dynamics": mjx_byof(mjx_model, qpos=qpos, qvel=qvel, ctrl=ctrl)}
+    dyn = ox.MjxDynamics(mjx_model)
+    problem = ox.Problem(
+        dynamics=dyn,
+        states=dyn.states,
+        controls=dyn.controls,
+        ...
+    )
 
-For models **without** free joints (cartpoles, manipulators, etc.) the
-returned dict contains only ``"qvel"``, and qpos kinematics must still be
-specified symbolically via ``dynamics={"qpos": qvel}``.  For models **with**
-free joints (drones, humanoids) ``"qpos"`` is included automatically and no
-symbolic dynamics entry is needed.
+Free-joint quaternion kinematics (``nq > nv`` models such as drones or
+humanoids) are detected and handled automatically.
 
-The lower-level :func:`mjx_dynamics` is also public for advanced users who
-need direct access to the BYOF callable for the ``qvel`` derivative.
+For advanced users, the lower-level `mjx_dynamics` callable factory and the
+legacy `mjx_byof` helper remain available.
 
 Note:
     Time dilation is handled automatically by the BYOF lowering pipeline; all
     functions return physical (un-dilated) quantities.
 """
 
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable, Optional, Tuple
 
 import jax.numpy as jnp
+
+from openscvx.integrations.base import DynamicsAdapter
 
 if TYPE_CHECKING:
     from openscvx.symbolic.expr.control import Control
@@ -257,9 +262,16 @@ def mjx_byof(
 ) -> dict:
     """Return a complete ``byof["dynamics"]`` dict for a MuJoCo MJX model.
 
-    This is the recommended high-level entry-point.  It inspects the model's
-    ``nq`` and ``nv`` to detect free joints and automatically includes the
-    quaternion kinematics callable for ``qpos`` when needed.
+    Note:
+        `MjxDynamics` is the preferred entry-point — it goes directly in the
+        ``dynamics=`` slot of `Problem` and constructs the matching
+        State/Control objects for you. Use `mjx_byof` only when you need to
+        supply custom State/Control objects (e.g. interleave them with other
+        states) or otherwise want full control over names.
+
+    It inspects the model's ``nq`` and ``nv`` to detect free joints and
+    automatically includes the quaternion kinematics callable for ``qpos``
+    when needed.
 
     Args:
         mjx_model: A model produced by :func:`mujoco.mjx.put_model`.
@@ -321,3 +333,103 @@ def mjx_byof(
         )
 
     return result
+
+
+class MjxDynamics(DynamicsAdapter):
+    """First-class MJX dynamics adapter for `Problem`.
+
+    Wraps a ``mujoco.mjx`` model so it can be passed directly to the
+    ``dynamics=`` argument of `Problem`. The adapter
+    constructs default ``qpos`` / ``qvel`` State objects and a ``ctrl``
+    Control matching the model's ``nq`` / ``nv`` / ``nu``, exposes them via
+    ``.states`` / ``.controls``, and routes the MJX forward dynamics through
+    the BYOF channel internally — without requiring the user to know about
+    BYOF at all.
+
+    Example:
+        Cartpole (``nq == nv``)::
+
+            mj_model = mujoco.MjModel.from_xml_path("cartpole.xml")
+            mj_model.opt.disableflags |= mujoco.mjtDisableBit.mjDSBL_CONTACT
+            mjx_model = mjx.put_model(mj_model)
+
+            dyn = ox.MjxDynamics(mjx_model)
+            problem = ox.Problem(
+                dynamics=dyn,
+                states=dyn.states,
+                controls=dyn.controls,
+                ...
+            )
+
+        Quadrotor with a free joint (``nq > nv``) — quaternion kinematics
+        are inserted automatically::
+
+            dyn = ox.MjxDynamics(mjx_model)  # nq=7, nv=6
+            problem = ox.Problem(
+                dynamics=dyn, states=dyn.states, controls=dyn.controls, ...
+            )
+
+    Custom State/Control names or shapes are *not* supported here on purpose
+    — the whole point of the adapter is "I don't want to think about names."
+    Drop to the lower-level `mjx_byof` helper if you need that control.
+    """
+
+    def __init__(
+        self,
+        mjx_model: Any,
+        *,
+        return_component: str = "qacc",
+        extra_postprocess: Optional[Callable[[Any], Any]] = None,
+    ) -> None:
+        from openscvx.symbolic.expr.control import Control
+        from openscvx.symbolic.expr.state import State
+
+        self.mjx_model = mjx_model
+        self.return_component = return_component
+        self.extra_postprocess = extra_postprocess
+
+        nq = int(mjx_model.nq)
+        nv = int(mjx_model.nv)
+        nu = int(mjx_model.nu)
+
+        self._qpos = State("qpos", shape=(nq,))
+        self._qvel = State("qvel", shape=(nv,))
+        self._ctrl = Control("ctrl", shape=(nu,))
+
+        self.states: list[State] = [self._qpos, self._qvel]
+        self.controls: list[Control] = [self._ctrl]
+
+    def expand(self) -> Tuple[dict, dict]:
+        """Return ``(dynamics_dict, byof_dict)`` for this MJX model.
+
+        - ``nq == nv``: ``dynamics_dict = {"qpos": qvel}`` (symbolic
+          kinematic identity), ``byof_dict["dynamics"] = {"qvel": ...}``.
+        - ``nq > nv``: ``dynamics_dict = {}``, ``byof_dict["dynamics"]``
+          contains both ``"qpos"`` (quaternion kinematics) and ``"qvel"``.
+        """
+        nq = int(self.mjx_model.nq)
+        nv = int(self.mjx_model.nv)
+
+        byof_dynamics: dict = {
+            "qvel": mjx_dynamics(
+                self.mjx_model,
+                qpos=self._qpos,
+                qvel=self._qvel,
+                ctrl=self._ctrl,
+                return_component=self.return_component,
+                extra_postprocess=self.extra_postprocess,
+            ),
+        }
+
+        n_free = nq - nv
+        if n_free > 0:
+            byof_dynamics["qpos"] = _free_joint_qpos_dynamics(
+                qpos=self._qpos,
+                qvel=self._qvel,
+                n_free_joints=n_free,
+            )
+            dynamics_dict: dict = {}
+        else:
+            dynamics_dict = {"qpos": self._qvel}
+
+        return dynamics_dict, {"dynamics": byof_dynamics}

--- a/openscvx/integrations/mjx.py
+++ b/openscvx/integrations/mjx.py
@@ -15,8 +15,9 @@ State/Control objects on ``.states`` / ``.controls``::
 Free-joint quaternion kinematics (``nq > nv`` models such as drones or
 humanoids) are detected and handled automatically.
 
-For advanced users, the lower-level `mjx_dynamics` callable factory and the
-legacy `mjx_byof` helper remain available.
+The lower-level `mjx_dynamics` callable factory is also public for advanced
+users who need to assemble their own BYOF dynamics dict (e.g. with custom
+State/Control names or interleaved with other states).
 
 Note:
     Time dilation is handled automatically by the BYOF lowering pipeline; all
@@ -169,7 +170,7 @@ def _free_joint_qpos_dynamics(
 ) -> Callable:
     """BYOF callable for ``qpos`` when the model has quaternion free joints.
 
-    Used internally by :func:`mjx_byof`.  When a MuJoCo model has a
+    Used internally by `MjxDynamics`.  When a MuJoCo model has a
     floating-base free joint, ``nq > nv`` because each quaternion orientation
     contributes 4 position DOF but only 3 angular velocity DOF. The simple
     symbolic shorthand ``"qpos": qvel`` therefore fails a shape check. This
@@ -251,88 +252,57 @@ def _free_joint_qpos_dynamics(
     return f
 
 
-def mjx_byof(
-    mjx_model: Any,
-    *,
-    qpos: "State | slice",
-    qvel: "State | slice",
-    ctrl: "Control | slice",
-    return_component: str = "qacc",
-    extra_postprocess: Optional[Callable[[Any], Any]] = None,
-) -> dict:
-    """Return a complete ``byof["dynamics"]`` dict for a MuJoCo MJX model.
+# MuJoCo joint type enum (matches mujoco.mjtJoint): 0=free, 1=ball, 2=slide, 3=hinge.
+# Inlined here so we don't require `mujoco` to be importable just for type validation —
+# the user already needs mujoco to have constructed the mjx_model, but keeping the
+# numeric constants local makes this file self-contained.
+_MJ_JNT_FREE = 0
+_MJ_JNT_BALL = 1
+_MJ_JNT_SLIDE = 2
+_MJ_JNT_HINGE = 3
 
-    Note:
-        `MjxDynamics` is the preferred entry-point — it goes directly in the
-        ``dynamics=`` slot of `Problem` and constructs the matching
-        State/Control objects for you. Use `mjx_byof` only when you need to
-        supply custom State/Control objects (e.g. interleave them with other
-        states) or otherwise want full control over names.
 
-    It inspects the model's ``nq`` and ``nv`` to detect free joints and
-    automatically includes the quaternion kinematics callable for ``qpos``
-    when needed.
+def _validate_supported_joints(mjx_model: Any) -> None:
+    """Refuse models whose joint layout the adapter cannot correctly handle.
 
-    Args:
-        mjx_model: A model produced by :func:`mujoco.mjx.put_model`.
-        qpos: Position state (or slice). Length must equal ``mjx_model.nq``.
-        qvel: Velocity state (or slice). Length must equal ``mjx_model.nv``.
-        ctrl: Control variable (or slice). Length must equal ``mjx_model.nu``.
-        return_component: Passed to :func:`mjx_dynamics`. ``"qacc"``
-            (default) uses the generalized acceleration as the ``qvel``
-            derivative; ``"qvel"`` returns qvel directly (rarely needed).
-        extra_postprocess: Optional callable applied to the MJX ``data``
-            object after ``mjx.forward``. Passed through to
-            :func:`mjx_dynamics`.
-
-    Returns:
-        A dict suitable for use as ``byof["dynamics"]``.
-        For models **without** free joints (``nq == nv``) only ``"qvel"`` is
-        included; position kinematics should still be provided symbolically
-        via ``dynamics={"qpos": qvel}``.
-        For models **with** free joints (``nq > nv``) both ``"qpos"`` and
-        ``"qvel"`` are included and no symbolic ``dynamics`` entry is needed.
-
-    Example:
-        Cartpole (nq == nv, no free joint)::
-
-            byof = {"dynamics": mjx_byof(mjx_model, qpos=qpos, qvel=qvel, ctrl=ctrl)}
-            problem = ox.Problem(
-                dynamics={"qpos": qvel},   # still required for non-free models
-                byof=byof, ...
-            )
-
-        Quadrotor / drone (nq > nv, one free joint)::
-
-            byof = {"dynamics": mjx_byof(mjx_model, qpos=qpos, qvel=qvel, ctrl=ctrl)}
-            problem = ox.Problem(
-                dynamics={},               # qpos handled automatically
-                byof=byof, ...
-            )
+    `MjxDynamics` only supports models composed of free / slide / hinge joints
+    where all free joints precede the others in the state layout. Anything else
+    (ball joints, custom joint orderings) silently breaks the
+    `_free_joint_qpos_dynamics` arithmetic, so we refuse with a clear error
+    rather than producing wrong dynamics.
     """
-    nq = int(mjx_model.nq)
-    nv = int(mjx_model.nv)
+    import numpy as _np
 
-    result: dict = {
-        "qvel": mjx_dynamics(
-            mjx_model,
-            qpos=qpos,
-            qvel=qvel,
-            ctrl=ctrl,
-            return_component=return_component,
-            extra_postprocess=extra_postprocess,
-        ),
-    }
-
-    n_free = nq - nv  # each free joint contributes exactly 1 extra position DOF
-    if n_free > 0:
-        result["qpos"] = _free_joint_qpos_dynamics(
-            qpos=qpos,
-            qvel=qvel,
-            n_free_joints=n_free,
+    jnt_type = _np.asarray(mjx_model.jnt_type).astype(int)
+    supported = {_MJ_JNT_FREE, _MJ_JNT_SLIDE, _MJ_JNT_HINGE}
+    bad = sorted(set(jnt_type.tolist()) - supported)
+    if bad:
+        if _MJ_JNT_BALL in bad:
+            raise NotImplementedError(
+                "MjxDynamics does not support ball joints (mjJNT_BALL): they "
+                "share nq=4, nv=3 with free joints but use different "
+                "kinematics, and the current quaternion-kinematics callable "
+                "would silently produce wrong dynamics. Use `mjx_dynamics` "
+                "directly and assemble byof['dynamics'] manually."
+            )
+        raise NotImplementedError(
+            f"MjxDynamics only supports free, slide, and hinge joints; "
+            f"model contains unsupported joint types {bad}. Use "
+            "`mjx_dynamics` directly and assemble byof['dynamics'] manually."
         )
 
-    return result
+    # _free_joint_qpos_dynamics assumes all free joints come first in the
+    # state vector. If a slide/hinge precedes a free joint, the quaternion
+    # offsets would be off.
+    free_mask = jnt_type == _MJ_JNT_FREE
+    n_free = int(free_mask.sum())
+    if n_free and not free_mask[:n_free].all():
+        raise NotImplementedError(
+            "MjxDynamics requires all free joints to come before any "
+            "slide/hinge joints in the MuJoCo model. Reorder the joints in "
+            "your MJCF/URDF, or use `mjx_dynamics` directly to assemble "
+            "byof['dynamics'] yourself."
+        )
 
 
 class MjxDynamics(DynamicsAdapter):
@@ -371,7 +341,22 @@ class MjxDynamics(DynamicsAdapter):
 
     Custom State/Control names or shapes are *not* supported here on purpose
     — the whole point of the adapter is "I don't want to think about names."
-    Drop to the lower-level `mjx_byof` helper if you need that control.
+    Drop to the lower-level `mjx_dynamics` helper if you need that control —
+    construct your own State/Control objects, pass them in, and assemble the
+    BYOF dict yourself.
+
+    Supported joint structure:
+        * Free (``mjJNT_FREE``), slide (``mjJNT_SLIDE``), and hinge
+          (``mjJNT_HINGE``) joints only.
+        * If the model contains any free joints, they must all come
+          *before* any slide/hinge joints in the MuJoCo layout.
+        * Ball joints (``mjJNT_BALL``) are explicitly refused — they share
+          ``nq=4, nv=3`` with free joints but use different kinematics, and
+          would silently produce wrong dynamics.
+
+        Construction raises ``NotImplementedError`` if any of these
+        conditions are violated; fall back to `mjx_dynamics` for those
+        cases.
     """
 
     def __init__(
@@ -383,6 +368,8 @@ class MjxDynamics(DynamicsAdapter):
     ) -> None:
         from openscvx.symbolic.expr.control import Control
         from openscvx.symbolic.expr.state import State
+
+        _validate_supported_joints(mjx_model)
 
         self.mjx_model = mjx_model
         self.return_component = return_component

--- a/openscvx/integrations/mjx.py
+++ b/openscvx/integrations/mjx.py
@@ -262,6 +262,54 @@ _MJ_JNT_SLIDE = 2
 _MJ_JNT_HINGE = 3
 
 
+def _initial_bounds_from_model(
+    mjx_model: Any, nq: int, nv: int, nu: int
+) -> Tuple[Any, Any, Any, Any, Any, Any]:
+    """Pull qpos / ctrl bounds out of the MJX model.
+
+    Returns ``(qpos_min, qpos_max, qvel_min, qvel_max, ctrl_min, ctrl_max)``.
+
+    - ``qpos`` bounds come from ``mjx_model.jnt_range`` for slide/hinge joints
+      flagged ``jnt_limited=True``. All other qpos slots — free-joint
+      translations and quaternion components, unlimited slide/hinge joints —
+      get ``±inf``.
+    - ``ctrl`` bounds come from ``mjx_model.actuator_ctrlrange`` for actuators
+      flagged ``actuator_ctrllimited=True``. Unlimited actuators get ``±inf``.
+    - ``qvel`` bounds are always ``±inf`` because MuJoCo has no per-joint
+      velocity-limit concept; users override as needed.
+    """
+    import numpy as _np
+
+    qpos_min = _np.full(nq, -_np.inf)
+    qpos_max = _np.full(nq, _np.inf)
+    qvel_min = _np.full(nv, -_np.inf)
+    qvel_max = _np.full(nv, _np.inf)
+    ctrl_min = _np.full(nu, -_np.inf)
+    ctrl_max = _np.full(nu, _np.inf)
+
+    # Per-joint qpos bounds — only slide/hinge can be range-limited; free
+    # joints always have jnt_limited=False so we skip them safely.
+    jnt_type = _np.asarray(mjx_model.jnt_type).astype(int)
+    jnt_qposadr = _np.asarray(mjx_model.jnt_qposadr).astype(int)
+    jnt_limited = _np.asarray(mjx_model.jnt_limited).astype(bool)
+    jnt_range = _np.asarray(mjx_model.jnt_range).astype(float)
+    for i, jtype in enumerate(jnt_type):
+        if jtype in (_MJ_JNT_SLIDE, _MJ_JNT_HINGE) and jnt_limited[i]:
+            adr = int(jnt_qposadr[i])
+            qpos_min[adr] = jnt_range[i, 0]
+            qpos_max[adr] = jnt_range[i, 1]
+
+    if nu > 0:
+        act_limited = _np.asarray(mjx_model.actuator_ctrllimited).astype(bool)
+        act_range = _np.asarray(mjx_model.actuator_ctrlrange).astype(float)
+        for i in range(nu):
+            if act_limited[i]:
+                ctrl_min[i] = act_range[i, 0]
+                ctrl_max[i] = act_range[i, 1]
+
+    return qpos_min, qpos_max, qvel_min, qvel_max, ctrl_min, ctrl_max
+
+
 def _validate_supported_joints(mjx_model: Any) -> None:
     """Refuse models whose joint layout the adapter cannot correctly handle.
 
@@ -357,6 +405,19 @@ class MjxDynamics(DynamicsAdapter):
         Construction raises ``NotImplementedError`` if any of these
         conditions are violated; fall back to `mjx_dynamics` for those
         cases.
+
+    Auto-populated bounds:
+        * ``qpos.min`` / ``qpos.max`` are read from ``mjx_model.jnt_range``
+          for slide / hinge joints flagged ``jnt_limited=True``; free-joint
+          slots and unlimited joints default to ``±inf``.
+        * ``ctrl.min`` / ``ctrl.max`` are read from ``actuator_ctrlrange``
+          for actuators flagged ``actuator_ctrllimited=True``; otherwise
+          ``±inf``.
+        * ``qvel`` bounds default to ``±inf`` (MuJoCo has no per-joint
+          velocity-limit concept).
+
+        Override any of these after construction if you want tighter
+        problem-specific bounds.
     """
 
     def __init__(
@@ -382,6 +443,19 @@ class MjxDynamics(DynamicsAdapter):
         self._qpos = State("qpos", shape=(nq,))
         self._qvel = State("qvel", shape=(nv,))
         self._ctrl = Control("ctrl", shape=(nu,))
+
+        # Auto-populate bounds from the model so the user doesn't have to
+        # re-type joint / actuator limits already declared in MJCF. Users
+        # can still override any of these after construction.
+        qpos_min, qpos_max, qvel_min, qvel_max, ctrl_min, ctrl_max = (
+            _initial_bounds_from_model(mjx_model, nq, nv, nu)
+        )
+        self._qpos.min = qpos_min
+        self._qpos.max = qpos_max
+        self._qvel.min = qvel_min
+        self._qvel.max = qvel_max
+        self._ctrl.min = ctrl_min
+        self._ctrl.max = ctrl_max
 
         self.states: list[State] = [self._qpos, self._qvel]
         self.controls: list[Control] = [self._ctrl]

--- a/openscvx/integrations/mjx.py
+++ b/openscvx/integrations/mjx.py
@@ -447,8 +447,8 @@ class MjxDynamics(DynamicsAdapter):
         # Auto-populate bounds from the model so the user doesn't have to
         # re-type joint / actuator limits already declared in MJCF. Users
         # can still override any of these after construction.
-        qpos_min, qpos_max, qvel_min, qvel_max, ctrl_min, ctrl_max = (
-            _initial_bounds_from_model(mjx_model, nq, nv, nu)
+        qpos_min, qpos_max, qvel_min, qvel_max, ctrl_min, ctrl_max = _initial_bounds_from_model(
+            mjx_model, nq, nv, nu
         )
         self._qpos.min = qpos_min
         self._qpos.max = qpos_max

--- a/openscvx/problem.py
+++ b/openscvx/problem.py
@@ -42,6 +42,7 @@ from openscvx.discretization import (
     resolve_discretizer_config,
 )
 from openscvx.expert import ByofSpec
+from openscvx.integrations.base import DynamicsAdapter, _merge_byof
 from openscvx.lowered import LoweredProblem, ParameterDict
 from openscvx.lowered.dynamics import Dynamics
 from openscvx.lowered.jax_constraints import (
@@ -70,7 +71,7 @@ from openscvx.utils.caching import (
 class Problem:
     def __init__(
         self,
-        dynamics: dict,
+        dynamics: Union[dict, DynamicsAdapter],
         constraints: List[Union[Constraint, CTCS]],
         states: List[State],
         controls: List[Control],
@@ -92,9 +93,11 @@ class Problem:
         """The primary class in charge of compiling and exporting the solvers.
 
         Args:
-            dynamics (dict): Dictionary mapping state names to their dynamics expressions.
-                Each key should be a state name, and each value should be an Expr
-                representing the derivative of that state.
+            dynamics: Dictionary mapping state names to their dynamics
+                expressions. Each key should be a state name, and each value
+                should be an ``Expr`` representing the derivative of that
+                state. A ``DynamicsAdapter`` may also be passed here in
+                place of the dict.
             constraints (List[Union[CTCSConstraint, NodalConstraint]]):
                 List of constraints decorated with @ctcs or @nodal
             states (List[State]): List of State objects representing the state variables.
@@ -250,6 +253,12 @@ class Problem:
         self._float_dtype: str = float_dtype
 
         # Symbolic Preprocessing & Augmentation
+        # If `dynamics` is a DynamicsAdapter, expand it into the standard
+        # (dynamics_dict, byof_dict) representation and merge into user byof.
+        if isinstance(dynamics, DynamicsAdapter):
+            dynamics, adapter_byof = dynamics.expand()
+            byof = _merge_byof(byof, adapter_byof)
+
         # Resolve byof: dict → ByofSpec (validates keys and nested specs)
         if byof is not None:
             byof = ByofSpec.model_validate(byof)

--- a/tests/integrations/test_mjx.py
+++ b/tests/integrations/test_mjx.py
@@ -7,7 +7,8 @@ Coverage
                        validation, lazy slice resolution, extra_postprocess hook.
 * ``_free_joint_qpos_dynamics`` — callable/output-shape contract and argument
                        handling (without re-testing quaternion math internals).
-* ``mjx_byof`` and ``integrations.__init__`` — high-level public interface.
+
+The high-level `MjxDynamics` adapter is covered in ``test_mjx_dynamics.py``.
 """
 
 from __future__ import annotations
@@ -298,69 +299,3 @@ class TestFreeJointQposDynamics:
         np.testing.assert_allclose(np.array(out1), np.array(out2), atol=1e-9)
 
 
-# ===========================================================================
-# integrations public API  (__init__.py lazy exports)
-# ===========================================================================
-
-
-@requires_mujoco
-class TestMjxByof:
-    """Tests for the high-level ``mjx_byof`` convenience wrapper."""
-
-    def test_no_free_joints_returns_qvel_only(self, cartpole_mjx_model):
-        """nq == nv model: mjx_byof should only include 'qvel'."""
-        from openscvx.integrations.mjx import mjx_byof
-
-        nq, nv, nu = 2, 2, 1
-        result = mjx_byof(
-            cartpole_mjx_model,
-            qpos=slice(0, nq),
-            qvel=slice(nq, nq + nv),
-            ctrl=slice(0, nu),
-        )
-        assert set(result.keys()) == {"qvel"}
-        assert callable(result["qvel"])
-
-    def test_free_joint_model_returns_qpos_and_qvel(self):
-        """nq > nv model: mjx_byof must include both 'qpos' and 'qvel'."""
-        import mujoco
-        import mujoco.mjx as mjx
-
-        from openscvx.integrations.mjx import mjx_byof
-
-        _FREE_XML = """
-        <mujoco><option gravity="0 0 -9.81"/>
-          <worldbody>
-            <body name="b"><freejoint/><geom type="sphere" size="0.1" mass="1"/></body>
-          </worldbody>
-        </mujoco>"""
-        mj_model = mujoco.MjModel.from_xml_string(_FREE_XML)
-        mj_model.opt.disableflags |= mujoco.mjtDisableBit.mjDSBL_CONTACT
-        mjx_model = mjx.put_model(mj_model)
-        assert mjx_model.nq == 7 and mjx_model.nv == 6
-
-        result = mjx_byof(
-            mjx_model,
-            qpos=slice(0, 7),
-            qvel=slice(7, 13),
-            ctrl=slice(0, 0),
-        )
-        assert set(result.keys()) == {"qpos", "qvel"}
-        assert callable(result["qpos"])
-        assert callable(result["qvel"])
-
-    def test_qvel_callable_output_shape(self, cartpole_mjx_model):
-        """qvel callable must return shape (nv,)."""
-        from openscvx.integrations.mjx import mjx_byof
-
-        nq, nv, nu = 2, 2, 1
-        result = mjx_byof(
-            cartpole_mjx_model,
-            qpos=slice(0, nq),
-            qvel=slice(nq, nq + nv),
-            ctrl=slice(0, nu),
-        )
-        x = jnp.zeros(nq + nv)
-        u = jnp.zeros(nu)
-        out = result["qvel"](x, u, 0, {})
-        assert out.shape == (nv,)

--- a/tests/integrations/test_mjx.py
+++ b/tests/integrations/test_mjx.py
@@ -297,5 +297,3 @@ class TestFreeJointQposDynamics:
         out1 = f(x, jnp.zeros(5), 0, {})
         out2 = f(x, jnp.ones(5) * 999, 42, {"key": "val"})
         np.testing.assert_allclose(np.array(out1), np.array(out2), atol=1e-9)
-
-

--- a/tests/integrations/test_mjx_dynamics.py
+++ b/tests/integrations/test_mjx_dynamics.py
@@ -435,3 +435,105 @@ def test_mjx_dynamics_accepts_slide_plus_hinge(cartpole_mjx_model):
 def test_mjx_dynamics_accepts_pure_free_joint(free_body_mjx_model):
     # No exception — a single free joint is supported.
     ox.MjxDynamics(free_body_mjx_model)
+
+
+# ===========================================================================
+# Auto-populated bounds (jnt_range / actuator_ctrlrange)
+# ===========================================================================
+
+
+_LIMITED_SLIDER_XML = """
+<mujoco model="limited_slider">
+  <option gravity="0 0 -9.81"/>
+  <worldbody>
+    <body name="cart">
+      <joint name="slider" type="slide" axis="1 0 0" limited="true" range="-2.5 4.0"/>
+      <geom type="box" size="0.1 0.1 0.1" mass="1"/>
+      <body name="pole">
+        <joint name="hinge" type="hinge" axis="0 1 0"/>
+        <geom type="capsule" fromto="0 0 0 0 0 0.3" size="0.02" mass="0.1"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <motor joint="slider" gear="5" ctrlrange="-1.5 2.0" ctrllimited="true"/>
+  </actuator>
+</mujoco>
+"""
+
+_UNLIMITED_ACTUATOR_XML = """
+<mujoco>
+  <worldbody>
+    <body><joint name="h" type="hinge" axis="0 0 1"/><geom type="sphere" size="0.1" mass="1"/></body>
+  </worldbody>
+  <actuator>
+    <motor joint="h" gear="1"/>
+  </actuator>
+</mujoco>
+"""
+
+
+@requires_mujoco
+def test_mjx_dynamics_populates_qpos_bounds_from_jnt_range():
+    """Slide joint with `limited="true" range="-2.5 4.0"` flows into qpos.min/max."""
+    mjx_model = _put_model(_LIMITED_SLIDER_XML)
+    dyn = ox.MjxDynamics(mjx_model)
+    qpos, qvel = dyn.states
+
+    # slider is joint 0 → qpos[0]; hinge has no range → ±inf
+    assert qpos.min[0] == pytest.approx(-2.5)
+    assert qpos.max[0] == pytest.approx(4.0)
+    assert qpos.min[1] == -np.inf
+    assert qpos.max[1] == np.inf
+
+
+@requires_mujoco
+def test_mjx_dynamics_populates_ctrl_bounds_from_actuator_ctrlrange():
+    """Actuator with `ctrlrange="-1.5 2.0" ctrllimited="true"` flows into ctrl.min/max."""
+    mjx_model = _put_model(_LIMITED_SLIDER_XML)
+    dyn = ox.MjxDynamics(mjx_model)
+    (ctrl,) = dyn.controls
+
+    assert ctrl.min[0] == pytest.approx(-1.5)
+    assert ctrl.max[0] == pytest.approx(2.0)
+
+
+@requires_mujoco
+def test_mjx_dynamics_unlimited_actuator_defaults_to_inf():
+    """Actuator without ctrllimited gets ±inf ctrl bounds."""
+    mjx_model = _put_model(_UNLIMITED_ACTUATOR_XML)
+    dyn = ox.MjxDynamics(mjx_model)
+    (ctrl,) = dyn.controls
+    assert ctrl.min[0] == -np.inf
+    assert ctrl.max[0] == np.inf
+
+
+@requires_mujoco
+def test_mjx_dynamics_qvel_defaults_to_inf(cartpole_mjx_model):
+    """qvel always defaults to ±inf since MuJoCo has no per-joint velocity limits."""
+    dyn = ox.MjxDynamics(cartpole_mjx_model)
+    _, qvel = dyn.states
+    assert np.all(np.isneginf(qvel.min))
+    assert np.all(np.isposinf(qvel.max))
+
+
+@requires_mujoco
+def test_mjx_dynamics_free_joint_qpos_bounds_are_inf(free_body_mjx_model):
+    """Free joints have jnt_limited=False, so all 7 qpos slots stay at ±inf."""
+    dyn = ox.MjxDynamics(free_body_mjx_model)
+    qpos, _ = dyn.states
+    assert np.all(np.isneginf(qpos.min))
+    assert np.all(np.isposinf(qpos.max))
+
+
+@requires_mujoco
+def test_mjx_dynamics_user_can_override_auto_bounds():
+    """Users can replace the auto-populated bounds after construction."""
+    mjx_model = _put_model(_LIMITED_SLIDER_XML)
+    dyn = ox.MjxDynamics(mjx_model)
+    qpos, _ = dyn.states
+
+    new_min = np.array([-10.0, -5.0])
+    qpos.min = new_min
+    assert qpos.min[0] == -10.0
+    assert qpos.min[1] == -5.0

--- a/tests/integrations/test_mjx_dynamics.py
+++ b/tests/integrations/test_mjx_dynamics.py
@@ -1,9 +1,8 @@
-"""Unit tests for the :class:`MjxDynamics` adapter and dispatch.
+"""Unit tests for the `MjxDynamics` adapter and `Problem` dispatch.
 
-These tests cover the new first-class adapter path (``dynamics=ox.MjxDynamics(...)``)
-introduced on top of the existing ``mjx_byof`` BYOF helper. The lower-level
-callable contract is already covered by ``test_mjx.py`` — this file focuses on
-the adapter surface, the ``Problem`` dispatch, and the BYOF-merge helper.
+The lower-level callable contract (``mjx_dynamics``, ``_free_joint_qpos_dynamics``)
+is covered by ``test_mjx.py``; this file focuses on the adapter surface, the
+``Problem`` dispatch, and the BYOF-merge helper.
 """
 
 from __future__ import annotations
@@ -369,3 +368,70 @@ def test_mjx_dynamics_callables_run_after_slice_assignment(cartpole_mjx_model):
     out = qvel_fn(x, u, 0, {})
     assert out.shape == (int(cartpole_mjx_model.nv),)
     np.testing.assert_array_equal(np.array(out).shape, (cartpole_mjx_model.nv,))
+
+
+# ===========================================================================
+# Joint-structure validation
+# ===========================================================================
+
+
+_BALL_JOINT_XML = """
+<mujoco>
+  <worldbody>
+    <body>
+      <joint type="ball"/>
+      <geom type="sphere" size="0.1" mass="1"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+_FREE_AFTER_HINGE_XML = """
+<mujoco>
+  <worldbody>
+    <body name="hinged">
+      <joint type="hinge" axis="0 0 1"/>
+      <geom type="sphere" size="0.1" mass="1"/>
+    </body>
+    <body name="floater">
+      <freejoint/>
+      <geom type="sphere" size="0.1" mass="1"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+
+def _put_model(xml: str):
+    import mujoco
+    import mujoco.mjx as mjx
+
+    mj_model = mujoco.MjModel.from_xml_string(xml)
+    mj_model.opt.disableflags |= mujoco.mjtDisableBit.mjDSBL_CONTACT
+    return mjx.put_model(mj_model)
+
+
+@requires_mujoco
+def test_mjx_dynamics_rejects_ball_joint():
+    mjx_model = _put_model(_BALL_JOINT_XML)
+    with pytest.raises(NotImplementedError, match="ball joints"):
+        ox.MjxDynamics(mjx_model)
+
+
+@requires_mujoco
+def test_mjx_dynamics_rejects_free_joint_after_hinge():
+    mjx_model = _put_model(_FREE_AFTER_HINGE_XML)
+    with pytest.raises(NotImplementedError, match="free joints to come before"):
+        ox.MjxDynamics(mjx_model)
+
+
+@requires_mujoco
+def test_mjx_dynamics_accepts_slide_plus_hinge(cartpole_mjx_model):
+    # No exception — the cartpole has slide + hinge joints in that order.
+    ox.MjxDynamics(cartpole_mjx_model)
+
+
+@requires_mujoco
+def test_mjx_dynamics_accepts_pure_free_joint(free_body_mjx_model):
+    # No exception — a single free joint is supported.
+    ox.MjxDynamics(free_body_mjx_model)

--- a/tests/integrations/test_mjx_dynamics.py
+++ b/tests/integrations/test_mjx_dynamics.py
@@ -464,7 +464,10 @@ _LIMITED_SLIDER_XML = """
 _UNLIMITED_ACTUATOR_XML = """
 <mujoco>
   <worldbody>
-    <body><joint name="h" type="hinge" axis="0 0 1"/><geom type="sphere" size="0.1" mass="1"/></body>
+    <body>
+      <joint name="h" type="hinge" axis="0 0 1"/>
+      <geom type="sphere" size="0.1" mass="1"/>
+    </body>
   </worldbody>
   <actuator>
     <motor joint="h" gear="1"/>

--- a/tests/integrations/test_mjx_dynamics.py
+++ b/tests/integrations/test_mjx_dynamics.py
@@ -1,0 +1,371 @@
+"""Unit tests for the :class:`MjxDynamics` adapter and dispatch.
+
+These tests cover the new first-class adapter path (``dynamics=ox.MjxDynamics(...)``)
+introduced on top of the existing ``mjx_byof`` BYOF helper. The lower-level
+callable contract is already covered by ``test_mjx.py`` — this file focuses on
+the adapter surface, the ``Problem`` dispatch, and the BYOF-merge helper.
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import openscvx as ox
+from openscvx.integrations.base import DynamicsAdapter, _merge_byof
+
+# ===========================================================================
+# Availability flag
+# ===========================================================================
+
+try:
+    import mujoco.mjx as _mjx  # noqa: F401
+
+    _MUJOCO_AVAILABLE = True
+except ImportError:
+    _MUJOCO_AVAILABLE = False
+
+requires_mujoco = pytest.mark.skipif(
+    not _MUJOCO_AVAILABLE, reason="mujoco / mujoco.mjx not installed"
+)
+
+
+_CARTPOLE_XML = """
+<mujoco model="test_cartpole">
+  <option gravity="0 0 -9.81" timestep="0.01" integrator="Euler"/>
+  <worldbody>
+    <body name="cart" pos="0 0 0">
+      <joint name="slider" type="slide" axis="1 0 0"/>
+      <geom type="box" size="0.2 0.1 0.1" mass="1.0"/>
+      <body name="pole" pos="0 0 0">
+        <joint name="hinge" type="hinge" axis="0 1 0"/>
+        <geom type="capsule" fromto="0 0 0 0 0 0.5" size="0.03" mass="0.5"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <motor joint="slider" name="cart_force" gear="10"
+           ctrlrange="-1 1" ctrllimited="true"/>
+  </actuator>
+</mujoco>
+"""
+
+_FREE_BODY_XML = """
+<mujoco model="free_body">
+  <option gravity="0 0 -9.81"/>
+  <worldbody>
+    <body name="b">
+      <freejoint/>
+      <geom type="sphere" size="0.1" mass="1"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+
+@pytest.fixture(scope="module")
+def cartpole_mjx_model():
+    """nq == nv == 2, nu == 1, contacts disabled."""
+    import mujoco
+    import mujoco.mjx as mjx
+
+    mj_model = mujoco.MjModel.from_xml_string(_CARTPOLE_XML)
+    mj_model.opt.disableflags |= mujoco.mjtDisableBit.mjDSBL_CONTACT
+    return mjx.put_model(mj_model)
+
+
+@pytest.fixture(scope="module")
+def free_body_mjx_model():
+    """nq == 7, nv == 6 (single free joint), nu == 0, contacts disabled."""
+    import mujoco
+    import mujoco.mjx as mjx
+
+    mj_model = mujoco.MjModel.from_xml_string(_FREE_BODY_XML)
+    mj_model.opt.disableflags |= mujoco.mjtDisableBit.mjDSBL_CONTACT
+    return mjx.put_model(mj_model)
+
+
+# ===========================================================================
+# DynamicsAdapter / _merge_byof
+# ===========================================================================
+
+
+def test_merge_byof_passes_extra_through_when_user_byof_is_none():
+    extra = {"dynamics": {"qvel": (lambda x, u, n, p: x)}}
+    merged = _merge_byof(None, extra)
+    assert set(merged.keys()) == {"dynamics"}
+    assert set(merged["dynamics"].keys()) == {"qvel"}
+
+
+def test_merge_byof_combines_user_dynamics_with_adapter_dynamics():
+    user = {"dynamics": {"pos": (lambda x, u, n, p: x)}}
+    extra = {"dynamics": {"qvel": (lambda x, u, n, p: x)}}
+    merged = _merge_byof(user, extra)
+    assert set(merged["dynamics"].keys()) == {"pos", "qvel"}
+
+
+def test_merge_byof_preserves_user_byof_top_level_keys():
+    """Non-``dynamics`` byof keys come through verbatim."""
+    cross_fn = lambda X, U, p: X[:, 0] - 1.0  # noqa: E731
+    user = {"cross_nodal_constraints": [cross_fn]}
+    extra = {"dynamics": {"qvel": (lambda x, u, n, p: x)}}
+    merged = _merge_byof(user, extra)
+    assert merged["cross_nodal_constraints"] is user["cross_nodal_constraints"]
+    assert "qvel" in merged["dynamics"]
+
+
+def test_merge_byof_raises_on_dynamics_key_collision():
+    user = {"dynamics": {"qvel": (lambda x, u, n, p: x)}}
+    extra = {"dynamics": {"qvel": (lambda x, u, n, p: x)}}
+    with pytest.raises(ValueError, match="collide"):
+        _merge_byof(user, extra)
+
+
+# ===========================================================================
+# MjxDynamics — construction and .expand() shape
+# ===========================================================================
+
+
+@requires_mujoco
+def test_mjx_dynamics_subclasses_dynamics_adapter(cartpole_mjx_model):
+    dyn = ox.MjxDynamics(cartpole_mjx_model)
+    assert isinstance(dyn, DynamicsAdapter)
+
+
+@requires_mujoco
+def test_mjx_dynamics_states_and_controls_match_model_dims(cartpole_mjx_model):
+    dyn = ox.MjxDynamics(cartpole_mjx_model)
+    assert len(dyn.states) == 2
+    qpos, qvel = dyn.states
+    assert qpos.name == "qpos" and qpos.shape == (cartpole_mjx_model.nq,)
+    assert qvel.name == "qvel" and qvel.shape == (cartpole_mjx_model.nv,)
+
+    assert len(dyn.controls) == 1
+    (ctrl,) = dyn.controls
+    assert ctrl.name == "ctrl" and ctrl.shape == (cartpole_mjx_model.nu,)
+
+
+@requires_mujoco
+def test_mjx_dynamics_expand_returns_qpos_kinematics_symbolic_when_nq_eq_nv(
+    cartpole_mjx_model,
+):
+    dyn = ox.MjxDynamics(cartpole_mjx_model)
+    dynamics_dict, byof_dict = dyn.expand()
+
+    assert set(dynamics_dict.keys()) == {"qpos"}
+    assert dynamics_dict["qpos"] is dyn.states[1]  # qvel state
+
+    assert set(byof_dict.keys()) == {"dynamics"}
+    assert set(byof_dict["dynamics"].keys()) == {"qvel"}
+    assert callable(byof_dict["dynamics"]["qvel"])
+
+
+@requires_mujoco
+def test_mjx_dynamics_expand_routes_both_through_byof_when_nq_gt_nv(
+    free_body_mjx_model,
+):
+    assert free_body_mjx_model.nq == 7 and free_body_mjx_model.nv == 6
+    dyn = ox.MjxDynamics(free_body_mjx_model)
+    dynamics_dict, byof_dict = dyn.expand()
+
+    assert dynamics_dict == {}
+    assert set(byof_dict["dynamics"].keys()) == {"qpos", "qvel"}
+    assert callable(byof_dict["dynamics"]["qpos"])
+    assert callable(byof_dict["dynamics"]["qvel"])
+
+
+# ===========================================================================
+# Problem dispatch — adapter goes in the dynamics= slot
+# ===========================================================================
+
+
+def _minimal_time(total_time: float = 1.0) -> ox.Time:
+    return ox.Time(
+        initial=0.0,
+        final=ox.Minimize(total_time),
+        min=0.0,
+        max=2.0 * total_time,
+        time_dilation_min=0.05 * total_time,
+        time_dilation_max=2.0 * total_time,
+    )
+
+
+def _set_simple_bounds(state, lo, hi, init, final):
+    state.min = np.asarray(lo)
+    state.max = np.asarray(hi)
+    state.initial = np.asarray(init)
+    state.final = np.asarray(final)
+
+
+@requires_mujoco
+def test_problem_accepts_mjx_dynamics_adapter_for_cartpole(cartpole_mjx_model):
+    """Construct a Problem with an MjxDynamics in the dynamics= slot (nq == nv)."""
+    dyn = ox.MjxDynamics(cartpole_mjx_model)
+    qpos, qvel = dyn.states
+    (ctrl,) = dyn.controls
+
+    _set_simple_bounds(qpos, [-3.0, -2 * np.pi], [3.0, 2 * np.pi], [0.0, np.pi], [0.0, 0.0])
+    _set_simple_bounds(qvel, [-10.0, -15.0], [10.0, 15.0], [0.0, 0.0], [0.0, 0.0])
+    ctrl.min = np.array([-1.0])
+    ctrl.max = np.array([1.0])
+
+    n = 10
+    qpos.guess = np.column_stack([np.zeros(n), np.linspace(np.pi, 0.0, n)])
+    qvel.guess = np.zeros((n, 2))
+    ctrl.guess = np.zeros((n, 1))
+
+    constraints = []
+    for s in (qpos, qvel):
+        constraints.extend([ox.ctcs(s <= s.max), ox.ctcs(s.min <= s)])
+    constraints.extend([ox.ctcs(ctrl <= ctrl.max), ox.ctcs(ctrl.min <= ctrl)])
+
+    problem = ox.Problem(
+        dynamics=dyn,
+        states=dyn.states,
+        controls=dyn.controls,
+        time=_minimal_time(),
+        constraints=constraints,
+        N=n,
+        float_dtype="float64",
+    )
+
+    # Symbolic preprocessing succeeded and merged byof has the qvel callable.
+    assert problem._byof is not None
+    assert "qvel" in problem._byof.dynamics
+    # qpos kinematics came from the symbolic side (nq == nv branch).
+    state_names = {s.name for s in problem.symbolic.states}
+    assert {"qpos", "qvel"}.issubset(state_names)
+
+
+@requires_mujoco
+def test_problem_accepts_mjx_dynamics_adapter_for_free_joint(free_body_mjx_model):
+    """nq > nv free-joint model: both qpos and qvel must be in byof."""
+    dyn = ox.MjxDynamics(free_body_mjx_model)
+    qpos, qvel = dyn.states
+    (ctrl,) = dyn.controls  # nu == 0 → zero-length Control
+
+    qpos.min = np.full(7, -1e3)
+    qpos.max = np.full(7, 1e3)
+    qpos.initial = np.array([0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0])
+    qpos.final = np.array([0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0])
+
+    qvel.min = np.full(6, -1e3)
+    qvel.max = np.full(6, 1e3)
+    qvel.initial = np.zeros(6)
+    qvel.final = np.zeros(6)
+
+    # nu = 0 → empty arrays still satisfy the bounds-required validator.
+    ctrl.min = np.zeros(0)
+    ctrl.max = np.zeros(0)
+
+    n = 8
+    qpos.guess = np.tile(qpos.initial, (n, 1))
+    qvel.guess = np.zeros((n, 6))
+    ctrl.guess = np.zeros((n, 0))
+
+    constraints = [ox.ctcs(qvel <= qvel.max), ox.ctcs(qvel.min <= qvel)]
+
+    problem = ox.Problem(
+        dynamics=dyn,
+        states=dyn.states,
+        controls=dyn.controls,
+        time=_minimal_time(),
+        constraints=constraints,
+        N=n,
+        float_dtype="float64",
+    )
+
+    assert problem._byof is not None
+    assert {"qpos", "qvel"}.issubset(problem._byof.dynamics)
+
+
+@requires_mujoco
+def test_problem_accepts_mjx_dynamics_with_extra_prop_state(cartpole_mjx_model):
+    """User can layer an extra propagation-only state on top of the adapter."""
+    dyn = ox.MjxDynamics(cartpole_mjx_model)
+    qpos, qvel = dyn.states
+    (ctrl,) = dyn.controls
+
+    _set_simple_bounds(qpos, [-3.0, -2 * np.pi], [3.0, 2 * np.pi], [0.0, np.pi], [0.0, 0.0])
+    _set_simple_bounds(qvel, [-10.0, -15.0], [10.0, 15.0], [0.0, 0.0], [0.0, 0.0])
+    ctrl.min = np.array([-1.0])
+    ctrl.max = np.array([1.0])
+
+    n = 8
+    qpos.guess = np.column_stack([np.zeros(n), np.linspace(np.pi, 0.0, n)])
+    qvel.guess = np.zeros((n, 2))
+    ctrl.guess = np.zeros((n, 1))
+
+    # An extra propagation-only state (e.g. cumulative ∫u² for diagnostics).
+    energy = ox.State("energy", shape=(1,))
+    energy.initial = np.array([0.0])
+
+    constraints = []
+    for s in (qpos, qvel):
+        constraints.extend([ox.ctcs(s <= s.max), ox.ctcs(s.min <= s)])
+    constraints.extend([ox.ctcs(ctrl <= ctrl.max), ox.ctcs(ctrl.min <= ctrl)])
+
+    problem = ox.Problem(
+        dynamics=dyn,
+        states=dyn.states,
+        controls=dyn.controls,
+        time=_minimal_time(),
+        constraints=constraints,
+        N=n,
+        states_prop=[energy],
+        dynamics_prop={"energy": ctrl[0] * ctrl[0]},
+        float_dtype="float64",
+    )
+
+    prop_state_names = {s.name for s in problem.symbolic.states_prop}
+    assert "energy" in prop_state_names
+
+
+# ===========================================================================
+# Sanity — MjxDynamics callables produce correct output shapes after dispatch
+# ===========================================================================
+
+
+@requires_mujoco
+def test_mjx_dynamics_callables_run_after_slice_assignment(cartpole_mjx_model):
+    """After Problem construction wires slices, the byof callables run."""
+    dyn = ox.MjxDynamics(cartpole_mjx_model)
+    qpos, qvel = dyn.states
+    (ctrl,) = dyn.controls
+
+    _set_simple_bounds(qpos, [-3.0, -2 * np.pi], [3.0, 2 * np.pi], [0.0, np.pi], [0.0, 0.0])
+    _set_simple_bounds(qvel, [-10.0, -15.0], [10.0, 15.0], [0.0, 0.0], [0.0, 0.0])
+    ctrl.min = np.array([-1.0])
+    ctrl.max = np.array([1.0])
+
+    n = 6
+    qpos.guess = np.zeros((n, 2))
+    qvel.guess = np.zeros((n, 2))
+    ctrl.guess = np.zeros((n, 1))
+
+    constraints = []
+    for s in (qpos, qvel):
+        constraints.extend([ox.ctcs(s <= s.max), ox.ctcs(s.min <= s)])
+    constraints.extend([ox.ctcs(ctrl <= ctrl.max), ox.ctcs(ctrl.min <= ctrl)])
+
+    problem = ox.Problem(
+        dynamics=dyn,
+        states=dyn.states,
+        controls=dyn.controls,
+        time=_minimal_time(),
+        constraints=constraints,
+        N=n,
+        float_dtype="float64",
+    )
+
+    # Pull the byof qvel callable from the validated ByofSpec; it should
+    # accept a unified x vector and return (nv,).
+    qvel_fn = problem._byof.dynamics["qvel"]
+    n_x = sum(s.shape[0] for s in problem.symbolic.states)
+    n_u = sum(c.shape[0] for c in problem.symbolic.controls)
+    x = jnp.zeros(n_x)
+    u = jnp.zeros(n_u)
+    out = qvel_fn(x, u, 0, {})
+    assert out.shape == (int(cartpole_mjx_model.nv),)
+    np.testing.assert_array_equal(np.array(out).shape, (cartpole_mjx_model.nv,))


### PR DESCRIPTION
- Promote MuJoCo MJX to a first-class dynamics backend via a new `DynamicsAdapter` ABC. `Problem` now accepts an adapter in the `dynamics=` slot, expanding it into the existing `(dynamics_dict, byof_dict)` representation internally. -> Fixes #468
- Add `ox.MjxDynamics(mjx_model)` adapter that builds default `qpos` / `qvel` / `ctrl` State and Control objects from `nq` / `nv` / `nu`, exposed on `.states` / `.controls`. Free-joint quaternion kinematics (nq > nv) are detected and routed through BYOF automatically.
- Auto-populate `qpos.min` / `qpos.max` from `jnt_range` (slide/hinge with `jnt_limited=True`) and `ctrl.min` / `ctrl.max` from `actuator_ctrlrange`; unlimited slots default to ±inf and users can still override.
- Validate joint structure on construction: ball joints (`mjJNT_BALL`) and unsupported types raise `NotImplementedError`, and free joints must precede slide/hinge joints in the model layout (the quaternion-kinematics callable depends on this).
- Remove the transitional `mjx_byof` helper. The lower-level `mjx_dynamics` callable factory stays public for users who need custom State/Control names.
- Migrate all five `examples/mjx/*.py` scripts to the new adapter form.
- Cover the new surface with 22 unit tests in `tests/integrations/test_mjx_dynamics.py` (adapter shape, `Problem` dispatch, `_merge_byof` collisions, joint validation, auto-populated bounds).