### PR TITLE
Feature/solver iteration callbacks

### DIFF
--- a/docs/UnderTheHood/lowering_architecture.md
+++ b/docs/UnderTheHood/lowering_architecture.md
@@ -171,6 +171,16 @@ of the abstract `PTRSolver` base. Three backends ship today:
 | QPAX | `QPAXPTRSolver` | `solver={"backend": "qpax"}` | JAX-native QP via `qpax.solve_qp`. Flat `(Q, q, A, b, G, h)` assembly. Supports box / dynamics (continuous and impulsive) / CTCS / boundary-Fix; **rejects** user `.convex()` and cross-node at `initialize()` with a clear "use `CVXPyPTRSolver`" message. Enables a path toward an end-to-end JAX-differentiable SCP loop in follow-up work. |
 | Moreau | `MoreauPTRSolver` | `solver={"backend": "moreau"}` | JAX-native conic solver (`moreau.jax.Solver`). Sparse CSR assembly; SOC epigraphs for the L1 / pos PTR penalties (fewer variables and rows than QPAX). Warm-starts between SCP iterations. Same supported subset as QPAX (continuous and impulsive dynamics). Paves the way for user `.convex()` SOC support in a follow-up. |
 
+Each backend exposes two per-iteration entry points: the historical NumPy
+`update_*` + `solve()` stages used by today's Python-side SCP loop, and a
+JAX-pure `iteration_callback()` built once at `initialize()`. The callback
+returns a `(state, SubproblemData) -> SubproblemSolution` callable; all
+three backends emit the same input/output pytree shape so the callable
+composes with `jax.jit` and `jax.vmap` (CVXPy via `jax.pure_callback` with
+`vmap_method="sequential"` — its batched solves are serial). The downstream
+batchable-`Problem.solve()` work wraps this callback in `lax.while_loop` to
+keep the entire SCP iteration on the JAX boundary.
+
 Picking a backend at construction time:
 
 ```python

--- a/openscvx/algorithms/base.py
+++ b/openscvx/algorithms/base.py
@@ -373,6 +373,14 @@ class AlgorithmState:
         actual_reduction: Actual reduction in ``J_nonlin`` for this iter.
         acceptance_ratio: ``actual_reduction / predicted_reduction``.
         adaptive_state_code: :class:`AdaptiveStateCode` value as ``int32``.
+        moreau_carry: ``(x, z, s)`` warm-start carry for the Moreau conic
+            backend. Populated by :meth:`MoreauPTRSolver.iteration_callback`;
+            non-Moreau backends carry zero arrays of the same shape so the
+            pytree shape stays uniform across backends. Until Phase 3 of
+            ``plans/solver-iteration-callbacks.md`` lands the leaves are
+            zero-length placeholders — the Moreau backend will replace them
+            with the cone-shaped warm-start when ``iteration_callback`` is
+            wired up.
     """
 
     x: jnp.ndarray
@@ -394,6 +402,7 @@ class AlgorithmState:
     actual_reduction: jnp.ndarray
     acceptance_ratio: jnp.ndarray
     adaptive_state_code: jnp.ndarray
+    moreau_carry: Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]
 
     # Field order is the source of truth for tree_flatten / tree_unflatten;
     # keep _FIELDS in sync with the dataclass field declarations above.
@@ -417,6 +426,7 @@ class AlgorithmState:
         "actual_reduction",
         "acceptance_ratio",
         "adaptive_state_code",
+        "moreau_carry",
     )
 
     def replace(self, **changes) -> "AlgorithmState":
@@ -475,6 +485,14 @@ class AlgorithmState:
         else:
             lam_cost_init = np.full(n_states, weights.lam_cost)
 
+        # ``moreau_carry`` is sized by the Moreau backend's conic decomposition,
+        # which is not known at this layer — Phase 3 of
+        # ``plans/solver-iteration-callbacks.md`` will plumb the real ``(n_z,)``
+        # / ``(n_cone,)`` shapes through from the solver. For now every backend
+        # carries zero-length placeholders so the pytree is well-formed.
+        carry_zero = put(jnp.zeros((0,), dtype=f))
+        moreau_carry = (carry_zero, carry_zero, carry_zero)
+
         return cls(
             x=put(jnp.asarray(settings.sim.x.guess, dtype=f)),
             u=put(jnp.asarray(settings.sim.u.guess, dtype=f)),
@@ -495,6 +513,7 @@ class AlgorithmState:
             actual_reduction=put(jnp.asarray(0.0, dtype=f)),
             acceptance_ratio=put(jnp.asarray(0.0, dtype=f)),
             adaptive_state_code=put(jnp.asarray(int(AdaptiveStateCode.INITIAL), dtype=i)),
+            moreau_carry=moreau_carry,
         )
 
 

--- a/openscvx/algorithms/base.py
+++ b/openscvx/algorithms/base.py
@@ -373,14 +373,6 @@ class AlgorithmState:
         actual_reduction: Actual reduction in ``J_nonlin`` for this iter.
         acceptance_ratio: ``actual_reduction / predicted_reduction``.
         adaptive_state_code: :class:`AdaptiveStateCode` value as ``int32``.
-        moreau_carry: ``(x, z, s)`` warm-start carry for the Moreau conic
-            backend. Populated by :meth:`MoreauPTRSolver.iteration_callback`;
-            non-Moreau backends carry zero arrays of the same shape so the
-            pytree shape stays uniform across backends. Until Phase 3 of
-            ``plans/solver-iteration-callbacks.md`` lands the leaves are
-            zero-length placeholders — the Moreau backend will replace them
-            with the cone-shaped warm-start when ``iteration_callback`` is
-            wired up.
     """
 
     x: jnp.ndarray
@@ -402,7 +394,6 @@ class AlgorithmState:
     actual_reduction: jnp.ndarray
     acceptance_ratio: jnp.ndarray
     adaptive_state_code: jnp.ndarray
-    moreau_carry: Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]
 
     # Field order is the source of truth for tree_flatten / tree_unflatten;
     # keep _FIELDS in sync with the dataclass field declarations above.
@@ -426,7 +417,6 @@ class AlgorithmState:
         "actual_reduction",
         "acceptance_ratio",
         "adaptive_state_code",
-        "moreau_carry",
     )
 
     def replace(self, **changes) -> "AlgorithmState":
@@ -485,14 +475,6 @@ class AlgorithmState:
         else:
             lam_cost_init = np.full(n_states, weights.lam_cost)
 
-        # ``moreau_carry`` is sized by the Moreau backend's conic decomposition,
-        # which is not known at this layer — Phase 3 of
-        # ``plans/solver-iteration-callbacks.md`` will plumb the real ``(n_z,)``
-        # / ``(n_cone,)`` shapes through from the solver. For now every backend
-        # carries zero-length placeholders so the pytree is well-formed.
-        carry_zero = put(jnp.zeros((0,), dtype=f))
-        moreau_carry = (carry_zero, carry_zero, carry_zero)
-
         return cls(
             x=put(jnp.asarray(settings.sim.x.guess, dtype=f)),
             u=put(jnp.asarray(settings.sim.u.guess, dtype=f)),
@@ -513,7 +495,6 @@ class AlgorithmState:
             actual_reduction=put(jnp.asarray(0.0, dtype=f)),
             acceptance_ratio=put(jnp.asarray(0.0, dtype=f)),
             adaptive_state_code=put(jnp.asarray(int(AdaptiveStateCode.INITIAL), dtype=i)),
-            moreau_carry=moreau_carry,
         )
 
 

--- a/openscvx/solvers/cvxpy_ptr_solver.py
+++ b/openscvx/solvers/cvxpy_ptr_solver.py
@@ -1015,8 +1015,8 @@ class CVXPyPTRSolver(PTRSolver):
 
         Args:
             state: :class:`AlgorithmState` pytree. Accepted for cross-backend
-                signature uniformity but unused — CVXPy has no warm-start hook
-                exposed on this path.
+                signature uniformity but unused — CVXPy exposes no warm-start
+                through ``update_*``.
             data: :class:`SubproblemData` pytree carrying the per-iteration
                 linearization arrays, penalty weights, and boundary conditions.
         """
@@ -1100,8 +1100,8 @@ class CVXPyPTRSolver(PTRSolver):
                 status_code=jnp.asarray(int(status_str_to_code(result.status)), dtype=jnp.int32),
             )
 
-        def callback(state, data: SubproblemData) -> SubproblemSolution:
-            del state  # CVXPy has no warm-start hook exposed through update_*.
+        def step(state, data: SubproblemData) -> SubproblemSolution:
+            del state  # CVXPy exposes no warm-start through ``update_*``.
             return jax.pure_callback(
                 host_solve,
                 result_struct,
@@ -1109,7 +1109,7 @@ class CVXPyPTRSolver(PTRSolver):
                 vmap_method="sequential",
             )
 
-        return callback
+        return step
 
     def citation(self) -> List[str]:
         """Return BibTeX citations for CVXPy.

--- a/openscvx/solvers/cvxpy_ptr_solver.py
+++ b/openscvx/solvers/cvxpy_ptr_solver.py
@@ -22,7 +22,6 @@ from openscvx.config import Config
 from .ptr_solver import (
     PTRSolver,
     PTRSolveResult,
-    StatusCode,
     SubproblemData,
     SubproblemSolution,
     status_str_to_code,

--- a/openscvx/solvers/cvxpy_ptr_solver.py
+++ b/openscvx/solvers/cvxpy_ptr_solver.py
@@ -1013,9 +1013,6 @@ class CVXPyPTRSolver(PTRSolver):
         :attr:`StatusCode.UNKNOWN` — the SCP trust-region check is the
         authoritative convergence gate.
 
-        ``moreau_carry`` is emitted as a zero-length placeholder triple so the
-        pytree shape stays uniform with the QPAX and Moreau backends.
-
         Args:
             state: :class:`AlgorithmState` pytree. Accepted for cross-backend
                 signature uniformity but unused — CVXPy has no warm-start hook
@@ -1040,7 +1037,6 @@ class CVXPyPTRSolver(PTRSolver):
         has_impulsive = bool(slice_imp.stop > slice_imp.start)
         f = jnp.float64 if jax.config.read("jax_enable_x64") else jnp.float32
 
-        zero = jax.ShapeDtypeStruct((0,), f)
         result_struct = SubproblemSolution(
             x=jax.ShapeDtypeStruct((N, n_x), f),
             u=jax.ShapeDtypeStruct((N, n_u), f),
@@ -1049,7 +1045,6 @@ class CVXPyPTRSolver(PTRSolver):
             nu_vb_cross=jax.ShapeDtypeStruct((n_cross,), f),
             cost=jax.ShapeDtypeStruct((), f),
             status_code=jax.ShapeDtypeStruct((), jnp.int32),
-            moreau_carry=(zero, zero, zero),
         )
 
         def host_solve(data: SubproblemData) -> SubproblemSolution:
@@ -1103,11 +1098,6 @@ class CVXPyPTRSolver(PTRSolver):
                 ),
                 cost=jnp.asarray(result.cost, dtype=f),
                 status_code=jnp.asarray(int(status_str_to_code(result.status)), dtype=jnp.int32),
-                moreau_carry=(
-                    jnp.zeros((0,), dtype=f),
-                    jnp.zeros((0,), dtype=f),
-                    jnp.zeros((0,), dtype=f),
-                ),
             )
 
         def callback(state, data: SubproblemData) -> SubproblemSolution:

--- a/openscvx/solvers/cvxpy_ptr_solver.py
+++ b/openscvx/solvers/cvxpy_ptr_solver.py
@@ -129,7 +129,11 @@ class CVXPyPTRSolver(PTRSolver):
 
     The solver builds the problem structure once during ``initialize()``, using
     CVXPy Parameters for values that change each iteration. The ``solve()``
-    method then solves and returns a structured ``PTRSolveResult``.
+    method then solves and returns a structured ``PTRSolveResult``. The
+    JAX-pure entry point :meth:`iteration_callback` wraps that same solve in
+    :func:`jax.pure_callback` (``vmap_method="sequential"`` — CVXPy cannot
+    batch) so the backend composes with ``jax.jit`` / ``jax.vmap`` alongside
+    the JAX-native QPAX and Moreau backends.
 
     The cost and constraint formulations are defined in the ``cost()`` and
     ``constraints()`` methods, which can be overridden in subclasses to

--- a/openscvx/solvers/cvxpy_ptr_solver.py
+++ b/openscvx/solvers/cvxpy_ptr_solver.py
@@ -997,12 +997,12 @@ class CVXPyPTRSolver(PTRSolver):
         :attr:`StatusCode.UNKNOWN` — the SCP trust-region check is the
         authoritative convergence gate.
 
-        Args:
-            state: :class:`AlgorithmState` pytree. Accepted for cross-backend
-                signature uniformity but unused — CVXPy exposes no warm-start
-                through ``update_*``.
-            data: :class:`SubproblemData` pytree carrying the per-iteration
-                linearization arrays, penalty weights, and boundary conditions.
+        The returned callable takes ``(state, data)``: ``state`` is the
+        :class:`AlgorithmState` pytree, accepted for cross-backend signature
+        uniformity but unused (CVXPy exposes no warm-start through
+        ``update_*``); ``data`` is the :class:`SubproblemData` pytree carrying
+        the per-iteration linearization arrays, penalty weights, and boundary
+        conditions.
         """
         if self._problem is None or self._settings is None or self._jax_constraints is None:
             raise RuntimeError(

--- a/openscvx/solvers/cvxpy_ptr_solver.py
+++ b/openscvx/solvers/cvxpy_ptr_solver.py
@@ -879,6 +879,19 @@ class CVXPyPTRSolver(PTRSolver):
             status=self._problem.status,
         )
 
+    def iteration_callback(self):
+        """JAX-pure SCP iteration entry point (not yet wired for CVXPy).
+
+        Implemented in a follow-up slice of ``plans/solver-iteration-callbacks.md``
+        — Phase 4 wraps the existing NumPy ``solve()`` in ``jax.pure_callback``.
+        Callers on the JAX-pure path should select QPAX or Moreau in the
+        meantime.
+        """
+        raise NotImplementedError(
+            "CVXPyPTRSolver.iteration_callback() not yet implemented; "
+            "use QPAXPTRSolver or MoreauPTRSolver for the JAX-pure path."
+        )
+
     def citation(self) -> List[str]:
         """Return BibTeX citations for CVXPy.
 

--- a/openscvx/solvers/cvxpy_ptr_solver.py
+++ b/openscvx/solvers/cvxpy_ptr_solver.py
@@ -119,25 +119,6 @@ def _unmask_bc(bc: "jnp.ndarray") -> np.ndarray:
     return np.nan_to_num(arr, nan=0.0)
 
 
-def _collapse_nu_vb(
-    nu_vb: List[np.ndarray],
-    N: int,
-    n_nodal: int,
-    dtype,
-) -> "jnp.ndarray":
-    """Collapse ``PTRSolveResult.nu_vb`` from list-of-``(N,)`` to ``(N, n_nodal)``.
-
-    :class:`PTRSolveResult` keeps the list-of-arrays layout the historic
-    NumPy SCP loop expects; the JAX-pure :class:`SubproblemSolution` declares
-    a single stacked array for ``pure_callback``'s ``ShapeDtypeStruct``
-    contract. The two paths diverge only at the iteration-callback output
-    boundary.
-    """
-    if n_nodal == 0:
-        return jnp.zeros((N, 0), dtype=dtype)
-    return jnp.asarray(np.stack([np.asarray(arr) for arr in nu_vb], axis=-1), dtype=dtype)
-
-
 class CVXPyPTRSolver(PTRSolver):
     """CVXPy-backed implementation of the PTR convex subproblem.
 
@@ -1091,7 +1072,17 @@ class CVXPyPTRSolver(PTRSolver):
                 x=jnp.asarray(result.x, dtype=f),
                 u=jnp.asarray(result.u, dtype=f),
                 nu=jnp.asarray(result.nu, dtype=f),
-                nu_vb=_collapse_nu_vb(result.nu_vb, N, n_nodal, f),
+                # nu_vb collapses from PTRSolveResult's list-of-(N,) layout to
+                # the (N, n_nodal) stacked array SubproblemSolution declares
+                # for pure_callback's ShapeDtypeStruct contract.
+                nu_vb=(
+                    jnp.zeros((N, 0), dtype=f)
+                    if n_nodal == 0
+                    else jnp.asarray(
+                        np.stack([np.asarray(a) for a in result.nu_vb], axis=-1),
+                        dtype=f,
+                    )
+                ),
                 nu_vb_cross=jnp.asarray(
                     np.asarray(result.nu_vb_cross, dtype=float).reshape(n_cross),
                     dtype=f,

--- a/openscvx/solvers/cvxpy_ptr_solver.py
+++ b/openscvx/solvers/cvxpy_ptr_solver.py
@@ -10,14 +10,23 @@ which targets pure-JAX execution.
 """
 
 import os
-from typing import TYPE_CHECKING, List, Optional, Union
+from typing import TYPE_CHECKING, Callable, List, Optional, Union
 
 import cvxpy as cp
+import jax
+import jax.numpy as jnp
 import numpy as np
 
 from openscvx.config import Config
 
-from .ptr_solver import PTRSolver, PTRSolveResult
+from .ptr_solver import (
+    PTRSolver,
+    PTRSolveResult,
+    StatusCode,
+    SubproblemData,
+    SubproblemSolution,
+    status_str_to_code,
+)
 
 if TYPE_CHECKING:
     from openscvx.lowered import LoweredProblem
@@ -36,6 +45,97 @@ except ImportError:
 
 
 ## TODO: (fabio) add support for impulsive controls
+
+
+def _unstack_nodal(
+    data: SubproblemData,
+    jax_constraints: "LoweredJaxConstraints",
+) -> List[dict]:
+    """Unstack ``SubproblemData``'s ``nodal_*`` arrays into per-constraint dicts.
+
+    The JAX-pure side stacks every nodal constraint's linearization into
+    ``(N, n_nodal, ...)`` arrays with zero-fill at nodes outside each
+    constraint's static ``nodes`` tuple. :meth:`update_constraint_linearizations`
+    expects the list-of-dicts layout the SCP loop has historically built —
+    this helper inverts the stack. The full-N arrays are returned (the zero
+    rows are harmless: CVXPy's constraint set only references the
+    constraint's own ``nodes``).
+    """
+    if not jax_constraints.nodal:
+        return []
+    nodal_g = np.asarray(data.nodal_g)
+    nodal_grad_x = np.asarray(data.nodal_grad_x)
+    nodal_grad_u = np.asarray(data.nodal_grad_u)
+    out: List[dict] = []
+    for c_idx, _constraint in enumerate(jax_constraints.nodal):
+        out.append(
+            {
+                "g": nodal_g[:, c_idx],
+                "grad_g_x": nodal_grad_x[:, c_idx, :],
+                "grad_g_u": nodal_grad_u[:, c_idx, :],
+            }
+        )
+    return out
+
+
+def _unstack_cross(
+    data: SubproblemData,
+    jax_constraints: "LoweredJaxConstraints",
+) -> List[dict]:
+    """Unstack ``SubproblemData``'s cross-node arrays into per-constraint dicts.
+
+    Cross-node constraints stack ``g`` to ``(n_cross,)`` and the gradients to
+    ``(n_cross, N, n_x | n_u)``. :meth:`update_constraint_linearizations`
+    expects per-constraint dicts with the natural orientation.
+    """
+    if not jax_constraints.cross_node:
+        return []
+    cross_g = np.asarray(data.cross_g)
+    cross_grad_X = np.asarray(data.cross_grad_X)
+    cross_grad_U = np.asarray(data.cross_grad_U)
+    out: List[dict] = []
+    for c_idx, _constraint in enumerate(jax_constraints.cross_node):
+        out.append(
+            {
+                "g": cross_g[c_idx],
+                "grad_g_X": cross_grad_X[c_idx],
+                "grad_g_U": cross_grad_U[c_idx],
+            }
+        )
+    return out
+
+
+def _unmask_bc(bc: "jnp.ndarray") -> np.ndarray:
+    """Replace NaN-sentinel free entries with zeros for CVXPy parameter assignment.
+
+    ``SubproblemData.x_init`` / ``x_term`` carry ``jnp.nan`` at indices where
+    the boundary condition is free; CVXPy's ``Parameter.value`` setter rejects
+    non-real arrays via :meth:`CVXPyPTRSolver._set_param`. The CVXPy
+    constraint set only references the indices flagged ``"Fix"`` in
+    ``initial_type`` / ``final_type``, so zeroing the free entries is safe —
+    they're written but never read.
+    """
+    arr = np.asarray(bc, dtype=float)
+    return np.nan_to_num(arr, nan=0.0)
+
+
+def _collapse_nu_vb(
+    nu_vb: List[np.ndarray],
+    N: int,
+    n_nodal: int,
+    dtype,
+) -> "jnp.ndarray":
+    """Collapse ``PTRSolveResult.nu_vb`` from list-of-``(N,)`` to ``(N, n_nodal)``.
+
+    :class:`PTRSolveResult` keeps the list-of-arrays layout the historic
+    NumPy SCP loop expects; the JAX-pure :class:`SubproblemSolution` declares
+    a single stacked array for ``pure_callback``'s ``ShapeDtypeStruct``
+    contract. The two paths diverge only at the iteration-callback output
+    boundary.
+    """
+    if n_nodal == 0:
+        return jnp.zeros((N, 0), dtype=dtype)
+    return jnp.asarray(np.stack([np.asarray(arr) for arr in nu_vb], axis=-1), dtype=dtype)
 
 
 class CVXPyPTRSolver(PTRSolver):
@@ -116,6 +216,11 @@ class CVXPyPTRSolver(PTRSolver):
         self._ocp_vars: "CVXPyVariables" = None
         self._problem: cp.Problem = None
         self._solve_fn: callable = None
+        # Stashed at create_variables / initialize so iteration_callback can
+        # close over them without retracing them off the ``lowered`` /
+        # ``settings`` arguments each iteration.
+        self._jax_constraints: Optional["LoweredJaxConstraints"] = None
+        self._settings: Optional[Config] = None
 
     @property
     def ocp_vars(self) -> "CVXPyVariables":
@@ -202,6 +307,11 @@ class CVXPyPTRSolver(PTRSolver):
             C_d_sparsity=C_d_sp,
             constraint_sparsity=constraint_sparsity,
         )
+
+        # Stash the constraint catalog so iteration_callback can unstack the
+        # JAX-pure ``SubproblemData`` back into the per-constraint dict layout
+        # ``update_constraint_linearizations`` expects.
+        self._jax_constraints = jax_constraints
 
     def lower_convex_constraints(self, constraints, parameters=None):
         """Lower user ``.convex()`` constraints into CVXPy constraint objects.
@@ -291,6 +401,7 @@ class CVXPyPTRSolver(PTRSolver):
                         )
 
         self._problem = prob
+        self._settings = settings
         self._setup_solve_function()
 
     def cost(
@@ -879,18 +990,136 @@ class CVXPyPTRSolver(PTRSolver):
             status=self._problem.status,
         )
 
-    def iteration_callback(self):
-        """JAX-pure SCP iteration entry point (not yet wired for CVXPy).
+    def iteration_callback(self) -> Callable[..., SubproblemSolution]:
+        """JAX-pure ``(state, SubproblemData) -> SubproblemSolution``.
 
-        Implemented in a follow-up slice of ``plans/solver-iteration-callbacks.md``
-        — Phase 4 wraps the existing NumPy ``solve()`` in ``jax.pure_callback``.
-        Callers on the JAX-pure path should select QPAX or Moreau in the
-        meantime.
+        Wraps the existing NumPy ``solve()`` path in :func:`jax.pure_callback`
+        with ``vmap_method="sequential"``. CVXPy can't trace — it builds a DCP
+        graph and reaches into a backend solver through Python attribute
+        mutation — so the only JAX-friendly surface it can present is a host
+        callback. Under :func:`jax.jit` the callback fires once per call; under
+        :func:`jax.vmap` it fires ``B`` times serially (CVXPy can't ingest a
+        batched parameter set).
+
+        The closure unstacks :class:`SubproblemData` back to the per-constraint
+        dict layout :meth:`update_constraint_linearizations` expects, runs the
+        four ``update_*`` methods + :meth:`solve`, and packs the result into a
+        :class:`SubproblemSolution` whose ``nu_vb`` is collapsed to a stacked
+        ``(N, n_nodal)`` array (the list-of-arrays form on
+        :attr:`PTRSolveResult.nu_vb` is preserved for the NumPy path).
+
+        ``status_code`` is mapped via :func:`status_str_to_code`; CVXPy's
+        ``"optimal_inaccurate"`` / ``"solver_error"`` / ... labels collapse to
+        :attr:`StatusCode.UNKNOWN` — the SCP trust-region check is the
+        authoritative convergence gate.
+
+        ``moreau_carry`` is emitted as a zero-length placeholder triple so the
+        pytree shape stays uniform with the QPAX and Moreau backends.
+
+        Args:
+            state: :class:`AlgorithmState` pytree. Accepted for cross-backend
+                signature uniformity but unused — CVXPy has no warm-start hook
+                exposed on this path.
+            data: :class:`SubproblemData` pytree carrying the per-iteration
+                linearization arrays, penalty weights, and boundary conditions.
         """
-        raise NotImplementedError(
-            "CVXPyPTRSolver.iteration_callback() not yet implemented; "
-            "use QPAXPTRSolver or MoreauPTRSolver for the JAX-pure path."
+        if self._problem is None or self._settings is None or self._jax_constraints is None:
+            raise RuntimeError(
+                "CVXPyPTRSolver.iteration_callback() requires initialize() to "
+                "have been called first."
+            )
+
+        settings = self._settings
+        jax_constraints = self._jax_constraints
+        n_x = settings.sim.n_states
+        n_u = settings.sim.n_controls
+        N = settings.sim.n
+        n_nodal = len(jax_constraints.nodal)
+        n_cross = len(jax_constraints.cross_node)
+        slice_imp = settings.sim.u.slice_impulsive
+        has_impulsive = bool(slice_imp.stop > slice_imp.start)
+        f = jnp.float64 if jax.config.read("jax_enable_x64") else jnp.float32
+
+        zero = jax.ShapeDtypeStruct((0,), f)
+        result_struct = SubproblemSolution(
+            x=jax.ShapeDtypeStruct((N, n_x), f),
+            u=jax.ShapeDtypeStruct((N, n_u), f),
+            nu=jax.ShapeDtypeStruct((N - 1, n_x), f),
+            nu_vb=jax.ShapeDtypeStruct((N, n_nodal), f),
+            nu_vb_cross=jax.ShapeDtypeStruct((n_cross,), f),
+            cost=jax.ShapeDtypeStruct((), f),
+            status_code=jax.ShapeDtypeStruct((), jnp.int32),
+            moreau_carry=(zero, zero, zero),
         )
+
+        def host_solve(data: SubproblemData) -> SubproblemSolution:
+            # SubproblemData always carries (N, n_x, n_x) D_d / (N, n_x, n_u) E_d
+            # / (N, n_x) x_prop_plus arrays — zero-filled when the problem has
+            # no impulsive component. ``update_dynamics_linearization`` treats
+            # a non-None D_d as "absorb into A/B/C", which would zero them out
+            # on the no-impulsive path; pass None in that case to keep A/B/C
+            # intact. Same logic for x_prop_plus / E_d.
+            x_prop_plus = np.asarray(data.x_prop_plus) if has_impulsive else None
+            D_d = np.asarray(data.D_d) if has_impulsive else None
+            E_d = np.asarray(data.E_d) if has_impulsive else None
+            self.update_dynamics_linearization(
+                x_bar=np.asarray(data.x_bar),
+                u_bar=np.asarray(data.u_bar),
+                A_d=np.asarray(data.A_d),
+                B_d=np.asarray(data.B_d),
+                C_d=np.asarray(data.C_d),
+                x_prop=np.asarray(data.x_prop),
+                x_prop_plus=x_prop_plus,
+                D_d=D_d,
+                E_d=E_d,
+            )
+            nodal = _unstack_nodal(data, jax_constraints)
+            cross_node = _unstack_cross(data, jax_constraints)
+            self.update_constraint_linearizations(
+                nodal=nodal or None,
+                cross_node=cross_node or None,
+            )
+            self.update_penalties(
+                lam_prox=np.asarray(data.lam_prox),
+                lam_cost=np.asarray(data.lam_cost),
+                lam_vc=np.asarray(data.lam_vc),
+                lam_vb_nodal=np.asarray(data.lam_vb_nodal),
+                lam_vb_cross=np.asarray(data.lam_vb_cross),
+            )
+            self.update_boundary_conditions(
+                x_init=_unmask_bc(data.x_init),
+                x_term=_unmask_bc(data.x_term),
+            )
+
+            result = self.solve()
+            return SubproblemSolution(
+                x=jnp.asarray(result.x, dtype=f),
+                u=jnp.asarray(result.u, dtype=f),
+                nu=jnp.asarray(result.nu, dtype=f),
+                nu_vb=_collapse_nu_vb(result.nu_vb, N, n_nodal, f),
+                nu_vb_cross=jnp.asarray(
+                    np.asarray(result.nu_vb_cross, dtype=float).reshape(n_cross),
+                    dtype=f,
+                ),
+                cost=jnp.asarray(result.cost, dtype=f),
+                status_code=jnp.asarray(int(status_str_to_code(result.status)), dtype=jnp.int32),
+                moreau_carry=(
+                    jnp.zeros((0,), dtype=f),
+                    jnp.zeros((0,), dtype=f),
+                    jnp.zeros((0,), dtype=f),
+                ),
+            )
+
+        def callback(state, data: SubproblemData) -> SubproblemSolution:
+            del state  # CVXPy has no warm-start hook exposed through update_*.
+            return jax.pure_callback(
+                host_solve,
+                result_struct,
+                data,
+                vmap_method="sequential",
+            )
+
+        return callback
 
     def citation(self) -> List[str]:
         """Return BibTeX citations for CVXPy.

--- a/openscvx/solvers/moreau_ptr_solver.py
+++ b/openscvx/solvers/moreau_ptr_solver.py
@@ -1132,6 +1132,19 @@ class MoreauPTRSolver(PTRSolver):
         z = np.asarray(solution.x)
         return self._unpack(z)
 
+    def iteration_callback(self):
+        """JAX-pure SCP iteration entry point (not yet wired for Moreau).
+
+        Implemented in a follow-up slice of ``plans/solver-iteration-callbacks.md``
+        — Phase 3 ports ``_assemble_conic`` to JAX and threads the warm-start
+        carry through ``AlgorithmState.moreau_carry`` instead of
+        ``self._warm_start``.
+        """
+        raise NotImplementedError(
+            "MoreauPTRSolver.iteration_callback() not yet implemented; "
+            "use the NumPy solve() path until Phase 3 lands."
+        )
+
     def _unpack(self, z: np.ndarray) -> PTRSolveResult:
         """Map the flat solution vector into a :class:`PTRSolveResult`.
 

--- a/openscvx/solvers/moreau_ptr_solver.py
+++ b/openscvx/solvers/moreau_ptr_solver.py
@@ -1429,7 +1429,7 @@ class MoreauPTRSolver(PTRSolver):
 
         # Impulsive zero-pin equalities.
         for nodes, ctrl_slice in self._impulsive_pins:
-            for node in nodes:
+            for _node in nodes:
                 for j in range(ctrl_slice.start, ctrl_slice.stop):
                     coo_blocks.append(jnp.asarray([1.0], dtype=f))
                     b_blocks.append((-inv_S_u[j] * c_u[j])[None])

--- a/openscvx/solvers/moreau_ptr_solver.py
+++ b/openscvx/solvers/moreau_ptr_solver.py
@@ -269,6 +269,14 @@ class MoreauPTRSolver(PTRSolver):
     iterations on successful solves, and opens a path to user ``.convex()``
     SOCP support in a follow-up.
 
+    The JAX-pure entry point :meth:`iteration_callback` builds Moreau's
+    functional factory ``moreau.jax.solver(...)`` once at
+    :meth:`initialize` and calls it as
+    ``(P_data, A_data, q, b) -> (JaxSolution, JaxSolveInfo)`` so the backend
+    composes with ``jax.jit`` and ``jax.vmap``. The functional API does not
+    expose a warm-start hook, so the JAX-pure path is cold-start every
+    iteration; the NumPy :meth:`solve` path keeps the OO warm-start.
+
     Scope:
         Supported — state/control box, dynamics linearization (continuous
         and impulsive), boundary Fix, uniform time grid, linearized nodal

--- a/openscvx/solvers/moreau_ptr_solver.py
+++ b/openscvx/solvers/moreau_ptr_solver.py
@@ -63,17 +63,27 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 import numpy as np
 from scipy import sparse as sp
 
-from .ptr_solver import PTRSolver, PTRSolveResult
+from .ptr_solver import (
+    PTRSolver,
+    PTRSolveResult,
+    StatusCode,
+    SubproblemData,
+    SubproblemSolution,
+)
 
 try:
+    import jax
     import jax.numpy as jnp
     import moreau
     from moreau.jax import Solver as _MoreauJaxSolver
+    from moreau.jax import solver as _moreau_jax_solver_fn  # functional factory
 
     _MOREAU_AVAILABLE = True
 except ImportError:  # pragma: no cover — exercised by the install-error test
     moreau = None  # type: ignore[assignment]
     _MoreauJaxSolver = None  # type: ignore[assignment,misc]
+    _moreau_jax_solver_fn = None  # type: ignore[assignment]
+    jax = None  # type: ignore[assignment]
     jnp = None  # type: ignore[assignment]
     _MOREAU_AVAILABLE = False
 
@@ -104,6 +114,40 @@ def _moreau_solve_ok(status: "moreau.SolverStatus") -> bool:
         moreau.SolverStatus.Solved,
         moreau.SolverStatus.AlmostSolved,
     )
+
+
+def _moreau_status_to_code(status: "jnp.ndarray") -> "jnp.ndarray":
+    """Map ``moreau`` solver status (as JAX scalar) to a :class:`StatusCode`.
+
+    Moreau's functional ``JaxSolveInfo.status`` is encoded as a float so it
+    stays JAX-traceable. We cast to ``int32`` and walk the known enum values:
+    :attr:`moreau.SolverStatus.Solved` and ``AlmostSolved`` map to
+    :attr:`StatusCode.OPTIMAL`; any infeasibility/unbounded enum that the
+    installed Moreau happens to expose maps to its natural code; everything
+    else falls through to :attr:`StatusCode.UNKNOWN`.
+
+    Built Python-side as a chain of ``jnp.where`` calls so the mapping table
+    is resolved at trace time and JIT compiles into a single switch.
+    """
+    s = jnp.int32(status)
+    code = jnp.full_like(s, int(StatusCode.UNKNOWN), dtype=jnp.int32)
+    # Successful solve states.
+    for attr in ("Solved", "AlmostSolved"):
+        if hasattr(moreau.SolverStatus, attr):
+            v = int(getattr(moreau.SolverStatus, attr))
+            code = jnp.where(s == v, jnp.int32(int(StatusCode.OPTIMAL)), code)
+    # Infeasibility / unboundedness — different Moreau releases name these
+    # differently. Map every known spelling so the test suite stays robust.
+    for attr, mapped in (
+        ("PrimalInfeasible", StatusCode.INFEASIBLE),
+        ("Infeasible", StatusCode.INFEASIBLE),
+        ("DualInfeasible", StatusCode.UNBOUNDED),
+        ("Unbounded", StatusCode.UNBOUNDED),
+    ):
+        if hasattr(moreau.SolverStatus, attr):
+            v = int(getattr(moreau.SolverStatus, attr))
+            code = jnp.where(s == v, jnp.int32(int(mapped)), code)
+    return code
 
 
 # ---------------------------------------------------------------------------
@@ -395,6 +439,19 @@ class MoreauPTRSolver(PTRSolver):
         self._inv_S_x_diag = 1.0 / self._S_x_diag
         self._inv_S_u_diag = 1.0 / self._S_u_diag
 
+        # JAX-side scaling diagonals for ``iteration_callback``. The dtype
+        # tracks the global ``jax_enable_x64`` setting so the assembled
+        # ``(P_data, A_data, q, b)`` lands in the dtype Moreau's functional
+        # solver expects.
+        f = jnp.float64 if jax.config.read("jax_enable_x64") else jnp.float32
+        self._S_x_diag_j = jnp.asarray(self._S_x_diag, dtype=f)
+        self._S_u_diag_j = jnp.asarray(self._S_u_diag, dtype=f)
+        self._inv_S_x_diag_j = jnp.asarray(self._inv_S_x_diag, dtype=f)
+        self._inv_S_u_diag_j = jnp.asarray(self._inv_S_u_diag, dtype=f)
+        self._c_x_j = jnp.asarray(self._c_x, dtype=f)
+        self._c_u_j = jnp.asarray(self._c_u, dtype=f)
+        self._jax_dtype = f
+
         self.layout = _ConicLayout(N=N, n_x=n_x, n_u=n_u, n_nodal=len(jax_constraints.nodal))
         self._jax_constraints = jax_constraints
 
@@ -461,9 +518,10 @@ class MoreauPTRSolver(PTRSolver):
         self._coo_cols = np.asarray(coo_cols, dtype=np.int32)
 
         # Build CSR for A from the structural COO.
-        if len(coo_rows) > 0:
+        n_coo = len(coo_rows)
+        if n_coo > 0:
             A_struct = sp.csr_matrix(
-                (np.ones(len(coo_rows)), (coo_rows, coo_cols)),
+                (np.ones(n_coo), (coo_rows, coo_cols)),
                 shape=(self._n_con, self.layout.n_z),
             )
             A_struct.sort_indices()
@@ -473,6 +531,22 @@ class MoreauPTRSolver(PTRSolver):
         A_indices = np.asarray(A_struct.indices, dtype=np.int32)
         self._A_indptr = A_indptr
         self._A_indices = A_indices
+
+        # Precompute the COO→CSR permutation so the JAX assembly can emit
+        # ``coo_vals`` in COO traversal order (matching ``_structural_pass``)
+        # and then ``A_data = coo_vals[csr_to_coo_perm]`` matches what
+        # ``solve_qp_primal``/Moreau's ``solve_fn`` expects under the fixed
+        # ``A_col_indices``. NumPy ``solve()`` keeps using scipy's sort path;
+        # this permutation is consumed only by ``_assemble_conic_jax``.
+        if n_coo > 0:
+            A_pos = sp.csr_matrix(
+                (np.arange(n_coo, dtype=np.int32), (coo_rows, coo_cols)),
+                shape=(self._n_con, self.layout.n_z),
+            )
+            A_pos.sort_indices()
+            self._csr_to_coo_perm = np.asarray(A_pos.data, dtype=np.int32)
+        else:
+            self._csr_to_coo_perm = np.zeros((0,), dtype=np.int32)
 
         # Build CSR for P (diagonal on dx/du slots only).
         L = self.layout
@@ -500,6 +574,22 @@ class MoreauPTRSolver(PTRSolver):
         moreau_settings = _build_moreau_settings(self.solver_args)
 
         self._moreau = _MoreauJaxSolver(
+            n=L.n_z,
+            m=self._n_con,
+            P_row_offsets=jnp.array(P_indptr),
+            P_col_indices=jnp.array(P_indices),
+            A_row_offsets=jnp.array(A_indptr),
+            A_col_indices=jnp.array(A_indices),
+            cones=cones,
+            settings=moreau_settings,
+        )
+
+        # Functional-API solve function for ``iteration_callback``. Returns
+        # ``(JaxSolution, JaxSolveInfo)`` as registered pytrees and does NOT
+        # accept warm-start — see the 2026-05-17 Decision Log entry in
+        # ``plans/solver-iteration-callbacks.md``. The OO ``self._moreau``
+        # path stays in use for the NumPy ``solve()`` route (which warm-starts).
+        self._moreau_solve_fn = _moreau_jax_solver_fn(
             n=L.n_z,
             m=self._n_con,
             P_row_offsets=jnp.array(P_indptr),
@@ -1133,17 +1223,375 @@ class MoreauPTRSolver(PTRSolver):
         return self._unpack(z)
 
     def iteration_callback(self):
-        """JAX-pure SCP iteration entry point (not yet wired for Moreau).
+        """JAX-pure ``(state, SubproblemData) -> SubproblemSolution``.
 
-        Implemented in a follow-up slice of ``plans/solver-iteration-callbacks.md``
-        — Phase 3 ports ``_assemble_conic`` to JAX and threads the warm-start
-        carry through ``AlgorithmState.moreau_carry`` instead of
-        ``self._warm_start``.
+        Composes :meth:`_assemble_conic_jax` + Moreau's functional
+        ``solve_fn`` + :meth:`_build_solution_jax` into a single
+        ``@jax.jit``-decorated closure built once at :meth:`initialize`.
+
+        Moreau's functional API (``moreau.jax.solver()``) is the JIT/vmap-friendly
+        path but does **not** accept a warm-start (see the 2026-05-17 Decision
+        Log entry in ``plans/solver-iteration-callbacks.md``). Every call is a
+        cold start; ``state`` is accepted only for cross-backend signature
+        uniformity. ``SubproblemSolution.moreau_carry`` carries a zero-length
+        placeholder triple so the pytree shape is uniform with the other
+        backends.
+
+        Args:
+            state: :class:`AlgorithmState` pytree. Unused on the QPAX/Moreau
+                read paths; preserved for cross-backend signature parity.
+            data: :class:`SubproblemData` pytree carrying the per-iteration
+                linearization arrays, penalty weights, and boundary
+                conditions.
         """
-        raise NotImplementedError(
-            "MoreauPTRSolver.iteration_callback() not yet implemented; "
-            "use the NumPy solve() path until Phase 3 lands."
+        if self.layout is None or self._settings is None:
+            raise RuntimeError(
+                "MoreauPTRSolver.iteration_callback() requires initialize() to "
+                "have been called first."
+            )
+
+        solve_fn = self._moreau_solve_fn
+        csr_to_coo_perm = jnp.asarray(self._csr_to_coo_perm)
+
+        def step(state, data: SubproblemData) -> SubproblemSolution:
+            del state  # Moreau's functional API takes no warm-start.
+            P_data, coo_vals, q, b = self._assemble_conic_jax(data)
+            A_data = coo_vals[csr_to_coo_perm]
+            sol, info = solve_fn(P_data, A_data, q, b)
+            return self._build_solution_jax(sol, info, data)
+
+        return jax.jit(step)
+
+    # ------------------------------------------------------------------
+    # JAX-pure assembly / unpack (used by iteration_callback)
+    # ------------------------------------------------------------------
+
+    def _assemble_conic_jax(
+        self,
+        data: SubproblemData,
+    ) -> Tuple["jnp.ndarray", "jnp.ndarray", "jnp.ndarray", "jnp.ndarray"]:
+        """JAX-pure counterpart of :meth:`_assemble_conic`.
+
+        Returns ``(P_data, coo_vals, q, b)`` where ``coo_vals`` is emitted in
+        the same COO traversal order as :meth:`_structural_pass` — the
+        caller applies the precomputed ``csr_to_coo_perm`` to obtain the
+        ``A_data`` array Moreau's fixed CSR layout expects.
+
+        Mirrors ``_assemble_conic`` row-block by row-block; structural
+        metadata (layout, BC types, impulsive pins, CTCS intervals) is
+        Python-side and closes over the function.
+        """
+        L = self.layout
+        sim = self._settings.sim
+        N, n_x, n_u = L.N, L.n_x, L.n_u
+        inv_S_x = self._inv_S_x_diag_j
+        inv_S_u = self._inv_S_u_diag_j
+        S_x = self._S_x_diag_j
+        S_u = self._S_u_diag_j
+        c_x = self._c_x_j
+        c_u = self._c_u_j
+        f = self._jax_dtype
+        slice_imp = sim.u.slice_impulsive
+        has_impulsive = slice_imp.stop > slice_imp.start
+        eps = jnp.asarray(_P_DIAG_EPS, dtype=f)
+
+        lam_prox = data.lam_prox
+        lam_cost = data.lam_cost
+        lam_vc = data.lam_vc
+        lam_vb_nodal = data.lam_vb_nodal
+
+        # ---------- P_data (diagonal on dx/du slots, in that order) ----------
+        P_dx = (2.0 * lam_prox[:, :n_x] + eps).reshape(-1)
+        P_du = (2.0 * lam_prox[:, n_x:] + eps).reshape(-1)
+        P_data = jnp.concatenate([P_dx, P_du])
+
+        # ---------- q (linear cost) ----------
+        init_signs_np = np.zeros(sim.n_states, dtype=float)
+        final_signs_np = np.zeros(sim.n_states, dtype=float)
+        for i in range(sim.true_state_slice.start, sim.true_state_slice.stop):
+            init_t = sim.x.initial_type[i]
+            final_t = sim.x.final_type[i]
+            if init_t == "Minimize":
+                init_signs_np[i] = 1.0
+            elif init_t == "Maximize":
+                init_signs_np[i] = -1.0
+            if final_t == "Minimize":
+                final_signs_np[i] = 1.0
+            elif final_t == "Maximize":
+                final_signs_np[i] = -1.0
+        init_signs = jnp.asarray(init_signs_np, dtype=f)
+        final_signs = jnp.asarray(final_signs_np, dtype=f)
+        lam_cost_arr = jnp.broadcast_to(jnp.asarray(lam_cost, dtype=f), (sim.n_states,))
+
+        q = jnp.zeros((L.n_z,), dtype=f)
+        x0_start = L.sl_x.start
+        xN_start = L.sl_x.start + (N - 1) * n_x
+        q = q.at[x0_start : x0_start + n_x].add(init_signs * lam_cost_arr)
+        q = q.at[xN_start : xN_start + n_x].add(final_signs * lam_cost_arr)
+        # L1 penalty on t_vc (epigraph of |nu|).
+        q = q.at[L.sl_t_vc].add(lam_vc.reshape(-1))
+        # Pos epigraph t_vb.
+        for c_idx in range(L.n_nodal):
+            q = q.at[L.sl_t_vb[c_idx]].add(lam_vb_nodal[:, c_idx])
+
+        # ---------- coo_vals & b in COO traversal order ----------
+        coo_blocks: List[jnp.ndarray] = []
+        b_blocks: List[jnp.ndarray] = []
+
+        # State error defs (N*n_x rows, 2 coeffs per row).
+        state_err_coeffs = jnp.tile(jnp.asarray([1.0, -1.0], dtype=f), N * n_x)
+        coo_blocks.append(state_err_coeffs)
+        b_blocks.append((inv_S_x * (data.x_bar - c_x[None, :])).reshape(-1))
+
+        # Control error defs (N*n_u rows, 2 coeffs per row).
+        ctrl_err_coeffs = jnp.tile(jnp.asarray([1.0, -1.0], dtype=f), N * n_u)
+        coo_blocks.append(ctrl_err_coeffs)
+        b_blocks.append((inv_S_u * (data.u_bar - c_u[None, :])).reshape(-1))
+
+        # Dynamics rows ((N-1) * n_x), n_per_row = 2 + n_x + 2*n_u.
+        # Match _assemble_conic's emission order:
+        #   [1.0 (x term)] + [-A_blk[i, :n_x]] +
+        #   interleaved [-B_blk[i, j], -C_blk_with_E[i, j] for j in 0..n_u-1] +
+        #   [-1.0 (nu term)]
+        if has_impulsive:
+            D_steps = data.D_d[1:]
+            A_eff = jnp.einsum("kij,kjl->kil", D_steps, data.A_d)
+            B_eff = jnp.einsum("kij,kjl->kil", D_steps, data.B_d)
+            C_eff = jnp.einsum("kij,kjl->kil", D_steps, data.C_d)
+        else:
+            A_eff = data.A_d
+            B_eff = data.B_d
+            C_eff = data.C_d
+        A_blk = (inv_S_x[None, :, None] * A_eff) * S_x[None, None, :]
+        B_blk = (inv_S_x[None, :, None] * B_eff) * S_u[None, None, :]
+        C_blk = (inv_S_x[None, :, None] * C_eff) * S_u[None, None, :]
+        C_with_E = C_blk
+        if has_impulsive:
+            E_blk = (inv_S_x[None, :, None] * data.E_d[1:]) * S_u[None, None, :]
+            imp_slice = slice(slice_imp.start, slice_imp.stop)
+            C_with_E = C_with_E.at[:, :, imp_slice].add(E_blk[:, :, imp_slice])
+
+        n_per_row = 2 + n_x + 2 * n_u
+        dyn_vals = jnp.zeros((N - 1, n_x, n_per_row), dtype=f)
+        dyn_vals = dyn_vals.at[:, :, 0].set(1.0)                       # x[k, i]
+        dyn_vals = dyn_vals.at[:, :, 1 : 1 + n_x].set(-A_blk)          # dx[kp, :]
+        for j in range(n_u):
+            base = 1 + n_x + 2 * j
+            dyn_vals = dyn_vals.at[:, :, base].set(-B_blk[:, :, j])    # du[kp, j]
+            dyn_vals = dyn_vals.at[:, :, base + 1].set(-C_with_E[:, :, j])  # du[k, j]
+        dyn_vals = dyn_vals.at[:, :, -1].set(-1.0)                     # nu[kp, i]
+        coo_blocks.append(dyn_vals.reshape(-1))
+        if has_impulsive:
+            rhs_dyn = inv_S_x[None, :] * (data.x_prop_plus[1:] - c_x[None, :])
+        else:
+            rhs_dyn = inv_S_x[None, :] * (data.x_prop - c_x[None, :])
+        b_blocks.append(rhs_dyn.reshape(-1))
+
+        # Linearized nodal constraints (variable rows per constraint).
+        for c_idx, constraint in enumerate(self._jax_constraints.nodal):
+            nodes_tuple = tuple(constraint.nodes)
+            if not nodes_tuple:
+                continue
+            nodes_arr = jnp.asarray(nodes_tuple)
+            n_nodes = len(nodes_tuple)
+            grad_x_vals = data.nodal_grad_x[nodes_arr, c_idx]          # (n_nodes, n_x)
+            grad_u_vals = data.nodal_grad_u[nodes_arr, c_idx]          # (n_nodes, n_u)
+            neg_one = jnp.full((n_nodes, 1), -1.0, dtype=f)
+            nodal_vals = jnp.concatenate([grad_x_vals, grad_u_vals, neg_one], axis=1)
+            coo_blocks.append(nodal_vals.reshape(-1))
+            b_blocks.append(-data.nodal_g[nodes_arr, c_idx])
+
+        # Boundary Fix rows — emit per-state, init then final, matching
+        # _assemble_conic. Under impulsive control the initial Fix row also
+        # carries du[0, slice_imp] coefficients.
+        imp_j_list = (
+            list(range(slice_imp.start, slice_imp.stop)) if has_impulsive else []
         )
+        for i in range(sim.true_state_slice.start, sim.true_state_slice.stop):
+            init_t = sim.x.initial_type[i]
+            final_t = sim.x.final_type[i]
+            if init_t == "Fix":
+                if has_impulsive:
+                    coeffs = [S_x[i]] + [-data.E_d[0, i, j] * S_u[j] for j in imp_j_list]
+                    rhs_val = data.x_prop_plus[0, i] - c_x[i]
+                else:
+                    coeffs = [S_x[i]]
+                    rhs_val = data.x_init[i] - c_x[i]
+                coo_blocks.append(jnp.stack(coeffs))
+                b_blocks.append(rhs_val[None])
+            if final_t == "Fix":
+                coo_blocks.append(jnp.stack([S_x[i]]))
+                b_blocks.append((data.x_term[i] - c_x[i])[None])
+
+        # Impulsive zero-pin equalities.
+        for nodes, ctrl_slice in self._impulsive_pins:
+            for node in nodes:
+                for j in range(ctrl_slice.start, ctrl_slice.stop):
+                    coo_blocks.append(jnp.asarray([1.0], dtype=f))
+                    b_blocks.append((-inv_S_u[j] * c_u[j])[None])
+
+        # Uniform time grid: u[k, j] - u[k-1, j] = 0.
+        if sim._uniform_time_grid:
+            td = sim.time_dilation_slice
+            n_tg_rows = (N - 1) * (td.stop - td.start)
+            tg_coeffs = jnp.tile(jnp.asarray([1.0, -1.0], dtype=f), n_tg_rows)
+            coo_blocks.append(tg_coeffs)
+            b_blocks.append(jnp.zeros((n_tg_rows,), dtype=f))
+
+        # CTCS initial: S_x[idx] * x[0, idx] = -c_x[idx].
+        ctcs_start = sim.ctcs_slice.start
+        ctcs_stop = sim.ctcs_slice.stop
+        if ctcs_stop > ctcs_start:
+            ctcs_idx_arr = jnp.arange(ctcs_start, ctcs_stop)
+            coo_blocks.append(S_x[ctcs_idx_arr])
+            b_blocks.append(-c_x[ctcs_idx_arr])
+
+        # State / control box (nonneg cone). All-constant coefficients.
+        x_max_sc = inv_S_x * (jnp.asarray(sim.x.max, dtype=f) - c_x)
+        x_min_sc = inv_S_x * (jnp.asarray(sim.x.min, dtype=f) - c_x)
+        u_max_sc = inv_S_u * (jnp.asarray(sim.u.max, dtype=f) - c_u)
+        u_min_sc = inv_S_u * (jnp.asarray(sim.u.min, dtype=f) - c_u)
+        # State box upper: N*n_x rows of coeff +1, RHS x_max_sc tiled.
+        coo_blocks.append(jnp.ones((N * n_x,), dtype=f))
+        b_blocks.append(jnp.tile(x_max_sc, N))
+        # State box lower: N*n_x rows of coeff -1, RHS -x_min_sc tiled.
+        coo_blocks.append(jnp.full((N * n_x,), -1.0, dtype=f))
+        b_blocks.append(jnp.tile(-x_min_sc, N))
+        # Control box upper
+        coo_blocks.append(jnp.ones((N * n_u,), dtype=f))
+        b_blocks.append(jnp.tile(u_max_sc, N))
+        # Control box lower
+        coo_blocks.append(jnp.full((N * n_u,), -1.0, dtype=f))
+        b_blocks.append(jnp.tile(-u_min_sc, N))
+
+        # CTCS difference rows.
+        for idx, nodes in zip(
+            range(ctcs_start, ctcs_stop),
+            sim.ctcs_node_intervals,
+        ):
+            start_i = 1 if nodes[0] == 0 else nodes[0]
+            scale = S_x[idx]
+            x_max_un = float(sim.x.max[idx])
+            for _ in range(start_i, nodes[1]):
+                # +direction: emission order [x[i], x[i-1]] = [scale, -scale]
+                coo_blocks.append(jnp.stack([scale, -scale]))
+                b_blocks.append(jnp.asarray([x_max_un], dtype=f))
+                # -direction: [-scale, scale]
+                coo_blocks.append(jnp.stack([-scale, scale]))
+                b_blocks.append(jnp.asarray([x_max_un], dtype=f))
+
+        # Pos epigraph: t_vb[c, k] >= nu_vb[c, k].
+        # Emission order matches _assemble_conic: [+1 (nu_vb), -1 (t_vb)].
+        for _c_idx in range(L.n_nodal):
+            coeffs_block = jnp.tile(jnp.asarray([1.0, -1.0], dtype=f), N)
+            coo_blocks.append(coeffs_block)
+            b_blocks.append(jnp.zeros((N,), dtype=f))
+
+        # Pos epigraph non-negativity: t_vb[c, k] >= 0.
+        for _c_idx in range(L.n_nodal):
+            coo_blocks.append(jnp.full((N,), -1.0, dtype=f))
+            b_blocks.append(jnp.zeros((N,), dtype=f))
+
+        # SOC: 2 rows per |nu| pair, coeffs [-1] each (t_vc row, then nu row).
+        n_soc = 2 * (N - 1) * n_x
+        soc_coeffs = jnp.full((n_soc,), -1.0, dtype=f)
+        coo_blocks.append(soc_coeffs)
+        b_blocks.append(jnp.zeros((n_soc,), dtype=f))
+
+        coo_vals = (
+            jnp.concatenate(coo_blocks)
+            if coo_blocks
+            else jnp.zeros((0,), dtype=f)
+        )
+        b_vec = (
+            jnp.concatenate(b_blocks) if b_blocks else jnp.zeros((0,), dtype=f)
+        )
+        return P_data, coo_vals, q, b_vec
+
+    def _build_solution_jax(
+        self,
+        sol,
+        info,
+        data: SubproblemData,
+    ) -> SubproblemSolution:
+        """Unpack ``(JaxSolution, JaxSolveInfo)`` into a :class:`SubproblemSolution`.
+
+        Mirrors :meth:`_unpack`: scaled-to-physical trajectories, virtual
+        controls in their natural orientation, ``nu_vb`` stacked to
+        ``(N, n_nodal)``. ``status_code`` is derived from ``info.status`` via
+        :func:`_moreau_status_to_code`. ``moreau_carry`` is a zero-length
+        placeholder triple — the functional API has no warm-start, so the
+        carry is structural-only.
+        """
+        L = self.layout
+        N, n_x, n_u = L.N, L.n_x, L.n_u
+        f = self._jax_dtype
+        z = sol.x
+
+        x_scaled = z[L.sl_x].reshape(N, n_x)
+        u_scaled = z[L.sl_u].reshape(N, n_u)
+        x = x_scaled * self._S_x_diag_j[None, :] + self._c_x_j[None, :]
+        u = u_scaled * self._S_u_diag_j[None, :] + self._c_u_j[None, :]
+        nu = z[L.sl_nu].reshape(N - 1, n_x)
+        if L.n_nodal:
+            nu_vb = jnp.stack([z[sl] for sl in L.sl_nu_vb], axis=-1)
+        else:
+            nu_vb = jnp.zeros((N, 0), dtype=f)
+
+        cost = self._reconstruct_cost_jax(z, data)
+        status_code = _moreau_status_to_code(info.status)
+
+        zero = jnp.zeros((0,), dtype=f)
+        return SubproblemSolution(
+            x=x,
+            u=u,
+            nu=nu,
+            nu_vb=nu_vb,
+            nu_vb_cross=jnp.zeros((0,), dtype=f),
+            cost=cost,
+            status_code=status_code,
+            moreau_carry=(zero, zero, zero),
+        )
+
+    def _reconstruct_cost_jax(
+        self,
+        z: "jnp.ndarray",
+        data: SubproblemData,
+    ) -> "jnp.ndarray":
+        """JAX-pure mirror of :meth:`_reconstruct_cost`."""
+        L = self.layout
+        sim = self._settings.sim
+        N, n_x = L.N, L.n_x
+        f = self._jax_dtype
+        lam_prox = data.lam_prox
+        lam_cost_arr = jnp.broadcast_to(
+            jnp.asarray(data.lam_cost, dtype=f), (sim.n_states,)
+        )
+        lam_vc = data.lam_vc
+        lam_vb_nodal = data.lam_vb_nodal
+
+        dx = z[L.sl_dx].reshape(N, n_x)
+        du = z[L.sl_du].reshape(N, L.n_u)
+        x_scaled = z[L.sl_x].reshape(N, n_x)
+        t_vc = z[L.sl_t_vc].reshape(N - 1, n_x)
+
+        cost = jnp.sum(lam_prox[:, :n_x] * dx**2) + jnp.sum(lam_prox[:, n_x:] * du**2)
+        for i in range(sim.true_state_slice.start, sim.true_state_slice.stop):
+            init_t = sim.x.initial_type[i]
+            final_t = sim.x.final_type[i]
+            if init_t == "Minimize":
+                cost = cost + lam_cost_arr[i] * x_scaled[0, i]
+            elif init_t == "Maximize":
+                cost = cost - lam_cost_arr[i] * x_scaled[0, i]
+            if final_t == "Minimize":
+                cost = cost + lam_cost_arr[i] * x_scaled[-1, i]
+            elif final_t == "Maximize":
+                cost = cost - lam_cost_arr[i] * x_scaled[-1, i]
+        cost = cost + jnp.sum(lam_vc * t_vc)
+        for c_idx in range(L.n_nodal):
+            t_vb = z[L.sl_t_vb[c_idx]]
+            cost = cost + jnp.dot(lam_vb_nodal[:, c_idx], t_vb)
+        return cost.astype(f)
 
     def _unpack(self, z: np.ndarray) -> PTRSolveResult:
         """Map the flat solution vector into a :class:`PTRSolveResult`.

--- a/openscvx/solvers/moreau_ptr_solver.py
+++ b/openscvx/solvers/moreau_ptr_solver.py
@@ -1236,8 +1236,10 @@ class MoreauPTRSolver(PTRSolver):
         uniformity.
 
         Args:
-            state: :class:`AlgorithmState` pytree. Unused on the QPAX/Moreau
-                read paths; preserved for cross-backend signature parity.
+            state: :class:`AlgorithmState` pytree. Accepted for cross-backend
+                signature uniformity but unused — Moreau's functional API
+                takes no warm-start (see the 2026-05-17 Decision Log entry
+                in ``plans/solver-iteration-callbacks.md``).
             data: :class:`SubproblemData` pytree carrying the per-iteration
                 linearization arrays, penalty weights, and boundary
                 conditions.

--- a/openscvx/solvers/moreau_ptr_solver.py
+++ b/openscvx/solvers/moreau_ptr_solver.py
@@ -1381,13 +1381,13 @@ class MoreauPTRSolver(PTRSolver):
 
         n_per_row = 2 + n_x + 2 * n_u
         dyn_vals = jnp.zeros((N - 1, n_x, n_per_row), dtype=f)
-        dyn_vals = dyn_vals.at[:, :, 0].set(1.0)                       # x[k, i]
-        dyn_vals = dyn_vals.at[:, :, 1 : 1 + n_x].set(-A_blk)          # dx[kp, :]
+        dyn_vals = dyn_vals.at[:, :, 0].set(1.0)  # x[k, i]
+        dyn_vals = dyn_vals.at[:, :, 1 : 1 + n_x].set(-A_blk)  # dx[kp, :]
         for j in range(n_u):
             base = 1 + n_x + 2 * j
-            dyn_vals = dyn_vals.at[:, :, base].set(-B_blk[:, :, j])    # du[kp, j]
+            dyn_vals = dyn_vals.at[:, :, base].set(-B_blk[:, :, j])  # du[kp, j]
             dyn_vals = dyn_vals.at[:, :, base + 1].set(-C_with_E[:, :, j])  # du[k, j]
-        dyn_vals = dyn_vals.at[:, :, -1].set(-1.0)                     # nu[kp, i]
+        dyn_vals = dyn_vals.at[:, :, -1].set(-1.0)  # nu[kp, i]
         coo_blocks.append(dyn_vals.reshape(-1))
         if has_impulsive:
             rhs_dyn = inv_S_x[None, :] * (data.x_prop_plus[1:] - c_x[None, :])
@@ -1402,8 +1402,8 @@ class MoreauPTRSolver(PTRSolver):
                 continue
             nodes_arr = jnp.asarray(nodes_tuple)
             n_nodes = len(nodes_tuple)
-            grad_x_vals = data.nodal_grad_x[nodes_arr, c_idx]          # (n_nodes, n_x)
-            grad_u_vals = data.nodal_grad_u[nodes_arr, c_idx]          # (n_nodes, n_u)
+            grad_x_vals = data.nodal_grad_x[nodes_arr, c_idx]  # (n_nodes, n_x)
+            grad_u_vals = data.nodal_grad_u[nodes_arr, c_idx]  # (n_nodes, n_u)
             neg_one = jnp.full((n_nodes, 1), -1.0, dtype=f)
             nodal_vals = jnp.concatenate([grad_x_vals, grad_u_vals, neg_one], axis=1)
             coo_blocks.append(nodal_vals.reshape(-1))
@@ -1412,9 +1412,7 @@ class MoreauPTRSolver(PTRSolver):
         # Boundary Fix rows — emit per-state, init then final, matching
         # _assemble_conic. Under impulsive control the initial Fix row also
         # carries du[0, slice_imp] coefficients.
-        imp_j_list = (
-            list(range(slice_imp.start, slice_imp.stop)) if has_impulsive else []
-        )
+        imp_j_list = list(range(slice_imp.start, slice_imp.stop)) if has_impulsive else []
         for i in range(sim.true_state_slice.start, sim.true_state_slice.stop):
             init_t = sim.x.initial_type[i]
             final_t = sim.x.final_type[i]
@@ -1506,14 +1504,8 @@ class MoreauPTRSolver(PTRSolver):
         coo_blocks.append(soc_coeffs)
         b_blocks.append(jnp.zeros((n_soc,), dtype=f))
 
-        coo_vals = (
-            jnp.concatenate(coo_blocks)
-            if coo_blocks
-            else jnp.zeros((0,), dtype=f)
-        )
-        b_vec = (
-            jnp.concatenate(b_blocks) if b_blocks else jnp.zeros((0,), dtype=f)
-        )
+        coo_vals = jnp.concatenate(coo_blocks) if coo_blocks else jnp.zeros((0,), dtype=f)
+        b_vec = jnp.concatenate(b_blocks) if b_blocks else jnp.zeros((0,), dtype=f)
         return P_data, coo_vals, q, b_vec
 
     def _build_solution_jax(
@@ -1568,9 +1560,7 @@ class MoreauPTRSolver(PTRSolver):
         N, n_x = L.N, L.n_x
         f = self._jax_dtype
         lam_prox = data.lam_prox
-        lam_cost_arr = jnp.broadcast_to(
-            jnp.asarray(data.lam_cost, dtype=f), (sim.n_states,)
-        )
+        lam_cost_arr = jnp.broadcast_to(jnp.asarray(data.lam_cost, dtype=f), (sim.n_states,))
         lam_vc = data.lam_vc
         lam_vb_nodal = data.lam_vb_nodal
 

--- a/openscvx/solvers/moreau_ptr_solver.py
+++ b/openscvx/solvers/moreau_ptr_solver.py
@@ -1243,14 +1243,12 @@ class MoreauPTRSolver(PTRSolver):
         cold start; ``state`` is accepted only for cross-backend signature
         uniformity.
 
-        Args:
-            state: :class:`AlgorithmState` pytree. Accepted for cross-backend
-                signature uniformity but unused — Moreau's functional API
-                takes no warm-start (see the 2026-05-17 Decision Log entry
-                in ``plans/solver-iteration-callbacks.md``).
-            data: :class:`SubproblemData` pytree carrying the per-iteration
-                linearization arrays, penalty weights, and boundary
-                conditions.
+        The returned callable takes ``(state, data)``: ``state`` is the
+        :class:`AlgorithmState` pytree, accepted for cross-backend signature
+        uniformity but unused (Moreau's functional API takes no warm-start);
+        ``data`` is the :class:`SubproblemData` pytree carrying the
+        per-iteration linearization arrays, penalty weights, and boundary
+        conditions.
         """
         if self.layout is None or self._settings is None:
             raise RuntimeError(

--- a/openscvx/solvers/moreau_ptr_solver.py
+++ b/openscvx/solvers/moreau_ptr_solver.py
@@ -1233,9 +1233,7 @@ class MoreauPTRSolver(PTRSolver):
         path but does **not** accept a warm-start (see the 2026-05-17 Decision
         Log entry in ``plans/solver-iteration-callbacks.md``). Every call is a
         cold start; ``state`` is accepted only for cross-backend signature
-        uniformity. ``SubproblemSolution.moreau_carry`` carries a zero-length
-        placeholder triple so the pytree shape is uniform with the other
-        backends.
+        uniformity.
 
         Args:
             state: :class:`AlgorithmState` pytree. Unused on the QPAX/Moreau
@@ -1519,9 +1517,7 @@ class MoreauPTRSolver(PTRSolver):
         Mirrors :meth:`_unpack`: scaled-to-physical trajectories, virtual
         controls in their natural orientation, ``nu_vb`` stacked to
         ``(N, n_nodal)``. ``status_code`` is derived from ``info.status`` via
-        :func:`_moreau_status_to_code`. ``moreau_carry`` is a zero-length
-        placeholder triple — the functional API has no warm-start, so the
-        carry is structural-only.
+        :func:`_moreau_status_to_code`.
         """
         L = self.layout
         N, n_x, n_u = L.N, L.n_x, L.n_u
@@ -1541,7 +1537,6 @@ class MoreauPTRSolver(PTRSolver):
         cost = self._reconstruct_cost_jax(z, data)
         status_code = _moreau_status_to_code(info.status)
 
-        zero = jnp.zeros((0,), dtype=f)
         return SubproblemSolution(
             x=x,
             u=u,
@@ -1550,7 +1545,6 @@ class MoreauPTRSolver(PTRSolver):
             nu_vb_cross=jnp.zeros((0,), dtype=f),
             cost=cost,
             status_code=status_code,
-            moreau_carry=(zero, zero, zero),
         )
 
     def _reconstruct_cost_jax(

--- a/openscvx/solvers/ptr_solver.py
+++ b/openscvx/solvers/ptr_solver.py
@@ -2,22 +2,38 @@
 
 The PTR formulation — its variables, slack structure, cost terms, and
 linearization contract — is shared across backends. This module defines that
-contract; concrete backends (CVXPy, QPAX) live in sibling modules and
+contract; concrete backends (CVXPy, QPAX, Moreau) live in sibling modules and
 implement the assembly/dispatch that each backend's modeling layer requires.
+
+Two per-iteration entry points coexist:
+
+* The historical NumPy contract — four :meth:`PTRSolver.update_*` stages
+  followed by :meth:`PTRSolver.solve`, returning a :class:`PTRSolveResult`.
+  Used by today's Python-side SCP loop and by direct interactive use of
+  :class:`~openscvx.solvers.cvxpy_ptr_solver.CVXPyPTRSolver`.
+* The JAX-pure contract — :meth:`PTRSolver.iteration_callback`, which returns
+  a ``(state, SubproblemData) -> SubproblemSolution`` callable built once at
+  :meth:`~openscvx.solvers.base.ConvexSolver.initialize`. All backends emit
+  the same input/output pytree shape so the callable composes with
+  ``jax.jit`` / ``jax.vmap`` and, downstream, ``lax.while_loop``-driven SCP
+  iteration.
 
 Backends:
     :class:`openscvx.solvers.cvxpy_ptr_solver.CVXPyPTRSolver`
         DCP graph assembled via CVXPy, dispatched to a conic solver
-        (QOCO, CLARABEL, ...).
+        (QOCO, CLARABEL, ...). The JAX-pure callback wraps the host solve
+        in :func:`jax.pure_callback` (``vmap_method="sequential"``).
     :class:`openscvx.solvers.qpax_ptr_solver.QPAXPTRSolver`
         Flat ``(Q, q, A, b, G, h)`` assembled as JAX arrays and solved with
-        ``qpax.solve_qp``. Enables an end-to-end JAX-differentiable SCP loop
-        in follow-up work.
+        ``qpax.solve_qp`` (NumPy path) or the differentiable
+        ``qpax.solve_qp_primal`` (JAX-pure path). Enables an end-to-end
+        JAX-differentiable SCP loop in follow-up work.
     :class:`openscvx.solvers.moreau_ptr_solver.MoreauPTRSolver`
         Sparse conic program assembled as CSR JAX arrays and solved with
-        ``moreau.jax.Solver``.  Uses SOC epigraphs for the L1 / pos PTR
-        penalties instead of QPAX-style slack expansion; warm-starts between
-        SCP iterations.
+        ``moreau.jax.Solver`` (NumPy path, warm-started between SCP
+        iterations) or the functional ``moreau.jax.solver(...)`` factory
+        (JAX-pure path, no warm-start). Uses SOC epigraphs for the L1 / pos
+        PTR penalties instead of QPAX-style slack expansion.
 """
 
 from abc import abstractmethod

--- a/openscvx/solvers/ptr_solver.py
+++ b/openscvx/solvers/ptr_solver.py
@@ -172,10 +172,7 @@ class SubproblemSolution:
     """JAX-pure output of :meth:`PTRSolver.iteration_callback`.
 
     All backends produce structurally-identical pytrees so the result composes
-    with ``lax.while_loop`` in the downstream batchable-problem work. The
-    Moreau warm-start carry (``moreau_carry``) is populated by
-    :class:`MoreauPTRSolver`; QPAX and CVXPy emit same-shape zeros so the
-    pytree shape is uniform across backends.
+    with ``lax.while_loop`` in the downstream batchable-problem work.
 
     Attributes:
         x: Nodal state, shape ``(N, n_x)``. Unscaled.
@@ -187,8 +184,6 @@ class SubproblemSolution:
         nu_vb_cross: Cross-node virtual-buffer slacks, shape ``(n_cross,)``.
         cost: Optimal objective value (scalar).
         status_code: :class:`StatusCode` value as ``int32``.
-        moreau_carry: ``(x, z, s)`` warm-start carry for the Moreau backend.
-            Non-Moreau backends emit zero arrays of the same shape.
     """
 
     x: jnp.ndarray
@@ -198,7 +193,6 @@ class SubproblemSolution:
     nu_vb_cross: jnp.ndarray
     cost: jnp.ndarray
     status_code: jnp.ndarray
-    moreau_carry: Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]
 
     def tree_flatten(self):
         children = tuple(getattr(self, f.name) for f in fields(self))

--- a/openscvx/solvers/ptr_solver.py
+++ b/openscvx/solvers/ptr_solver.py
@@ -21,9 +21,12 @@ Backends:
 """
 
 from abc import abstractmethod
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, List, Optional, Tuple, Union
+from dataclasses import dataclass, fields
+from enum import IntEnum
+from typing import TYPE_CHECKING, Callable, List, Optional, Tuple, Union
 
+import jax
+import jax.numpy as jnp
 import numpy as np
 
 from .base import ConvexSolver
@@ -31,6 +34,159 @@ from .base import ConvexSolver
 if TYPE_CHECKING:
     from openscvx.lowered.unified import UnifiedControl, UnifiedState
     from openscvx.symbolic.constraint_set import ConstraintSet
+
+
+# ---------------------------------------------------------------------------
+# Status codes
+# ---------------------------------------------------------------------------
+
+
+class StatusCode(IntEnum):
+    """Subproblem solve outcome, encoded as ``int32`` for JAX traceability.
+
+    ``iteration_callback`` returns a numeric status on the JAX side rather than
+    a Python string so the result pytree stays valid under ``jax.jit`` /
+    ``jax.vmap``. The SCP loop maps the code back to a label via
+    :func:`status_code_to_str` only on the Python-loop printing path.
+    """
+
+    OPTIMAL = 0
+    INFEASIBLE = 1
+    UNBOUNDED = 2
+    UNKNOWN = 3
+
+
+_STATUS_NAMES = {
+    StatusCode.OPTIMAL: "optimal",
+    StatusCode.INFEASIBLE: "infeasible",
+    StatusCode.UNBOUNDED: "unbounded",
+    StatusCode.UNKNOWN: "unknown",
+}
+
+
+def status_code_to_str(code: Union[int, jnp.ndarray, np.ndarray]) -> str:
+    """Map a :class:`StatusCode` value (int or 0-d array) to its label."""
+    return _STATUS_NAMES[StatusCode(int(code))]
+
+
+# ---------------------------------------------------------------------------
+# Per-iteration JAX-pure I/O pytrees
+# ---------------------------------------------------------------------------
+
+
+@jax.tree_util.register_pytree_node_class
+@dataclass(frozen=True)
+class SubproblemData:
+    """JAX-pure inputs to :meth:`PTRSolver.iteration_callback`.
+
+    Packs the per-iteration linearization, penalty weights, and boundary
+    conditions into a single registered pytree so a single SCP iteration —
+    assemble → solve → unpack — happens on the JAX boundary instead of
+    bouncing through NumPy each step.
+
+    Attributes:
+        x_bar: Previous nodal state, shape ``(N, n_x)``.
+        u_bar: Previous nodal control, shape ``(N, n_u)``.
+        A_d, B_d, C_d: Continuous-step discretized Jacobians,
+            shapes ``(N-1, n_x, n_x)`` / ``(N-1, n_x, n_u)`` / ``(N-1, n_x, n_u)``.
+        x_prop: Propagated state, shape ``(N-1, n_x)``.
+        x_prop_plus: Impulsive propagated state, shape ``(N, n_x)``. Zeros when
+            no impulsive component is present.
+        D_d, E_d: Impulsive Jacobians, shapes ``(N, n_x, n_x)`` /
+            ``(N, n_x, n_u)``. Zeros when no impulsive component is present.
+        nodal_g: Nodal constraint values stacked to fixed shape
+            ``(N, n_nodal)``. Rows for nodes not in a constraint's ``nodes`` set
+            are filled with zeros (mask-by-zero — backend assembly closes over
+            each constraint's static ``nodes`` tuple to skip them).
+        nodal_grad_x: Nodal constraint state gradients, shape
+            ``(N, n_nodal, n_x)``.
+        nodal_grad_u: Nodal constraint control gradients, shape
+            ``(N, n_nodal, n_u)``.
+        cross_g: Cross-node constraint values, shape ``(n_cross,)``.
+        cross_grad_X: Cross-node state gradients, shape ``(n_cross, N, n_x)``.
+        cross_grad_U: Cross-node control gradients, shape ``(n_cross, N, n_u)``.
+        lam_prox: Trust-region weights, shape ``(N, n_x + n_u)``.
+        lam_cost: Cost weight, scalar or shape ``(n_x,)``.
+        lam_vc: Virtual-control penalty weights, shape ``(N-1, n_x)``.
+        lam_vb_nodal: Nodal virtual-buffer weights, shape ``(N, n_nodal)``.
+        lam_vb_cross: Cross-node virtual-buffer weights, shape ``(n_cross,)``.
+        x_init: Initial state, shape ``(n_x,)``. ``jnp.nan`` sentinel where free.
+        x_term: Terminal state, shape ``(n_x,)``. ``jnp.nan`` sentinel where free.
+    """
+
+    x_bar: jnp.ndarray
+    u_bar: jnp.ndarray
+    A_d: jnp.ndarray
+    B_d: jnp.ndarray
+    C_d: jnp.ndarray
+    x_prop: jnp.ndarray
+    x_prop_plus: jnp.ndarray
+    D_d: jnp.ndarray
+    E_d: jnp.ndarray
+    nodal_g: jnp.ndarray
+    nodal_grad_x: jnp.ndarray
+    nodal_grad_u: jnp.ndarray
+    cross_g: jnp.ndarray
+    cross_grad_X: jnp.ndarray
+    cross_grad_U: jnp.ndarray
+    lam_prox: jnp.ndarray
+    lam_cost: jnp.ndarray
+    lam_vc: jnp.ndarray
+    lam_vb_nodal: jnp.ndarray
+    lam_vb_cross: jnp.ndarray
+    x_init: jnp.ndarray
+    x_term: jnp.ndarray
+
+    def tree_flatten(self):
+        children = tuple(getattr(self, f.name) for f in fields(self))
+        return children, None
+
+    @classmethod
+    def tree_unflatten(cls, aux, children):
+        return cls(*children)
+
+
+@jax.tree_util.register_pytree_node_class
+@dataclass(frozen=True)
+class SubproblemSolution:
+    """JAX-pure output of :meth:`PTRSolver.iteration_callback`.
+
+    All backends produce structurally-identical pytrees so the result composes
+    with ``lax.while_loop`` in the downstream batchable-problem work. The
+    Moreau warm-start carry (``moreau_carry``) is populated by
+    :class:`MoreauPTRSolver`; QPAX and CVXPy emit same-shape zeros so the
+    pytree shape is uniform across backends.
+
+    Attributes:
+        x: Nodal state, shape ``(N, n_x)``. Unscaled.
+        u: Nodal control, shape ``(N, n_u)``. Unscaled.
+        nu: Virtual-control slack, shape ``(N-1, n_x)``.
+        nu_vb: Nodal virtual-buffer slacks stacked to ``(N, n_nodal)`` (the
+            CVXPy / QPAX list-of-arrays layout is collapsed at the
+            ``iteration_callback`` output boundary).
+        nu_vb_cross: Cross-node virtual-buffer slacks, shape ``(n_cross,)``.
+        cost: Optimal objective value (scalar).
+        status_code: :class:`StatusCode` value as ``int32``.
+        moreau_carry: ``(x, z, s)`` warm-start carry for the Moreau backend.
+            Non-Moreau backends emit zero arrays of the same shape.
+    """
+
+    x: jnp.ndarray
+    u: jnp.ndarray
+    nu: jnp.ndarray
+    nu_vb: jnp.ndarray
+    nu_vb_cross: jnp.ndarray
+    cost: jnp.ndarray
+    status_code: jnp.ndarray
+    moreau_carry: Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]
+
+    def tree_flatten(self):
+        children = tuple(getattr(self, f.name) for f in fields(self))
+        return children, None
+
+    @classmethod
+    def tree_unflatten(cls, aux, children):
+        return cls(*children)
 
 
 @dataclass
@@ -172,6 +328,22 @@ class PTRSolver(ConvexSolver):
 
         Call the four ``update_*`` methods first to set the linearization
         point, constraint gradients, penalties, and boundary conditions.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def iteration_callback(self) -> Callable[..., SubproblemSolution]:
+        """Return a JAX-friendly ``(state, SubproblemData) -> SubproblemSolution``.
+
+        Built once at :meth:`initialize`; called once per SCP iteration. The
+        callable consumes the algorithm-state pytree plus an assembled
+        :class:`SubproblemData`, performs one ``assemble → solve → unpack``
+        cycle on the JAX boundary, and returns a :class:`SubproblemSolution`.
+
+        Replaces the four ``update_*`` methods + :meth:`solve` for the
+        JAX-pure SCP path. All backends share the same input/output pytree
+        shape so the SCP loop downstream can wrap the callback in
+        ``lax.while_loop`` and compose with ``jax.jit`` / ``jax.vmap``.
         """
         raise NotImplementedError
 

--- a/openscvx/solvers/ptr_solver.py
+++ b/openscvx/solvers/ptr_solver.py
@@ -69,6 +69,26 @@ def status_code_to_str(code: Union[int, jnp.ndarray, np.ndarray]) -> str:
     return _STATUS_NAMES[StatusCode(int(code))]
 
 
+_STATUS_STR_TO_CODE = {
+    "optimal": StatusCode.OPTIMAL,
+    "infeasible": StatusCode.INFEASIBLE,
+    "unbounded": StatusCode.UNBOUNDED,
+}
+
+
+def status_str_to_code(status: str) -> StatusCode:
+    """Map a backend-emitted status string to a :class:`StatusCode`.
+
+    Used by :class:`CVXPyPTRSolver.iteration_callback` to coerce CVXPy's
+    ``problem.status`` into the int32 form the JAX-pure result pytree
+    requires. Only the three definite outcomes (``"optimal"``,
+    ``"infeasible"``, ``"unbounded"``) are recognized — every other label
+    CVXPy emits (``"optimal_inaccurate"``, ``"solver_error"``, ...) collapses
+    to :attr:`StatusCode.UNKNOWN`.
+    """
+    return _STATUS_STR_TO_CODE.get(status, StatusCode.UNKNOWN)
+
+
 # ---------------------------------------------------------------------------
 # Per-iteration JAX-pure I/O pytrees
 # ---------------------------------------------------------------------------

--- a/openscvx/solvers/qpax_ptr_solver.py
+++ b/openscvx/solvers/qpax_ptr_solver.py
@@ -1326,9 +1326,7 @@ class QPAXPTRSolver(PTRSolver):
         Mirrors :meth:`_unpack` but stays JAX-pure: returns scaled-to-physical
         trajectories, the collapsed ``(N, n_nodal)`` ``nu_vb`` layout, and a
         ``status_code = UNKNOWN`` (``solve_qp_primal`` exposes no convergence
-        diagnostic — the SCP trust-region check is the gate). ``moreau_carry``
-        is left as zero arrays of the AlgorithmState shape so every backend's
-        :class:`SubproblemSolution` pytree is structurally identical.
+        diagnostic — the SCP trust-region check is the gate).
         """
         L = self.layout
         N, n_x, n_u = L.N, L.n_x, L.n_u
@@ -1346,12 +1344,6 @@ class QPAXPTRSolver(PTRSolver):
 
         cost = self._reconstruct_cost_jax(z, data)
 
-        # Same-shape zero carry so the SubproblemSolution pytree is uniform
-        # across backends — Moreau will populate this with its real (x, z, s)
-        # warm-start once Phase 3 lands.
-        zero = jnp.zeros((0,), dtype=f)
-        moreau_carry = (zero, zero, zero)
-
         return SubproblemSolution(
             x=x,
             u=u,
@@ -1360,7 +1352,6 @@ class QPAXPTRSolver(PTRSolver):
             nu_vb_cross=jnp.zeros((0,), dtype=f),
             cost=cost,
             status_code=jnp.asarray(int(StatusCode.UNKNOWN), dtype=jnp.int32),
-            moreau_carry=moreau_carry,
         )
 
     def _reconstruct_cost_jax(

--- a/openscvx/solvers/qpax_ptr_solver.py
+++ b/openscvx/solvers/qpax_ptr_solver.py
@@ -869,12 +869,12 @@ class QPAXPTRSolver(PTRSolver):
         ``status_code = StatusCode.UNKNOWN`` unconditionally — the SCP
         trust-region check catches divergence at the algorithm layer instead.
 
-        Args:
-            state: :class:`AlgorithmState` pytree. Accepted for cross-backend
-                signature uniformity but unused — every input the QP needs
-                already lives in ``data``.
-            data: :class:`SubproblemData` pytree carrying the per-iteration
-                linearization arrays, penalty weights, and boundary conditions.
+        The returned callable takes ``(state, data)``: ``state`` is the
+        :class:`AlgorithmState` pytree, accepted for cross-backend signature
+        uniformity but unused (every input the QP needs already lives in
+        ``data``); ``data`` is the :class:`SubproblemData` pytree carrying the
+        per-iteration linearization arrays, penalty weights, and boundary
+        conditions.
         """
         if self.layout is None or self._settings is None:
             raise RuntimeError(

--- a/openscvx/solvers/qpax_ptr_solver.py
+++ b/openscvx/solvers/qpax_ptr_solver.py
@@ -167,6 +167,12 @@ class QPAXPTRSolver(PTRSolver):
     dispatches to ``qpax.solve_qp``. See the module docstring for the L1 /
     positive-part slack reformulation and the rationale behind the design.
 
+    The JAX-pure entry point :meth:`iteration_callback` performs the same
+    ``assemble → solve → unpack`` cycle entirely on the JAX boundary using
+    ``qpax.solve_qp_primal`` — the ``jax.custom_vjp``-differentiable variant
+    — so the backend composes with ``jax.jit``, ``jax.vmap``, and
+    (downstream) ``jax.grad``.
+
     Scope:
         Supported — state/control box, dynamics linearization (continuous
         and impulsive), boundary ``Fix``, uniform time grid, linearized

--- a/openscvx/solvers/qpax_ptr_solver.py
+++ b/openscvx/solvers/qpax_ptr_solver.py
@@ -967,7 +967,9 @@ class QPAXPTRSolver(PTRSolver):
     def _assemble_qp_jax(
         self,
         data: SubproblemData,
-    ) -> Tuple["jnp.ndarray", "jnp.ndarray", "jnp.ndarray", "jnp.ndarray", "jnp.ndarray", "jnp.ndarray"]:
+    ) -> Tuple[
+        "jnp.ndarray", "jnp.ndarray", "jnp.ndarray", "jnp.ndarray", "jnp.ndarray", "jnp.ndarray"
+    ]:
         """Build ``(Q, q, A, b, G, h)`` from a :class:`SubproblemData` pytree.
 
         JAX-pure counterpart of :meth:`_assemble_qp`. The decision-vector
@@ -1047,26 +1049,16 @@ class QPAXPTRSolver(PTRSolver):
             n_nodes = len(nodes_tuple)
             nodes_arr = jnp.asarray(nodes_tuple)
             dx_cols = jnp.asarray(
-                np.asarray(
-                    [[L.dx_idx(node, j) for j in range(n_x)] for node in nodes_tuple]
-                )
+                np.asarray([[L.dx_idx(node, j) for j in range(n_x)] for node in nodes_tuple])
             )  # (n_nodes, n_x)
             du_cols = jnp.asarray(
-                np.asarray(
-                    [[L.du_idx(node, j) for j in range(n_u)] for node in nodes_tuple]
-                )
+                np.asarray([[L.du_idx(node, j) for j in range(n_u)] for node in nodes_tuple])
             )  # (n_nodes, n_u)
-            nuvb_cols = jnp.asarray(
-                np.asarray([L.nu_vb_idx(c_idx, node) for node in nodes_tuple])
-            )
+            nuvb_cols = jnp.asarray(np.asarray([L.nu_vb_idx(c_idx, node) for node in nodes_tuple]))
             row_idx = jnp.arange(n_nodes)
             block = jnp.zeros((n_nodes, L.n_z), dtype=f)
-            block = block.at[row_idx[:, None], dx_cols].set(
-                data.nodal_grad_x[nodes_arr, c_idx]
-            )
-            block = block.at[row_idx[:, None], du_cols].set(
-                data.nodal_grad_u[nodes_arr, c_idx]
-            )
+            block = block.at[row_idx[:, None], dx_cols].set(data.nodal_grad_x[nodes_arr, c_idx])
+            block = block.at[row_idx[:, None], du_cols].set(data.nodal_grad_u[nodes_arr, c_idx])
             block = block.at[row_idx, nuvb_cols].set(-1.0)
             A_blocks.append(block)
             b_blocks.append(-data.nodal_g[nodes_arr, c_idx])
@@ -1129,8 +1121,8 @@ class QPAXPTRSolver(PTRSolver):
         node_block_rows = n_x + n_u
         n_rows = N * node_block_rows
         block = jnp.zeros((n_rows, L.n_z), dtype=f)
-        x_err_rhs = (inv_S_x * (data.x_bar - c_x[None, :]))  # (N, n_x)
-        u_err_rhs = (inv_S_u * (data.u_bar - c_u[None, :]))  # (N, n_u)
+        x_err_rhs = inv_S_x * (data.x_bar - c_x[None, :])  # (N, n_x)
+        u_err_rhs = inv_S_u * (data.u_bar - c_u[None, :])  # (N, n_u)
         b_err = jnp.concatenate([x_err_rhs, u_err_rhs], axis=1).reshape(-1)  # (N*(n_x+n_u),)
         for k in range(N):
             row_base = k * node_block_rows
@@ -1176,19 +1168,13 @@ class QPAXPTRSolver(PTRSolver):
         x_term_cols = jnp.asarray(np.asarray([L.x_idx(kp + 1, i) for kp, i in zip(kp_idx, i_idx)]))
         nu_cols = jnp.asarray(np.asarray([L.nu_idx(kp, i) for kp, i in zip(kp_idx, i_idx)]))
         dx_cols_2d = jnp.asarray(
-            np.asarray(
-                [[L.dx_idx(kp, j) for j in range(n_x)] for kp in kp_idx]
-            )
+            np.asarray([[L.dx_idx(kp, j) for j in range(n_x)] for kp in kp_idx])
         )  # (n_dyn, n_x)
         du_prev_cols_2d = jnp.asarray(
-            np.asarray(
-                [[L.du_idx(kp, j) for j in range(n_u)] for kp in kp_idx]
-            )
+            np.asarray([[L.du_idx(kp, j) for j in range(n_u)] for kp in kp_idx])
         )  # (n_dyn, n_u)
         du_curr_cols_2d = jnp.asarray(
-            np.asarray(
-                [[L.du_idx(kp + 1, j) for j in range(n_u)] for kp in kp_idx]
-            )
+            np.asarray([[L.du_idx(kp + 1, j) for j in range(n_u)] for kp in kp_idx])
         )  # (n_dyn, n_u)
 
         block = jnp.zeros((n_dyn, L.n_z), dtype=f)
@@ -1206,9 +1192,7 @@ class QPAXPTRSolver(PTRSolver):
             E_blk = (inv_S_x[None, :, None] * data.E_d[1:]) * S_u[None, None, :]
             imp_j = np.arange(slice_imp.start, slice_imp.stop)
             imp_du_cols_2d = jnp.asarray(
-                np.asarray(
-                    [[L.du_idx(kp + 1, j) for j in imp_j] for kp in kp_idx]
-                )
+                np.asarray([[L.du_idx(kp + 1, j) for j in imp_j] for kp in kp_idx])
             )  # (n_dyn, n_imp)
             E_vals = -E_blk[:, :, imp_j].reshape(n_dyn, len(imp_j))
             block = block.at[flat_row[:, None], imp_du_cols_2d].add(E_vals)

--- a/openscvx/solvers/qpax_ptr_solver.py
+++ b/openscvx/solvers/qpax_ptr_solver.py
@@ -865,8 +865,8 @@ class QPAXPTRSolver(PTRSolver):
 
         Args:
             state: :class:`AlgorithmState` pytree. Accepted for cross-backend
-                signature uniformity but unused by QPAX (every input the QP
-                needs already lives in ``data``).
+                signature uniformity but unused — every input the QP needs
+                already lives in ``data``.
             data: :class:`SubproblemData` pytree carrying the per-iteration
                 linearization arrays, penalty weights, and boundary conditions.
         """
@@ -879,7 +879,7 @@ class QPAXPTRSolver(PTRSolver):
         solver_args = self.solver_args
 
         def step(state, data: SubproblemData) -> SubproblemSolution:
-            del state  # QPAX's QP inputs all live on ``data``.
+            del state  # every input the QP needs already lives on ``data``.
             Q, q, A, b, G, h = self._assemble_qp_jax(data)
             z = qpax.solve_qp_primal(Q, q, A, b, G, h, **solver_args)
             return self._build_solution_jax(z, data)

--- a/openscvx/solvers/qpax_ptr_solver.py
+++ b/openscvx/solvers/qpax_ptr_solver.py
@@ -828,6 +828,18 @@ class QPAXPTRSolver(PTRSolver):
 
         return self._unpack(z)
 
+    def iteration_callback(self):
+        """JAX-pure SCP iteration entry point (not yet wired for QPAX).
+
+        Implemented in a follow-up slice of ``plans/solver-iteration-callbacks.md``
+        — Phase 2 ports ``_assemble_qp`` to JAX and dispatches via
+        ``qpax.solve_qp_primal``.
+        """
+        raise NotImplementedError(
+            "QPAXPTRSolver.iteration_callback() not yet implemented; "
+            "use the NumPy solve() path until Phase 2 lands."
+        )
+
     def _unpack(self, z: np.ndarray) -> PTRSolveResult:
         """Reverse the layout into the structured :class:`PTRSolveResult`."""
         L = self.layout

--- a/openscvx/solvers/qpax_ptr_solver.py
+++ b/openscvx/solvers/qpax_ptr_solver.py
@@ -53,15 +53,23 @@ import numpy as np
 
 from openscvx.config import Config
 
-from .ptr_solver import PTRSolver, PTRSolveResult
+from .ptr_solver import (
+    PTRSolver,
+    PTRSolveResult,
+    StatusCode,
+    SubproblemData,
+    SubproblemSolution,
+)
 
 try:
+    import jax
     import jax.numpy as jnp
     import qpax
 
     _QPAX_AVAILABLE = True
 except ImportError:  # pragma: no cover — exercised by the install-error test
     qpax = None
+    jax = None
     jnp = None
     _QPAX_AVAILABLE = False
 
@@ -285,6 +293,19 @@ class QPAXPTRSolver(PTRSolver):
         self._S_u_diag = np.diag(S_u)
         self._inv_S_x_diag = 1.0 / self._S_x_diag
         self._inv_S_u_diag = 1.0 / self._S_u_diag
+
+        # JAX-side scaling diagonals for ``iteration_callback``. The dtype
+        # tracks the global ``jax_enable_x64`` setting so the assembled
+        # ``(Q, q, A, b, G, h)`` lands in the dtype ``qpax.solve_qp_primal``
+        # expects.
+        f = jnp.float64 if jax.config.read("jax_enable_x64") else jnp.float32
+        self._S_x_diag_j = jnp.asarray(self._S_x_diag, dtype=f)
+        self._S_u_diag_j = jnp.asarray(self._S_u_diag, dtype=f)
+        self._inv_S_x_diag_j = jnp.asarray(self._inv_S_x_diag, dtype=f)
+        self._inv_S_u_diag_j = jnp.asarray(self._inv_S_u_diag, dtype=f)
+        self._c_x_j = jnp.asarray(self._c_x, dtype=f)
+        self._c_u_j = jnp.asarray(self._c_u, dtype=f)
+        self._jax_dtype = f
 
         self.layout = _QPLayout(N=N, n_x=n_x, n_u=n_u, n_nodal=len(jax_constraints.nodal))
         self._jax_constraints = jax_constraints
@@ -829,16 +850,41 @@ class QPAXPTRSolver(PTRSolver):
         return self._unpack(z)
 
     def iteration_callback(self):
-        """JAX-pure SCP iteration entry point (not yet wired for QPAX).
+        """JAX-pure ``(state, SubproblemData) -> SubproblemSolution``.
 
-        Implemented in a follow-up slice of ``plans/solver-iteration-callbacks.md``
-        — Phase 2 ports ``_assemble_qp`` to JAX and dispatches via
-        ``qpax.solve_qp_primal``.
+        Composes :meth:`_assemble_qp_jax` + ``qpax.solve_qp_primal`` +
+        :meth:`_unpack_jax` into a single ``@jax.jit``-decorated closure built
+        once at :meth:`initialize` time. The closure is reusable across SCP
+        iterations — only the ``SubproblemData`` pytree changes between calls.
+
+        ``qpax.solve_qp_primal`` is the differentiable primal-only variant of
+        ``qpax.solve_qp``. It returns only the primal ``z`` (no convergence
+        diagnostics), so the returned :class:`SubproblemSolution` reports
+        ``status_code = StatusCode.UNKNOWN`` unconditionally — the SCP
+        trust-region check catches divergence at the algorithm layer instead.
+
+        Args:
+            state: :class:`AlgorithmState` pytree. Accepted for cross-backend
+                signature uniformity but unused by QPAX (every input the QP
+                needs already lives in ``data``).
+            data: :class:`SubproblemData` pytree carrying the per-iteration
+                linearization arrays, penalty weights, and boundary conditions.
         """
-        raise NotImplementedError(
-            "QPAXPTRSolver.iteration_callback() not yet implemented; "
-            "use the NumPy solve() path until Phase 2 lands."
-        )
+        if self.layout is None or self._settings is None:
+            raise RuntimeError(
+                "QPAXPTRSolver.iteration_callback() requires initialize() to "
+                "have been called first."
+            )
+
+        solver_args = self.solver_args
+
+        def step(state, data: SubproblemData) -> SubproblemSolution:
+            del state  # QPAX's QP inputs all live on ``data``.
+            Q, q, A, b, G, h = self._assemble_qp_jax(data)
+            z = qpax.solve_qp_primal(Q, q, A, b, G, h, **solver_args)
+            return self._build_solution_jax(z, data)
+
+        return jax.jit(step)
 
     def _unpack(self, z: np.ndarray) -> PTRSolveResult:
         """Reverse the layout into the structured :class:`PTRSolveResult`."""
@@ -907,6 +953,454 @@ class QPAXPTRSolver(PTRSolver):
             s_pos = z[L.sl_s_pos[c_idx]]
             cost += float(np.dot(lam_vb_nodal[:, c_idx], s_pos))
         return cost
+
+    # ------------------------------------------------------------------
+    # JAX-pure assembly / unpack (used by iteration_callback)
+    # ------------------------------------------------------------------
+
+    def _assemble_qp_jax(
+        self,
+        data: SubproblemData,
+    ) -> Tuple["jnp.ndarray", "jnp.ndarray", "jnp.ndarray", "jnp.ndarray", "jnp.ndarray", "jnp.ndarray"]:
+        """Build ``(Q, q, A, b, G, h)`` from a :class:`SubproblemData` pytree.
+
+        JAX-pure counterpart of :meth:`_assemble_qp`. The decision-vector
+        layout, the per-row recipes, and the variable scaling are identical
+        to the NumPy path — only the array library differs. Structural
+        metadata (layout slices, boundary-condition types, impulsive pin
+        schedule, CTCS node intervals) is closed over Python-side; numerical
+        inputs flow through ``data``.
+        """
+        L = self.layout
+        sim = self._settings.sim
+        N, n_x, n_u = L.N, L.n_x, L.n_u
+        inv_S_x = self._inv_S_x_diag_j
+        inv_S_u = self._inv_S_u_diag_j
+        S_x = self._S_x_diag_j
+        S_u = self._S_u_diag_j
+        c_x = self._c_x_j
+        c_u = self._c_u_j
+        f = self._jax_dtype
+        slice_imp = sim.u.slice_impulsive
+        has_impulsive = slice_imp.stop > slice_imp.start
+        eps = jnp.asarray(_Q_DIAG_EPS, dtype=f)
+
+        lam_prox = data.lam_prox
+        lam_cost = data.lam_cost
+        lam_vc = data.lam_vc
+        lam_vb_nodal = data.lam_vb_nodal
+
+        # ---------- cost: diagonal Q + linear q ----------
+        q_diag = jnp.full((L.n_z,), eps, dtype=f)
+        # Trust-region quadratic: 2·lam_prox on dx / du slots (+ eps).
+        q_diag = q_diag.at[L.sl_dx].set((2.0 * lam_prox[:, :n_x] + eps).reshape(-1))
+        q_diag = q_diag.at[L.sl_du].set((2.0 * lam_prox[:, n_x:] + eps).reshape(-1))
+        Q = jnp.diag(q_diag)
+
+        # Boundary-cost signs computed Python-side from initial / final type.
+        init_signs_np = np.zeros(sim.n_states, dtype=float)
+        final_signs_np = np.zeros(sim.n_states, dtype=float)
+        for i in range(sim.true_state_slice.start, sim.true_state_slice.stop):
+            init_t = sim.x.initial_type[i]
+            final_t = sim.x.final_type[i]
+            if init_t == "Minimize":
+                init_signs_np[i] = 1.0
+            elif init_t == "Maximize":
+                init_signs_np[i] = -1.0
+            if final_t == "Minimize":
+                final_signs_np[i] = 1.0
+            elif final_t == "Maximize":
+                final_signs_np[i] = -1.0
+        init_signs = jnp.asarray(init_signs_np, dtype=f)
+        final_signs = jnp.asarray(final_signs_np, dtype=f)
+        lam_cost_arr = jnp.broadcast_to(jnp.asarray(lam_cost, dtype=f), (sim.n_states,))
+
+        q_vec = jnp.zeros((L.n_z,), dtype=f)
+        x0_start = L.sl_x.start
+        xN_start = L.sl_x.start + (N - 1) * n_x
+        q_vec = q_vec.at[x0_start : x0_start + n_x].add(init_signs * lam_cost_arr)
+        q_vec = q_vec.at[xN_start : xN_start + n_x].add(final_signs * lam_cost_arr)
+        # L1 penalty on |nu| → linear cost on s_abs
+        q_vec = q_vec.at[L.sl_s_abs].add(lam_vc.reshape(-1))
+        # Positive-part penalty on nu_vb → linear cost on s_pos (one block per constraint)
+        for c_idx in range(L.n_nodal):
+            q_vec = q_vec.at[L.sl_s_pos[c_idx]].add(lam_vb_nodal[:, c_idx])
+
+        # ---------- equality rows (A z = b) ----------
+        A_blocks: List[jnp.ndarray] = []
+        b_blocks: List[jnp.ndarray] = []
+
+        # Linearized nodal constraints. SubproblemData stacks nodal_g /
+        # nodal_grad_x / nodal_grad_u across all constraints to (N, n_nodal*),
+        # with zero-fill for nodes not in a given constraint's static
+        # ``nodes`` tuple — we index those rows out here.
+        for c_idx, constraint in enumerate(self._jax_constraints.nodal):
+            nodes_tuple = tuple(constraint.nodes)
+            if not nodes_tuple:
+                continue
+            n_nodes = len(nodes_tuple)
+            nodes_arr = jnp.asarray(nodes_tuple)
+            dx_cols = jnp.asarray(
+                np.asarray(
+                    [[L.dx_idx(node, j) for j in range(n_x)] for node in nodes_tuple]
+                )
+            )  # (n_nodes, n_x)
+            du_cols = jnp.asarray(
+                np.asarray(
+                    [[L.du_idx(node, j) for j in range(n_u)] for node in nodes_tuple]
+                )
+            )  # (n_nodes, n_u)
+            nuvb_cols = jnp.asarray(
+                np.asarray([L.nu_vb_idx(c_idx, node) for node in nodes_tuple])
+            )
+            row_idx = jnp.arange(n_nodes)
+            block = jnp.zeros((n_nodes, L.n_z), dtype=f)
+            block = block.at[row_idx[:, None], dx_cols].set(
+                data.nodal_grad_x[nodes_arr, c_idx]
+            )
+            block = block.at[row_idx[:, None], du_cols].set(
+                data.nodal_grad_u[nodes_arr, c_idx]
+            )
+            block = block.at[row_idx, nuvb_cols].set(-1.0)
+            A_blocks.append(block)
+            b_blocks.append(-data.nodal_g[nodes_arr, c_idx])
+
+        # Boundary Fix rows — emitted in the same interleaved per-state order
+        # as the NumPy loop (init row, then final row, for each true-state
+        # index). When impulsive is active, the initial-Fix row also couples
+        # du at node 0 through the linearized impulse Jacobian E_d.
+        imp_j_list = list(range(slice_imp.start, slice_imp.stop)) if has_impulsive else []
+        for i in range(sim.true_state_slice.start, sim.true_state_slice.stop):
+            init_t = sim.x.initial_type[i]
+            final_t = sim.x.final_type[i]
+            if init_t == "Fix":
+                row = jnp.zeros((L.n_z,), dtype=f).at[L.x_idx(0, i)].set(S_x[i])
+                if has_impulsive:
+                    for j in imp_j_list:
+                        row = row.at[L.du_idx(0, j)].set(-data.E_d[0, i, j] * S_u[j])
+                    rhs = data.x_prop_plus[0, i] - c_x[i]
+                else:
+                    rhs = data.x_init[i] - c_x[i]
+                A_blocks.append(row[None, :])
+                b_blocks.append(rhs[None])
+            if final_t == "Fix":
+                row = jnp.zeros((L.n_z,), dtype=f).at[L.x_idx(N - 1, i)].set(S_x[i])
+                A_blocks.append(row[None, :])
+                b_blocks.append((data.x_term[i] - c_x[i])[None])
+
+        # Impulsive zero-pins — every impulsive control DOF forced to zero
+        # at each non-impulse node (in scaled coords).
+        for nodes, ctrl_slice in self._impulsive_pins:
+            for node in nodes:
+                for j in range(ctrl_slice.start, ctrl_slice.stop):
+                    row = jnp.zeros((L.n_z,), dtype=f)
+                    row = row.at[L.u_idx(node, j)].set(1.0)
+                    A_blocks.append(row[None, :])
+                    b_blocks.append((-inv_S_u[j] * c_u[j])[None])
+
+        # Uniform time-grid: scaled u along the time-dilation slice is
+        # constant across nodes — encoded as u[k] - u[k-1] = 0.
+        if sim._uniform_time_grid:
+            td = sim.time_dilation_slice
+            for k in range(1, N):
+                for j in range(td.start, td.stop):
+                    row = jnp.zeros((L.n_z,), dtype=f)
+                    row = row.at[L.u_idx(k, j)].set(1.0)
+                    row = row.at[L.u_idx(k - 1, j)].set(-1.0)
+                    A_blocks.append(row[None, :])
+                    b_blocks.append(jnp.zeros((1,), dtype=f))
+
+        # State / control error definitions, interleaved per-node to match
+        # the NumPy loop ordering (for each k: all x errors then all u errors).
+        # Vectorize per k: build the (n_x + n_u, n_z) "node block" once with
+        # static columns, replicate over k, then patch in the rhs values.
+        x_cols_per_k = np.asarray([L.x_idx(0, j) for j in range(n_x)])  # offsets at k=0
+        dx_cols_per_k = np.asarray([L.dx_idx(0, j) for j in range(n_x)])
+        u_cols_per_k = np.asarray([L.u_idx(0, j) for j in range(n_u)])
+        du_cols_per_k = np.asarray([L.du_idx(0, j) for j in range(n_u)])
+        # Per-node column strides (state offsets advance by n_x per k, control
+        # offsets by n_u).
+        node_block_rows = n_x + n_u
+        n_rows = N * node_block_rows
+        block = jnp.zeros((n_rows, L.n_z), dtype=f)
+        x_err_rhs = (inv_S_x * (data.x_bar - c_x[None, :]))  # (N, n_x)
+        u_err_rhs = (inv_S_u * (data.u_bar - c_u[None, :]))  # (N, n_u)
+        b_err = jnp.concatenate([x_err_rhs, u_err_rhs], axis=1).reshape(-1)  # (N*(n_x+n_u),)
+        for k in range(N):
+            row_base = k * node_block_rows
+            x_rows = row_base + jnp.arange(n_x)
+            u_rows = row_base + n_x + jnp.arange(n_u)
+            block = block.at[x_rows, jnp.asarray(x_cols_per_k + k * n_x)].set(1.0)
+            block = block.at[x_rows, jnp.asarray(dx_cols_per_k + k * n_x)].set(-1.0)
+            block = block.at[u_rows, jnp.asarray(u_cols_per_k + k * n_u)].set(1.0)
+            block = block.at[u_rows, jnp.asarray(du_cols_per_k + k * n_u)].set(-1.0)
+        A_blocks.append(block)
+        b_blocks.append(b_err)
+
+        # Dynamics (continuous FOH branch, plus optional impulsive coupling).
+        # SubproblemData carries the raw A_d / B_d / C_d / D_d / E_d; the
+        # NumPy path's D-absorption (cvxpy_ptr_solver.py:636-654 recipe) is
+        # done inline here when impulsive.
+        if has_impulsive:
+            D_steps = data.D_d[1:]
+            A_eff = jnp.einsum("kij,kjl->kil", D_steps, data.A_d)
+            B_eff = jnp.einsum("kij,kjl->kil", D_steps, data.B_d)
+            C_eff = jnp.einsum("kij,kjl->kil", D_steps, data.C_d)
+        else:
+            A_eff = data.A_d
+            B_eff = data.B_d
+            C_eff = data.C_d
+        # Pre-scaled blocks: shape (N-1, n_x, n_x | n_u).
+        A_blk = (inv_S_x[None, :, None] * A_eff) * S_x[None, None, :]
+        B_blk = (inv_S_x[None, :, None] * B_eff) * S_u[None, None, :]
+        C_blk = (inv_S_x[None, :, None] * C_eff) * S_u[None, None, :]
+
+        # dyn_block: (N-1, n_x, n_z). For each (k_prime, i):
+        #   row[x_idx(k_prime+1, i)] = 1
+        #   row[dx_idx(k_prime, j)]  = -A_blk[k_prime, i, j]
+        #   row[du_idx(k_prime, j)]  = -B_blk[k_prime, i, j]
+        #   row[du_idx(k_prime+1, j)] = -C_blk[k_prime, i, j] (- E_blk[i, j] for j in slice_imp)
+        #   row[nu_idx(k_prime, i)]  = -1
+        n_dyn = (N - 1) * n_x
+        kp_idx = np.repeat(np.arange(N - 1), n_x)
+        i_idx = np.tile(np.arange(n_x), N - 1)
+        # Flat row indices (kp * n_x + i) ↔ index into the (N-1, n_x) row grid.
+        flat_row = jnp.arange(n_dyn)
+        # Column indices for the four sets of writes, computed Python-side.
+        x_term_cols = jnp.asarray(np.asarray([L.x_idx(kp + 1, i) for kp, i in zip(kp_idx, i_idx)]))
+        nu_cols = jnp.asarray(np.asarray([L.nu_idx(kp, i) for kp, i in zip(kp_idx, i_idx)]))
+        dx_cols_2d = jnp.asarray(
+            np.asarray(
+                [[L.dx_idx(kp, j) for j in range(n_x)] for kp in kp_idx]
+            )
+        )  # (n_dyn, n_x)
+        du_prev_cols_2d = jnp.asarray(
+            np.asarray(
+                [[L.du_idx(kp, j) for j in range(n_u)] for kp in kp_idx]
+            )
+        )  # (n_dyn, n_u)
+        du_curr_cols_2d = jnp.asarray(
+            np.asarray(
+                [[L.du_idx(kp + 1, j) for j in range(n_u)] for kp in kp_idx]
+            )
+        )  # (n_dyn, n_u)
+
+        block = jnp.zeros((n_dyn, L.n_z), dtype=f)
+        block = block.at[flat_row, x_term_cols].set(1.0)
+        block = block.at[flat_row, nu_cols].set(-1.0)
+        # A: -A_blk[kp_idx, i_idx, :] over the (kp_idx, i_idx, j) grid
+        A_vals = -A_blk.reshape(n_dyn, n_x)  # rows already in (kp, i) → (kp*n_x + i) order
+        B_vals = -B_blk.reshape(n_dyn, n_u)
+        C_vals = -C_blk.reshape(n_dyn, n_u)
+        block = block.at[flat_row[:, None], dx_cols_2d].set(A_vals)
+        block = block.at[flat_row[:, None], du_prev_cols_2d].set(B_vals)
+        block = block.at[flat_row[:, None], du_curr_cols_2d].set(C_vals)
+        if has_impulsive:
+            # E_blk: (N-1, n_x, n_u). E_d_arr[k] for k in 1..N-1 contributes.
+            E_blk = (inv_S_x[None, :, None] * data.E_d[1:]) * S_u[None, None, :]
+            imp_j = np.arange(slice_imp.start, slice_imp.stop)
+            imp_du_cols_2d = jnp.asarray(
+                np.asarray(
+                    [[L.du_idx(kp + 1, j) for j in imp_j] for kp in kp_idx]
+                )
+            )  # (n_dyn, n_imp)
+            E_vals = -E_blk[:, :, imp_j].reshape(n_dyn, len(imp_j))
+            block = block.at[flat_row[:, None], imp_du_cols_2d].add(E_vals)
+        # RHS
+        if has_impulsive:
+            rhs = inv_S_x[None, :] * (data.x_prop_plus[1:] - c_x[None, :])
+        else:
+            rhs = inv_S_x[None, :] * (data.x_prop - c_x[None, :])
+        A_blocks.append(block)
+        b_blocks.append(rhs.reshape(-1))
+
+        # CTCS x[0] = 0 (in unscaled coords) → S_x[idx] · x[0, idx] = -c_x[idx]
+        ctcs_start = sim.ctcs_slice.start
+        ctcs_stop = sim.ctcs_slice.stop
+        if ctcs_stop > ctcs_start:
+            ctcs_idx_list = list(range(ctcs_start, ctcs_stop))
+            ctcs_idx_arr = jnp.asarray(ctcs_idx_list)
+            ctcs_cols = jnp.asarray([L.x_idx(0, idx) for idx in ctcs_idx_list])
+            row_idx = jnp.arange(len(ctcs_idx_list))
+            block = jnp.zeros((len(ctcs_idx_list), L.n_z), dtype=f)
+            block = block.at[row_idx, ctcs_cols].set(S_x[ctcs_idx_arr])
+            A_blocks.append(block)
+            b_blocks.append(-c_x[ctcs_idx_arr])
+
+        A_mat = jnp.concatenate(A_blocks, axis=0) if A_blocks else jnp.zeros((0, L.n_z), dtype=f)
+        b_vec = jnp.concatenate(b_blocks, axis=0) if b_blocks else jnp.zeros((0,), dtype=f)
+
+        # ---------- inequality rows (G z ≤ h) ----------
+        G_blocks: List[jnp.ndarray] = []
+        h_blocks: List[jnp.ndarray] = []
+
+        # State / control box constraints in scaled coords. Ordering matches
+        # the NumPy loop: per node, all u DOFs (max then -min row), then all
+        # x DOFs (max then -min row).
+        box_rows: List[jnp.ndarray] = []
+        box_h: List[float] = []
+        for k in range(N):
+            for j in range(n_u):
+                box_rows.append(jnp.zeros((L.n_z,), dtype=f).at[L.u_idx(k, j)].set(1.0))
+                box_h.append(float(self._inv_S_u_diag[j] * (sim.u.max[j] - self._c_u[j])))
+                box_rows.append(jnp.zeros((L.n_z,), dtype=f).at[L.u_idx(k, j)].set(-1.0))
+                box_h.append(-float(self._inv_S_u_diag[j] * (sim.u.min[j] - self._c_u[j])))
+            for j in range(n_x):
+                box_rows.append(jnp.zeros((L.n_z,), dtype=f).at[L.x_idx(k, j)].set(1.0))
+                box_h.append(float(self._inv_S_x_diag[j] * (sim.x.max[j] - self._c_x[j])))
+                box_rows.append(jnp.zeros((L.n_z,), dtype=f).at[L.x_idx(k, j)].set(-1.0))
+                box_h.append(-float(self._inv_S_x_diag[j] * (sim.x.min[j] - self._c_x[j])))
+        G_blocks.append(jnp.stack(box_rows))
+        h_blocks.append(jnp.asarray(box_h, dtype=f))
+
+        # CTCS LICQ-style |x[i][idx] - x[i-1][idx]| ≤ x.max[idx] over each
+        # group's node interval, in scaled coords.
+        for idx, nodes in zip(
+            range(sim.ctcs_slice.start, sim.ctcs_slice.stop),
+            sim.ctcs_node_intervals,
+        ):
+            start_i = 1 if nodes[0] == 0 else nodes[0]
+            scale = float(self._S_x_diag[idx])
+            x_max_unscaled = float(sim.x.max[idx])
+            for i in range(start_i, nodes[1]):
+                row_pos = (
+                    jnp.zeros((L.n_z,), dtype=f)
+                    .at[L.x_idx(i, idx)]
+                    .set(scale)
+                    .at[L.x_idx(i - 1, idx)]
+                    .set(-scale)
+                )
+                row_neg = (
+                    jnp.zeros((L.n_z,), dtype=f)
+                    .at[L.x_idx(i, idx)]
+                    .set(-scale)
+                    .at[L.x_idx(i - 1, idx)]
+                    .set(scale)
+                )
+                G_blocks.append(jnp.stack([row_pos, row_neg]))
+                h_blocks.append(jnp.asarray([x_max_unscaled, x_max_unscaled], dtype=f))
+
+        # L1 reformulation of |nu|: nu - s_abs ≤ 0, -nu - s_abs ≤ 0.
+        n_nu_rows = 2 * (N - 1) * n_x
+        block = jnp.zeros((n_nu_rows, L.n_z), dtype=f)
+        # Build columns and values vectorized:
+        # For each (k, j) ∈ [0..N-2] × [0..n_x-1], two rows.
+        pair_idx = np.arange((N - 1) * n_x)
+        nu_cols_flat = np.asarray([L.nu_idx(k, j) for k in range(N - 1) for j in range(n_x)])
+        sabs_cols_flat = np.asarray([L.s_abs_idx(k, j) for k in range(N - 1) for j in range(n_x)])
+        row_pos = jnp.asarray(2 * pair_idx)
+        row_neg = jnp.asarray(2 * pair_idx + 1)
+        block = block.at[row_pos, jnp.asarray(nu_cols_flat)].set(1.0)
+        block = block.at[row_pos, jnp.asarray(sabs_cols_flat)].set(-1.0)
+        block = block.at[row_neg, jnp.asarray(nu_cols_flat)].set(-1.0)
+        block = block.at[row_neg, jnp.asarray(sabs_cols_flat)].set(-1.0)
+        G_blocks.append(block)
+        h_blocks.append(jnp.zeros((n_nu_rows,), dtype=f))
+
+        # Positive-part reformulation: pos(nu_vb) needs s ≥ nu_vb AND s ≥ 0.
+        for c_idx in range(L.n_nodal):
+            nuvb_cols = jnp.asarray([L.nu_vb_idx(c_idx, k) for k in range(N)])
+            spos_cols = jnp.asarray([L.s_pos_idx(c_idx, k) for k in range(N)])
+            row_idx = jnp.arange(N)
+            block = jnp.zeros((2 * N, L.n_z), dtype=f)
+            # Row 2k: nu_vb - s_pos ≤ 0
+            block = block.at[2 * row_idx, nuvb_cols].set(1.0)
+            block = block.at[2 * row_idx, spos_cols].set(-1.0)
+            # Row 2k+1: -s_pos ≤ 0
+            block = block.at[2 * row_idx + 1, spos_cols].set(-1.0)
+            G_blocks.append(block)
+            h_blocks.append(jnp.zeros((2 * N,), dtype=f))
+
+        G_mat = jnp.concatenate(G_blocks, axis=0) if G_blocks else jnp.zeros((0, L.n_z), dtype=f)
+        h_vec = jnp.concatenate(h_blocks, axis=0) if h_blocks else jnp.zeros((0,), dtype=f)
+
+        return Q, q_vec, A_mat, b_vec, G_mat, h_vec
+
+    def _build_solution_jax(
+        self,
+        z: "jnp.ndarray",
+        data: SubproblemData,
+    ) -> SubproblemSolution:
+        """Unpack a primal ``z`` into a :class:`SubproblemSolution` pytree.
+
+        Mirrors :meth:`_unpack` but stays JAX-pure: returns scaled-to-physical
+        trajectories, the collapsed ``(N, n_nodal)`` ``nu_vb`` layout, and a
+        ``status_code = UNKNOWN`` (``solve_qp_primal`` exposes no convergence
+        diagnostic — the SCP trust-region check is the gate). ``moreau_carry``
+        is left as zero arrays of the AlgorithmState shape so every backend's
+        :class:`SubproblemSolution` pytree is structurally identical.
+        """
+        L = self.layout
+        N, n_x, n_u = L.N, L.n_x, L.n_u
+        f = self._jax_dtype
+
+        x_scaled = z[L.sl_x].reshape(N, n_x)
+        u_scaled = z[L.sl_u].reshape(N, n_u)
+        x = x_scaled * self._S_x_diag_j[None, :] + self._c_x_j[None, :]
+        u = u_scaled * self._S_u_diag_j[None, :] + self._c_u_j[None, :]
+        nu = z[L.sl_nu].reshape(N - 1, n_x)
+        if L.n_nodal:
+            nu_vb = jnp.stack([z[sl] for sl in L.sl_nu_vb], axis=-1)
+        else:
+            nu_vb = jnp.zeros((N, 0), dtype=f)
+
+        cost = self._reconstruct_cost_jax(z, data)
+
+        # Same-shape zero carry so the SubproblemSolution pytree is uniform
+        # across backends — Moreau will populate this with its real (x, z, s)
+        # warm-start once Phase 3 lands.
+        zero = jnp.zeros((0,), dtype=f)
+        moreau_carry = (zero, zero, zero)
+
+        return SubproblemSolution(
+            x=x,
+            u=u,
+            nu=nu,
+            nu_vb=nu_vb,
+            nu_vb_cross=jnp.zeros((0,), dtype=f),
+            cost=cost,
+            status_code=jnp.asarray(int(StatusCode.UNKNOWN), dtype=jnp.int32),
+            moreau_carry=moreau_carry,
+        )
+
+    def _reconstruct_cost_jax(
+        self,
+        z: "jnp.ndarray",
+        data: SubproblemData,
+    ) -> "jnp.ndarray":
+        """JAX-pure mirror of :meth:`_reconstruct_cost`."""
+        L = self.layout
+        sim = self._settings.sim
+        N, n_x, n_u = L.N, L.n_x, L.n_u
+        f = self._jax_dtype
+        lam_prox = data.lam_prox
+        lam_cost_arr = jnp.broadcast_to(jnp.asarray(data.lam_cost, dtype=f), (sim.n_states,))
+        lam_vc = data.lam_vc
+        lam_vb_nodal = data.lam_vb_nodal
+
+        dx = z[L.sl_dx].reshape(N, n_x)
+        du = z[L.sl_du].reshape(N, n_u)
+        x_scaled = z[L.sl_x].reshape(N, n_x)
+        s_abs = z[L.sl_s_abs].reshape(N - 1, n_x)
+
+        cost = jnp.sum(lam_prox[:, :n_x] * dx**2) + jnp.sum(lam_prox[:, n_x:] * du**2)
+        # Boundary cost: same signed sum as _reconstruct_cost.
+        for i in range(sim.true_state_slice.start, sim.true_state_slice.stop):
+            init_t = sim.x.initial_type[i]
+            final_t = sim.x.final_type[i]
+            if init_t == "Minimize":
+                cost = cost + lam_cost_arr[i] * x_scaled[0, i]
+            elif init_t == "Maximize":
+                cost = cost - lam_cost_arr[i] * x_scaled[0, i]
+            if final_t == "Minimize":
+                cost = cost + lam_cost_arr[i] * x_scaled[-1, i]
+            elif final_t == "Maximize":
+                cost = cost - lam_cost_arr[i] * x_scaled[-1, i]
+        cost = cost + jnp.sum(lam_vc * s_abs)
+        for c_idx in range(L.n_nodal):
+            s_pos = z[L.sl_s_pos[c_idx]]
+            cost = cost + jnp.dot(lam_vb_nodal[:, c_idx], s_pos)
+        return cost.astype(f)
 
     # ------------------------------------------------------------------
     # Misc API

--- a/tests/solvers/_iteration_callback_helpers.py
+++ b/tests/solvers/_iteration_callback_helpers.py
@@ -80,9 +80,7 @@ def build_brachistochrone(
     constraint_exprs = []
     if constraint_style == "ctcs":
         for state in states:
-            constraint_exprs.extend(
-                [ox.ctcs(state <= state.max), ox.ctcs(state.min <= state)]
-            )
+            constraint_exprs.extend([ox.ctcs(state <= state.max), ox.ctcs(state.min <= state)])
     elif constraint_style == "nodal":
         for state in states:
             constraint_exprs.extend([state <= state.max, state.min <= state])
@@ -158,9 +156,7 @@ def subproblem_data_from_numpy_stash(solver) -> SubproblemData:
         nodal_grad_x = np.zeros((N, 0, n_x))
         nodal_grad_u = np.zeros((N, 0, n_u))
 
-    x_prop_plus = (
-        dyn["x_prop_plus"] if dyn["x_prop_plus"] is not None else np.zeros((N, n_x))
-    )
+    x_prop_plus = dyn["x_prop_plus"] if dyn["x_prop_plus"] is not None else np.zeros((N, n_x))
     E_d = dyn["E_d"] if dyn["E_d"] is not None else np.zeros((N, n_x, n_u))
     D_d = np.zeros((N, n_x, n_x))
 

--- a/tests/solvers/_iteration_callback_helpers.py
+++ b/tests/solvers/_iteration_callback_helpers.py
@@ -1,0 +1,193 @@
+"""Shared fixtures for ``iteration_callback`` tests across backends.
+
+The brachistochrone problem and the ``SubproblemData`` reconstruction step
+were previously copy-pasted across four test modules; this module owns the
+canonical definitions. Per-backend test files import from here.
+
+* :func:`build_brachistochrone` parametrizes over the solver backend and
+  optional constraint style (CTCS vs. plain nodal), matching every variant
+  the existing tests need.
+* :func:`subproblem_data_from_numpy_stash` reads the JAX-pure
+  :class:`SubproblemData` back from the QPAX/Moreau internal stash
+  (``solver._dyn`` / ``solver._cons`` / ``solver._pen``). CVXPy reads the
+  same iterate from its CVXPy ``Parameter`` values instead, so its variant
+  lives in ``test_iteration_callback_cvxpy.py``.
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import numpy as np
+
+from openscvx import Problem
+from openscvx.solvers.ptr_solver import SubproblemData
+
+
+def build_brachistochrone(
+    backend: str,
+    n: int = 4,
+    k_max: int = 1,
+    constraint_style: str = "ctcs",
+):
+    """Build the brachistochrone problem at small ``N`` for callback tests.
+
+    Mirrors ``examples/abstract/brachistochrone.py`` but rebuilds the symbolic
+    state in-test so the cached problem from the example doesn't carry over.
+
+    Args:
+        backend: ``"qpax"`` / ``"moreau"`` / ``"cvxpy"`` — passed straight
+            through to ``solver={"backend": ...}``.
+        n: Number of discretization nodes. Small values keep the assembly
+            matrices small enough to compare element-wise.
+        k_max: SCP iteration cap. One iteration is enough to populate the
+            solver's per-iteration stash for parity tests.
+        constraint_style: ``"ctcs"`` (CTCS box rows; the default) or
+            ``"nodal"`` (plain nodal inequalities; exercises the
+            nodal-constraint assembly block that's dormant under CTCS-only).
+    """
+    import openscvx as ox
+
+    g = 9.81
+
+    position = ox.State("position", shape=(2,))
+    position.max = np.array([10.0, 10.0])
+    position.min = np.array([0.0, 0.0])
+    position.initial = np.array([0.0, 10.0])
+    position.final = [10.0, 5.0]
+
+    velocity = ox.State("velocity", shape=(1,))
+    velocity.max = np.array([10.0])
+    velocity.min = np.array([0.0])
+    velocity.initial = np.array([0.0])
+    velocity.final = [("free", 10.0)]
+
+    theta = ox.Control("theta", shape=(1,))
+    theta.max = np.array([100.5 * jnp.pi / 180])
+    theta.min = np.array([0.0])
+    theta.guess = np.linspace(5 * jnp.pi / 180, 100.5 * jnp.pi / 180, n).reshape(-1, 1)
+
+    states = [position, velocity]
+    controls = [theta]
+
+    dynamics = {
+        "position": ox.Concat(
+            velocity[0] * ox.Sin(theta[0]),
+            -velocity[0] * ox.Cos(theta[0]),
+        ),
+        "velocity": g * ox.Cos(theta[0]),
+    }
+
+    constraint_exprs = []
+    if constraint_style == "ctcs":
+        for state in states:
+            constraint_exprs.extend(
+                [ox.ctcs(state <= state.max), ox.ctcs(state.min <= state)]
+            )
+    elif constraint_style == "nodal":
+        for state in states:
+            constraint_exprs.extend([state <= state.max, state.min <= state])
+    else:
+        raise ValueError(f"unknown constraint_style {constraint_style!r}")
+
+    time = ox.Time(
+        initial=0.0,
+        final=("minimize", 2.0),
+        min=0.0,
+        max=2.0,
+        uniform_time_grid=True,
+    )
+
+    prob = Problem(
+        dynamics=dynamics,
+        states=states,
+        controls=controls,
+        time=time,
+        constraints=constraint_exprs,
+        N=n,
+        float_dtype="float64",
+        algorithm={
+            "autotuner": "ConstantProximalWeight",
+            "lam_prox": 1e0,
+            "lam_cost": 6e-1,
+            "k_max": k_max,
+        },
+        solver={"backend": backend},
+    )
+    prob.settings.dev.printing = False
+    return prob
+
+
+def subproblem_data_from_numpy_stash(solver) -> SubproblemData:
+    """Reconstruct :class:`SubproblemData` from QPAX/Moreau's NumPy stash.
+
+    After one ``update_*`` cycle the solver has every per-iteration array on
+    hand (``solver._dyn`` / ``solver._cons`` / ``solver._pen``). This helper
+    rebuilds the stacked-array layout the JAX callback expects so both
+    assembly paths see the same iterate.
+
+    The NumPy path absorbs ``D_d`` into ``A_d`` / ``B_d`` / ``C_d`` at update
+    time, so we pass a zero ``D_d`` here — the JAX path's ``has_impulsive``
+    branch is statically False for brachistochrone and the absorption einsum
+    is skipped.
+
+    CVXPy stores the same data on its CVXPy parameters and has its own reader
+    that lives in ``test_iteration_callback_cvxpy.py``.
+    """
+    L = solver.layout
+    N, n_x, n_u = L.N, L.n_x, L.n_u
+
+    dyn = solver._dyn
+    cons = solver._cons
+    pen = solver._pen
+    n_nodal = L.n_nodal
+
+    # Stack nodal linearizations into (N, n_nodal*) layout with zero-fill for
+    # nodes outside each constraint's static ``nodes`` tuple.
+    nodal_g = np.zeros((N, max(n_nodal, 1)), dtype=float)
+    nodal_grad_x = np.zeros((N, max(n_nodal, 1), n_x), dtype=float)
+    nodal_grad_u = np.zeros((N, max(n_nodal, 1), n_u), dtype=float)
+    for c_idx, (constraint, entry) in enumerate(
+        zip(solver._jax_constraints.nodal, cons.get("nodal", []))
+    ):
+        for node in constraint.nodes:
+            nodal_g[node, c_idx] = entry["g"][node]
+            nodal_grad_x[node, c_idx] = entry["grad_g_x"][node]
+            nodal_grad_u[node, c_idx] = entry["grad_g_u"][node]
+    if n_nodal == 0:
+        nodal_g = np.zeros((N, 0))
+        nodal_grad_x = np.zeros((N, 0, n_x))
+        nodal_grad_u = np.zeros((N, 0, n_u))
+
+    x_prop_plus = (
+        dyn["x_prop_plus"] if dyn["x_prop_plus"] is not None else np.zeros((N, n_x))
+    )
+    E_d = dyn["E_d"] if dyn["E_d"] is not None else np.zeros((N, n_x, n_u))
+    D_d = np.zeros((N, n_x, n_x))
+
+    x_init = solver._x_init if solver._x_init is not None else np.full(n_x, np.nan)
+    x_term = solver._x_term if solver._x_term is not None else np.full(n_x, np.nan)
+
+    return SubproblemData(
+        x_bar=jnp.asarray(dyn["x_bar"]),
+        u_bar=jnp.asarray(dyn["u_bar"]),
+        A_d=jnp.asarray(dyn["A_d"]),
+        B_d=jnp.asarray(dyn["B_d"]),
+        C_d=jnp.asarray(dyn["C_d"]),
+        x_prop=jnp.asarray(dyn["x_prop"]),
+        x_prop_plus=jnp.asarray(x_prop_plus),
+        D_d=jnp.asarray(D_d),
+        E_d=jnp.asarray(E_d),
+        nodal_g=jnp.asarray(nodal_g),
+        nodal_grad_x=jnp.asarray(nodal_grad_x),
+        nodal_grad_u=jnp.asarray(nodal_grad_u),
+        cross_g=jnp.zeros((0,)),
+        cross_grad_X=jnp.zeros((0, N, n_x)),
+        cross_grad_U=jnp.zeros((0, N, n_u)),
+        lam_prox=jnp.asarray(pen["lam_prox"]),
+        lam_cost=jnp.asarray(pen["lam_cost"]),
+        lam_vc=jnp.asarray(pen["lam_vc"]),
+        lam_vb_nodal=jnp.asarray(pen["lam_vb_nodal"]),
+        lam_vb_cross=jnp.zeros((0,)),
+        x_init=jnp.asarray(x_init),
+        x_term=jnp.asarray(x_term),
+    )

--- a/tests/solvers/test_cvxpy_callback_jit_spike.py
+++ b/tests/solvers/test_cvxpy_callback_jit_spike.py
@@ -1,0 +1,144 @@
+"""Spike: verify ``jax.pure_callback`` composes cleanly with a CVXPy solve.
+
+This is the go/no-go gate for Phase 4 of
+``plans/solver-iteration-callbacks.md``. Before wrapping the full PTR solver
+in a callback, prove on a trivial CVXPy problem that:
+
+* ``jax.pure_callback`` ferries a parameter array into ``cvxpy.Problem.solve``
+  and returns the optimum as a JAX-shaped array;
+* ``jax.jit`` around the callback gives the same answer as a bare call;
+* ``jax.jit(jax.vmap(cb))`` with ``vmap_method="sequential"`` fires the
+  callback once per batch element and produces per-element-correct outputs.
+
+If any of the three fail, the plan's CVXPy strategy is wrong and the rest of
+Phase 4 has to be rethought before the real ``CVXPyPTRSolver.iteration_callback``
+is implemented. If they pass, the plan's premise holds and the same shape of
+wrapping works in the real solver.
+
+The toy problem is ``min ||x - p||^2 s.t. x >= 0``, whose closed-form solution
+is ``max(p, 0)`` — easy to assert against without re-running the solver.
+"""
+
+import numpy as np
+import pytest
+
+import cvxpy as cp
+import jax
+import jax.numpy as jnp
+
+# Declared output dtype follows JAX's current x64 setting so the spike runs
+# regardless of how the rest of the suite has configured precision.
+_JAX_FLOAT = jnp.float64 if jax.config.read("jax_enable_x64") else jnp.float32
+
+
+# ============================================================================
+# Toy CVXPy problem
+# ============================================================================
+
+
+def _make_toy_cvxpy_solve():
+    """Build a parameterized CVXPy problem and return a host-side solve closure.
+
+    The closure mirrors what ``CVXPyPTRSolver.iteration_callback`` will do:
+    take a NumPy parameter value, mutate the CVXPy ``Parameter``, solve, and
+    return a NumPy array. Built once and reused across calls so the same
+    ``cvxpy.Problem`` (and its compiled chain) is exercised on every callback
+    invocation — exactly how the real solver will use it.
+    """
+    n = 3
+    x = cp.Variable(n)
+    p = cp.Parameter(n)
+    prob = cp.Problem(cp.Minimize(cp.sum_squares(x - p)), [x >= 0])
+
+    def host_solve(p_value: np.ndarray) -> np.ndarray:
+        p.value = np.asarray(p_value, dtype=float)
+        prob.solve(solver="CLARABEL")
+        return np.asarray(x.value, dtype=_JAX_FLOAT)
+
+    return host_solve, n
+
+
+def _build_callback(host_solve, n: int):
+    """Wrap ``host_solve`` in ``jax.pure_callback`` with a declared shape."""
+    result_struct = jax.ShapeDtypeStruct((n,), _JAX_FLOAT)
+
+    def callback(p_value):
+        return jax.pure_callback(
+            host_solve,
+            result_struct,
+            p_value,
+            vmap_method="sequential",
+        )
+
+    return callback
+
+
+# ============================================================================
+# Spike assertions
+# ============================================================================
+
+
+def test_pure_callback_matches_bare_solve():
+    """Bare ``pure_callback`` call returns the closed-form optimum.
+
+    Floor of the closed-form: ``argmin ||x - p||^2 s.t. x >= 0`` is
+    ``max(p, 0)``. Exercises the basic ``pure_callback`` plumbing without any
+    transform on top.
+    """
+    host_solve, n = _make_toy_cvxpy_solve()
+    callback = _build_callback(host_solve, n)
+
+    p_value = jnp.asarray([1.0, -2.0, 0.5])
+    result = callback(p_value)
+
+    # Tolerance is CLARABEL's default convergence floor — the test only cares
+    # that the callback ferried the answer back into JAX shape, not that the
+    # toy problem was solved to machine precision.
+    np.testing.assert_allclose(np.asarray(result), np.maximum(np.asarray(p_value), 0.0), atol=1e-4)
+
+
+def test_pure_callback_composes_with_jit():
+    """``jax.jit`` around the callback produces the same answer as the bare call.
+
+    This is the load-bearing assertion: if ``jit`` can't trace the callback,
+    the real ``CVXPyPTRSolver.iteration_callback`` can't be embedded in the
+    JAX-pure SCP loop. Run twice to confirm the compiled trace is cached and
+    reused (no per-call re-tracing).
+    """
+    host_solve, n = _make_toy_cvxpy_solve()
+    callback = _build_callback(host_solve, n)
+    jitted = jax.jit(callback)
+
+    p_value = jnp.asarray([1.0, -2.0, 0.5])
+
+    bare = callback(p_value)
+    jit1 = jitted(p_value)
+    jit2 = jitted(jnp.asarray([0.0, 3.0, -1.0]))
+
+    np.testing.assert_allclose(np.asarray(jit1), np.asarray(bare), atol=1e-4)
+    np.testing.assert_allclose(np.asarray(jit2), np.asarray([0.0, 3.0, 0.0]), atol=1e-4)
+
+
+def test_pure_callback_composes_with_jit_vmap():
+    """``jax.jit(jax.vmap(cb))`` fires the callback B times sequentially.
+
+    ``vmap_method="sequential"`` is the only contract CVXPy can satisfy
+    (CVXPy can't ingest a batched parameter set). Confirm the resulting batch
+    output is element-wise the per-element solve.
+    """
+    host_solve, n = _make_toy_cvxpy_solve()
+    callback = _build_callback(host_solve, n)
+    batched = jax.jit(jax.vmap(callback))
+
+    batch = jnp.asarray(
+        [
+            [1.0, -2.0, 0.5],
+            [0.0, 3.0, -1.0],
+            [-4.0, -5.0, 2.0],
+            [7.0, 0.25, -0.25],
+        ]
+    )
+    result = batched(batch)
+
+    expected = np.maximum(np.asarray(batch), 0.0)
+    np.testing.assert_allclose(np.asarray(result), expected, atol=1e-4)

--- a/tests/solvers/test_cvxpy_callback_jit_spike.py
+++ b/tests/solvers/test_cvxpy_callback_jit_spike.py
@@ -24,9 +24,16 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
-# Declared output dtype follows JAX's current x64 setting so the spike runs
-# regardless of how the rest of the suite has configured precision.
-_JAX_FLOAT = jnp.float64 if jax.config.read("jax_enable_x64") else jnp.float32
+
+def _jax_float():
+    """Resolve the active JAX float dtype from the live x64 config.
+
+    Read on every call rather than latched at module import: under
+    ``pytest-xdist``, other tests and example modules flip ``jax_enable_x64``
+    in-process, and a stale capture leads to ``pure_callback`` validation
+    errors when the declared dtype no longer matches the global config.
+    """
+    return jnp.float64 if jax.config.read("jax_enable_x64") else jnp.float32
 
 
 # ============================================================================
@@ -51,14 +58,14 @@ def _make_toy_cvxpy_solve():
     def host_solve(p_value: np.ndarray) -> np.ndarray:
         p.value = np.asarray(p_value, dtype=float)
         prob.solve(solver="CLARABEL")
-        return np.asarray(x.value, dtype=_JAX_FLOAT)
+        return np.asarray(x.value, dtype=_jax_float())
 
     return host_solve, n
 
 
 def _build_callback(host_solve, n: int):
     """Wrap ``host_solve`` in ``jax.pure_callback`` with a declared shape."""
-    result_struct = jax.ShapeDtypeStruct((n,), _JAX_FLOAT)
+    result_struct = jax.ShapeDtypeStruct((n,), _jax_float())
 
     def callback(p_value):
         return jax.pure_callback(

--- a/tests/solvers/test_cvxpy_callback_jit_spike.py
+++ b/tests/solvers/test_cvxpy_callback_jit_spike.py
@@ -19,12 +19,10 @@ The toy problem is ``min ||x - p||^2 s.t. x >= 0``, whose closed-form solution
 is ``max(p, 0)`` — easy to assert against without re-running the solver.
 """
 
-import numpy as np
-import pytest
-
 import cvxpy as cp
 import jax
 import jax.numpy as jnp
+import numpy as np
 
 # Declared output dtype follows JAX's current x64 setting so the spike runs
 # regardless of how the rest of the suite has configured precision.

--- a/tests/solvers/test_iteration_callback_cvxpy.py
+++ b/tests/solvers/test_iteration_callback_cvxpy.py
@@ -1,0 +1,303 @@
+"""Tests for ``CVXPyPTRSolver.iteration_callback``.
+
+The CVXPy callback wraps the existing NumPy ``solve()`` in
+:func:`jax.pure_callback`; the assertion is that running the callback
+end-to-end on a fixed brachistochrone iterate produces the same primal
+trajectory as a direct :meth:`solve` call (the spike in
+``test_cvxpy_callback_jit_spike.py`` already confirms the
+``pure_callback`` + ``jit`` plumbing works at the toy level — this test
+exercises the real PTR pipeline).
+"""
+
+import numpy as np
+import pytest
+
+import jax
+import jax.numpy as jnp
+
+from openscvx import Problem
+from openscvx.solvers.ptr_solver import (
+    StatusCode,
+    SubproblemData,
+    SubproblemSolution,
+)
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+def _build_brachistochrone(n: int = 4, k_max: int = 1):
+    """Build the brachistochrone problem at small ``N`` for callback tests.
+
+    Mirrors ``examples/abstract/brachistochrone.py`` but selects the CVXPy
+    backend explicitly and disables printing so the test output stays clean.
+    """
+    import openscvx as ox
+
+    g = 9.81
+
+    position = ox.State("position", shape=(2,))
+    position.max = np.array([10.0, 10.0])
+    position.min = np.array([0.0, 0.0])
+    position.initial = np.array([0.0, 10.0])
+    position.final = [10.0, 5.0]
+
+    velocity = ox.State("velocity", shape=(1,))
+    velocity.max = np.array([10.0])
+    velocity.min = np.array([0.0])
+    velocity.initial = np.array([0.0])
+    velocity.final = [("free", 10.0)]
+
+    theta = ox.Control("theta", shape=(1,))
+    theta.max = np.array([100.5 * jnp.pi / 180])
+    theta.min = np.array([0.0])
+    theta.guess = np.linspace(5 * jnp.pi / 180, 100.5 * jnp.pi / 180, n).reshape(-1, 1)
+
+    states = [position, velocity]
+    controls = [theta]
+
+    dynamics = {
+        "position": ox.Concat(
+            velocity[0] * ox.Sin(theta[0]),
+            -velocity[0] * ox.Cos(theta[0]),
+        ),
+        "velocity": g * ox.Cos(theta[0]),
+    }
+
+    constraint_exprs = []
+    for state in states:
+        constraint_exprs.extend(
+            [ox.ctcs(state <= state.max), ox.ctcs(state.min <= state)]
+        )
+
+    time = ox.Time(
+        initial=0.0,
+        final=("minimize", 2.0),
+        min=0.0,
+        max=2.0,
+        uniform_time_grid=True,
+    )
+
+    prob = Problem(
+        dynamics=dynamics,
+        states=states,
+        controls=controls,
+        time=time,
+        constraints=constraint_exprs,
+        N=n,
+        float_dtype="float64",
+        algorithm={
+            "autotuner": "ConstantProximalWeight",
+            "lam_prox": 1e0,
+            "lam_cost": 6e-1,
+            "k_max": k_max,
+        },
+        solver={"backend": "cvxpy"},
+    )
+    prob.settings.dev.printing = False
+    return prob
+
+
+def _subproblem_data_from_solver(prob) -> SubproblemData:
+    """Build a :class:`SubproblemData` from the CVXPy params after one solve.
+
+    Reads back the exact linearization the last ``update_*`` cycle wrote into
+    the CVXPy parameters. This means ``solver.solve()`` and
+    ``iteration_callback()(None, data)`` are guaranteed to see the same
+    inputs (the post-SCP-iter ``state.x`` is *not* the same as the
+    last-iteration ``x_bar``, so reading from the params is the only way to
+    get matched inputs without re-running an iteration).
+    """
+    settings = prob.settings
+    lowered = prob._lowered
+    solver = prob.solver
+    ocp = solver._ocp_vars
+
+    N = settings.sim.n
+    n_x = settings.sim.n_states
+    n_u = settings.sim.n_controls
+
+    x_bar = np.asarray(ocp.x_bar.value)
+    u_bar = np.asarray(ocp.u_bar.value)
+    A_d = np.asarray(ocp.A_d.value)
+    B_d = np.asarray(ocp.B_d.value)
+    C_d = np.asarray(ocp.C_d.value)
+    x_prop = (
+        np.asarray(ocp.x_prop.value)
+        if ocp.x_prop is not None
+        else np.zeros((N - 1, n_x))
+    )
+    x_prop_plus = (
+        np.asarray(ocp.x_prop_plus.value)
+        if ocp.x_prop_plus is not None and ocp.x_prop_plus.value is not None
+        else np.zeros((N, n_x))
+    )
+    E_d = (
+        np.asarray(ocp.E_d.value)
+        if ocp.E_d is not None and ocp.E_d.value is not None
+        else np.zeros((N, n_x, n_u))
+    )
+    # D_d is absorbed into A/B/C at update time on the CVXPy path; passing
+    # zeros tells the callback "no further absorption" — it just calls
+    # update_dynamics_linearization with the already-absorbed A/B/C.
+    D_d = np.zeros((N, n_x, n_x))
+
+    jax_constraints = lowered.jax_constraints
+    n_nodal = len(jax_constraints.nodal)
+    n_cross = len(jax_constraints.cross_node)
+    nodal_g = np.zeros((N, max(n_nodal, 1)))
+    nodal_grad_x = np.zeros((N, max(n_nodal, 1), n_x))
+    nodal_grad_u = np.zeros((N, max(n_nodal, 1), n_u))
+    for c_idx, constraint in enumerate(jax_constraints.nodal):
+        g_full = np.asarray(ocp.g[c_idx].value)
+        grad_x_full = np.asarray(ocp.grad_g_x[c_idx].value)
+        grad_u_full = np.asarray(ocp.grad_g_u[c_idx].value)
+        for node in constraint.nodes:
+            nodal_g[node, c_idx] = g_full[node]
+            nodal_grad_x[node, c_idx] = grad_x_full[node]
+            nodal_grad_u[node, c_idx] = grad_u_full[node]
+    if n_nodal == 0:
+        nodal_g = np.zeros((N, 0))
+        nodal_grad_x = np.zeros((N, 0, n_x))
+        nodal_grad_u = np.zeros((N, 0, n_u))
+
+    cross_g = np.zeros((n_cross,))
+    cross_grad_X = np.zeros((n_cross, N, n_x))
+    cross_grad_U = np.zeros((n_cross, N, n_u))
+    for c_idx in range(n_cross):
+        cross_g[c_idx] = float(np.asarray(ocp.g_cross[c_idx].value))
+        cross_grad_X[c_idx] = np.asarray(ocp.grad_g_X_cross[c_idx].value)
+        cross_grad_U[c_idx] = np.asarray(ocp.grad_g_U_cross[c_idx].value)
+
+    lam_prox = np.asarray(ocp.lam_prox.value)
+    lam_cost = np.asarray(ocp.lam_cost.value)
+    lam_vc = np.asarray(ocp.lam_vc.value)
+    lam_vb_nodal = np.asarray(ocp.lam_vb_nodal.value)
+    lam_vb_cross = np.asarray(ocp.lam_vb_cross.value)
+
+    x_init = (
+        np.asarray(lowered.x_unified.initial, dtype=float)
+        if lowered.x_unified.initial is not None
+        else np.full(n_x, np.nan)
+    )
+    x_term = (
+        np.asarray(lowered.x_unified.final, dtype=float)
+        if lowered.x_unified.final is not None
+        else np.full(n_x, np.nan)
+    )
+
+    return SubproblemData(
+        x_bar=jnp.asarray(x_bar),
+        u_bar=jnp.asarray(u_bar),
+        A_d=jnp.asarray(A_d),
+        B_d=jnp.asarray(B_d),
+        C_d=jnp.asarray(C_d),
+        x_prop=jnp.asarray(x_prop),
+        x_prop_plus=jnp.asarray(x_prop_plus),
+        D_d=jnp.asarray(D_d),
+        E_d=jnp.asarray(E_d),
+        nodal_g=jnp.asarray(nodal_g),
+        nodal_grad_x=jnp.asarray(nodal_grad_x),
+        nodal_grad_u=jnp.asarray(nodal_grad_u),
+        cross_g=jnp.asarray(cross_g),
+        cross_grad_X=jnp.asarray(cross_grad_X),
+        cross_grad_U=jnp.asarray(cross_grad_U),
+        lam_prox=jnp.asarray(lam_prox),
+        lam_cost=jnp.asarray(lam_cost),
+        lam_vc=jnp.asarray(lam_vc),
+        lam_vb_nodal=jnp.asarray(lam_vb_nodal),
+        lam_vb_cross=jnp.asarray(lam_vb_cross),
+        x_init=jnp.asarray(x_init),
+        x_term=jnp.asarray(x_term),
+    )
+
+
+# ============================================================================
+# Solution parity
+# ============================================================================
+
+
+def test_iteration_callback_matches_solve_on_brachistochrone():
+    """``iteration_callback()(state, data)`` must produce the same primal
+    trajectory as ``solver.solve()`` on the same iterate. The callback wraps
+    the same NumPy ``solve()`` we compare against, so parity should be
+    exact modulo CLARABEL re-solve noise.
+    """
+    prob = _build_brachistochrone(n=4, k_max=1)
+    prob.initialize()
+    prob.solve()
+    solver = prob.solver
+
+    reference = solver.solve()
+
+    data = _subproblem_data_from_solver(prob)
+    callback = solver.iteration_callback()
+    solution = callback(None, data)
+
+    assert isinstance(solution, SubproblemSolution)
+    np.testing.assert_allclose(np.asarray(solution.x), reference.x, atol=1e-6, rtol=1e-6)
+    np.testing.assert_allclose(np.asarray(solution.u), reference.u, atol=1e-6, rtol=1e-6)
+    np.testing.assert_allclose(np.asarray(solution.nu), reference.nu, atol=1e-6, rtol=1e-6)
+    # nu_vb is stacked (N, n_nodal) in the callback output, list-of-arrays on NumPy.
+    assert solution.nu_vb.shape == (prob.settings.sim.n, len(prob._lowered.jax_constraints.nodal))
+    np.testing.assert_allclose(float(solution.cost), reference.cost, atol=1e-6, rtol=1e-6)
+    # CVXPy + CLARABEL on a feasible iterate reports "optimal".
+    assert int(solution.status_code) == int(StatusCode.OPTIMAL)
+
+
+def test_iteration_callback_composes_with_jit():
+    """``jax.jit(cb)(state, data)`` matches the bare call.
+
+    The spike test already covers ``pure_callback`` + ``jit`` at the toy
+    level; this asserts the real CVXPy solver also composes under ``jit``
+    without per-call retracing.
+    """
+    prob = _build_brachistochrone(n=4, k_max=1)
+    prob.initialize()
+    prob.solve()
+    solver = prob.solver
+
+    data = _subproblem_data_from_solver(prob)
+    callback = solver.iteration_callback()
+    jitted = jax.jit(callback)
+
+    bare = callback(None, data)
+    jitt = jitted(None, data)
+
+    np.testing.assert_allclose(np.asarray(jitt.x), np.asarray(bare.x), atol=1e-8)
+    np.testing.assert_allclose(np.asarray(jitt.u), np.asarray(bare.u), atol=1e-8)
+    np.testing.assert_allclose(
+        np.asarray(jitt.nu_vb), np.asarray(bare.nu_vb), atol=1e-8
+    )
+
+
+def test_iteration_callback_composes_with_vmap_sequential():
+    """``jax.vmap(cb)`` fires the callback once per batch element.
+
+    CVXPy can't ingest a batched parameter set, so the callback declares
+    ``vmap_method="sequential"`` — under vmap the host is invoked B times in
+    sequence. Stacking the same ``SubproblemData`` four times should yield
+    four identical ``SubproblemSolution`` slices that each match the bare
+    call.
+    """
+    prob = _build_brachistochrone(n=4, k_max=1)
+    prob.initialize()
+    prob.solve()
+    solver = prob.solver
+
+    data = _subproblem_data_from_solver(prob)
+    callback = solver.iteration_callback()
+    bare = callback(None, data)
+
+    batch = jax.tree_util.tree_map(lambda x: jnp.broadcast_to(x, (3,) + x.shape), data)
+    batched = jax.vmap(callback, in_axes=(None, 0))(None, batch)
+
+    for i in range(3):
+        np.testing.assert_allclose(
+            np.asarray(batched.x[i]), np.asarray(bare.x), atol=1e-8
+        )
+        np.testing.assert_allclose(
+            np.asarray(batched.u[i]), np.asarray(bare.u), atol=1e-8
+        )

--- a/tests/solvers/test_iteration_callback_cvxpy.py
+++ b/tests/solvers/test_iteration_callback_cvxpy.py
@@ -9,20 +9,16 @@ trajectory as a direct :meth:`solve` call (the spike in
 exercises the real PTR pipeline).
 """
 
-import numpy as np
-import pytest
-
 import jax
 import jax.numpy as jnp
+import numpy as np
 
 from openscvx.solvers.ptr_solver import (
     StatusCode,
     SubproblemData,
     SubproblemSolution,
 )
-
 from tests.solvers._iteration_callback_helpers import build_brachistochrone
-
 
 # ============================================================================
 # Fixtures
@@ -53,11 +49,7 @@ def _subproblem_data_from_solver(prob) -> SubproblemData:
     A_d = np.asarray(ocp.A_d.value)
     B_d = np.asarray(ocp.B_d.value)
     C_d = np.asarray(ocp.C_d.value)
-    x_prop = (
-        np.asarray(ocp.x_prop.value)
-        if ocp.x_prop is not None
-        else np.zeros((N - 1, n_x))
-    )
+    x_prop = np.asarray(ocp.x_prop.value) if ocp.x_prop is not None else np.zeros((N - 1, n_x))
     x_prop_plus = (
         np.asarray(ocp.x_prop_plus.value)
         if ocp.x_prop_plus is not None and ocp.x_prop_plus.value is not None
@@ -197,9 +189,7 @@ def test_iteration_callback_composes_with_jit():
 
     np.testing.assert_allclose(np.asarray(jitt.x), np.asarray(bare.x), atol=1e-8)
     np.testing.assert_allclose(np.asarray(jitt.u), np.asarray(bare.u), atol=1e-8)
-    np.testing.assert_allclose(
-        np.asarray(jitt.nu_vb), np.asarray(bare.nu_vb), atol=1e-8
-    )
+    np.testing.assert_allclose(np.asarray(jitt.nu_vb), np.asarray(bare.nu_vb), atol=1e-8)
 
 
 def test_iteration_callback_composes_with_vmap_sequential():
@@ -224,9 +214,5 @@ def test_iteration_callback_composes_with_vmap_sequential():
     batched = jax.vmap(callback, in_axes=(None, 0))(None, batch)
 
     for i in range(3):
-        np.testing.assert_allclose(
-            np.asarray(batched.x[i]), np.asarray(bare.x), atol=1e-8
-        )
-        np.testing.assert_allclose(
-            np.asarray(batched.u[i]), np.asarray(bare.u), atol=1e-8
-        )
+        np.testing.assert_allclose(np.asarray(batched.x[i]), np.asarray(bare.x), atol=1e-8)
+        np.testing.assert_allclose(np.asarray(batched.u[i]), np.asarray(bare.u), atol=1e-8)

--- a/tests/solvers/test_iteration_callback_cvxpy.py
+++ b/tests/solvers/test_iteration_callback_cvxpy.py
@@ -15,89 +15,18 @@ import pytest
 import jax
 import jax.numpy as jnp
 
-from openscvx import Problem
 from openscvx.solvers.ptr_solver import (
     StatusCode,
     SubproblemData,
     SubproblemSolution,
 )
 
+from tests.solvers._iteration_callback_helpers import build_brachistochrone
+
 
 # ============================================================================
 # Fixtures
 # ============================================================================
-
-
-def _build_brachistochrone(n: int = 4, k_max: int = 1):
-    """Build the brachistochrone problem at small ``N`` for callback tests.
-
-    Mirrors ``examples/abstract/brachistochrone.py`` but selects the CVXPy
-    backend explicitly and disables printing so the test output stays clean.
-    """
-    import openscvx as ox
-
-    g = 9.81
-
-    position = ox.State("position", shape=(2,))
-    position.max = np.array([10.0, 10.0])
-    position.min = np.array([0.0, 0.0])
-    position.initial = np.array([0.0, 10.0])
-    position.final = [10.0, 5.0]
-
-    velocity = ox.State("velocity", shape=(1,))
-    velocity.max = np.array([10.0])
-    velocity.min = np.array([0.0])
-    velocity.initial = np.array([0.0])
-    velocity.final = [("free", 10.0)]
-
-    theta = ox.Control("theta", shape=(1,))
-    theta.max = np.array([100.5 * jnp.pi / 180])
-    theta.min = np.array([0.0])
-    theta.guess = np.linspace(5 * jnp.pi / 180, 100.5 * jnp.pi / 180, n).reshape(-1, 1)
-
-    states = [position, velocity]
-    controls = [theta]
-
-    dynamics = {
-        "position": ox.Concat(
-            velocity[0] * ox.Sin(theta[0]),
-            -velocity[0] * ox.Cos(theta[0]),
-        ),
-        "velocity": g * ox.Cos(theta[0]),
-    }
-
-    constraint_exprs = []
-    for state in states:
-        constraint_exprs.extend(
-            [ox.ctcs(state <= state.max), ox.ctcs(state.min <= state)]
-        )
-
-    time = ox.Time(
-        initial=0.0,
-        final=("minimize", 2.0),
-        min=0.0,
-        max=2.0,
-        uniform_time_grid=True,
-    )
-
-    prob = Problem(
-        dynamics=dynamics,
-        states=states,
-        controls=controls,
-        time=time,
-        constraints=constraint_exprs,
-        N=n,
-        float_dtype="float64",
-        algorithm={
-            "autotuner": "ConstantProximalWeight",
-            "lam_prox": 1e0,
-            "lam_cost": 6e-1,
-            "k_max": k_max,
-        },
-        solver={"backend": "cvxpy"},
-    )
-    prob.settings.dev.printing = False
-    return prob
 
 
 def _subproblem_data_from_solver(prob) -> SubproblemData:
@@ -225,7 +154,7 @@ def test_iteration_callback_matches_solve_on_brachistochrone():
     the same NumPy ``solve()`` we compare against, so parity should be
     exact modulo CLARABEL re-solve noise.
     """
-    prob = _build_brachistochrone(n=4, k_max=1)
+    prob = build_brachistochrone("cvxpy", n=4, k_max=1)
     prob.initialize()
     prob.solve()
     solver = prob.solver
@@ -254,7 +183,7 @@ def test_iteration_callback_composes_with_jit():
     level; this asserts the real CVXPy solver also composes under ``jit``
     without per-call retracing.
     """
-    prob = _build_brachistochrone(n=4, k_max=1)
+    prob = build_brachistochrone("cvxpy", n=4, k_max=1)
     prob.initialize()
     prob.solve()
     solver = prob.solver
@@ -282,7 +211,7 @@ def test_iteration_callback_composes_with_vmap_sequential():
     four identical ``SubproblemSolution`` slices that each match the bare
     call.
     """
-    prob = _build_brachistochrone(n=4, k_max=1)
+    prob = build_brachistochrone("cvxpy", n=4, k_max=1)
     prob.initialize()
     prob.solve()
     solver = prob.solver

--- a/tests/solvers/test_iteration_callback_moreau.py
+++ b/tests/solvers/test_iteration_callback_moreau.py
@@ -20,14 +20,13 @@ without a license while still exercising on CI / dev hosts that have one.
 import numpy as np
 import pytest
 
-from tests._marks import requires_moreau, _MOREAU_OK
+from tests._marks import _MOREAU_OK, requires_moreau
 
 pytestmark = requires_moreau
 
 # Imports below are only reached when _MOREAU_OK is True.
 if _MOREAU_OK:
     from openscvx.solvers.ptr_solver import StatusCode, SubproblemSolution
-
     from tests.solvers._iteration_callback_helpers import (
         build_brachistochrone,
         subproblem_data_from_numpy_stash,
@@ -113,19 +112,11 @@ def test_iteration_callback_matches_solve_on_brachistochrone():
     solution = callback(None, data)
 
     assert isinstance(solution, SubproblemSolution)
-    np.testing.assert_allclose(
-        np.asarray(solution.x), reference.x, atol=1e-7, rtol=1e-7
-    )
-    np.testing.assert_allclose(
-        np.asarray(solution.u), reference.u, atol=1e-7, rtol=1e-7
-    )
-    np.testing.assert_allclose(
-        np.asarray(solution.nu), reference.nu, atol=1e-7, rtol=1e-7
-    )
+    np.testing.assert_allclose(np.asarray(solution.x), reference.x, atol=1e-7, rtol=1e-7)
+    np.testing.assert_allclose(np.asarray(solution.u), reference.u, atol=1e-7, rtol=1e-7)
+    np.testing.assert_allclose(np.asarray(solution.nu), reference.nu, atol=1e-7, rtol=1e-7)
     assert solution.nu_vb.shape == (solver.layout.N, solver.layout.n_nodal)
-    np.testing.assert_allclose(
-        float(solution.cost), reference.cost, atol=1e-7, rtol=1e-7
-    )
+    np.testing.assert_allclose(float(solution.cost), reference.cost, atol=1e-7, rtol=1e-7)
     # Optimal solves should map to StatusCode.OPTIMAL.
     assert int(solution.status_code) == int(StatusCode.OPTIMAL)
 

--- a/tests/solvers/test_iteration_callback_moreau.py
+++ b/tests/solvers/test_iteration_callback_moreau.py
@@ -26,170 +26,11 @@ pytestmark = requires_moreau
 
 # Imports below are only reached when _MOREAU_OK is True.
 if _MOREAU_OK:
-    import jax
-    import jax.numpy as jnp
+    from openscvx.solvers.ptr_solver import StatusCode, SubproblemSolution
 
-    from openscvx import Problem
-    from openscvx.solvers.ptr_solver import (
-        StatusCode,
-        SubproblemData,
-        SubproblemSolution,
-    )
-
-
-# ============================================================================
-# Fixtures
-# ============================================================================
-
-
-def _build_brachistochrone(n: int = 4, k_max: int = 1, constraint_style: str = "ctcs"):
-    """Build the brachistochrone problem with the Moreau backend.
-
-    Mirrors the QPAX iteration-callback test fixture so the two backends are
-    exercised on the same problem shape — the only delta is ``backend="moreau"``
-    and the constraint-row encoding choice (Moreau uses SOC epigraphs for
-    ``|nu|`` where QPAX uses paired nonneg slacks).
-    """
-    import openscvx as ox
-
-    g = 9.81
-
-    position = ox.State("position", shape=(2,))
-    position.max = np.array([10.0, 10.0])
-    position.min = np.array([0.0, 0.0])
-    position.initial = np.array([0.0, 10.0])
-    position.final = [10.0, 5.0]
-
-    velocity = ox.State("velocity", shape=(1,))
-    velocity.max = np.array([10.0])
-    velocity.min = np.array([0.0])
-    velocity.initial = np.array([0.0])
-    velocity.final = [("free", 10.0)]
-
-    theta = ox.Control("theta", shape=(1,))
-    theta.max = np.array([100.5 * jnp.pi / 180])
-    theta.min = np.array([0.0])
-    theta.guess = np.linspace(5 * jnp.pi / 180, 100.5 * jnp.pi / 180, n).reshape(-1, 1)
-
-    states = [position, velocity]
-    controls = [theta]
-
-    dynamics = {
-        "position": ox.Concat(
-            velocity[0] * ox.Sin(theta[0]),
-            -velocity[0] * ox.Cos(theta[0]),
-        ),
-        "velocity": g * ox.Cos(theta[0]),
-    }
-
-    constraint_exprs = []
-    if constraint_style == "ctcs":
-        for state in states:
-            constraint_exprs.extend(
-                [ox.ctcs(state <= state.max), ox.ctcs(state.min <= state)]
-            )
-    elif constraint_style == "nodal":
-        for state in states:
-            constraint_exprs.extend([state <= state.max, state.min <= state])
-    else:
-        raise ValueError(f"unknown constraint_style {constraint_style!r}")
-
-    time = ox.Time(
-        initial=0.0,
-        final=("minimize", 2.0),
-        min=0.0,
-        max=2.0,
-        uniform_time_grid=True,
-    )
-
-    prob = Problem(
-        dynamics=dynamics,
-        states=states,
-        controls=controls,
-        time=time,
-        constraints=constraint_exprs,
-        N=n,
-        float_dtype="float64",
-        algorithm={
-            "autotuner": "ConstantProximalWeight",
-            "lam_prox": 1e0,
-            "lam_cost": 6e-1,
-            "k_max": k_max,
-        },
-        solver={"backend": "moreau"},
-    )
-    prob.settings.dev.printing = False
-    return prob
-
-
-def _subproblem_data_from_solver(solver) -> "SubproblemData":
-    """Reconstruct the JAX-pure :class:`SubproblemData` from the NumPy stash.
-
-    Mirrors the QPAX-side helper: after one ``update_*`` cycle the solver
-    has every per-iteration array on hand, and the stacked-array layout
-    required by the callback is built here so both assembly paths see the
-    identical iterate.
-    """
-    L = solver.layout
-    N, n_x, n_u = L.N, L.n_x, L.n_u
-    sim = solver._settings.sim
-    has_impulsive = sim.u.slice_impulsive.stop > sim.u.slice_impulsive.start
-
-    dyn = solver._dyn
-    cons = solver._cons
-    pen = solver._pen
-    n_nodal = L.n_nodal
-
-    nodal_g = np.zeros((N, max(n_nodal, 1)), dtype=float)
-    nodal_grad_x = np.zeros((N, max(n_nodal, 1), n_x), dtype=float)
-    nodal_grad_u = np.zeros((N, max(n_nodal, 1), n_u), dtype=float)
-    for c_idx, (constraint, entry) in enumerate(
-        zip(solver._jax_constraints.nodal, cons.get("nodal", []))
-    ):
-        for node in constraint.nodes:
-            nodal_g[node, c_idx] = entry["g"][node]
-            nodal_grad_x[node, c_idx] = entry["grad_g_x"][node]
-            nodal_grad_u[node, c_idx] = entry["grad_g_u"][node]
-    if n_nodal == 0:
-        nodal_g = np.zeros((N, 0))
-        nodal_grad_x = np.zeros((N, 0, n_x))
-        nodal_grad_u = np.zeros((N, 0, n_u))
-
-    x_prop_plus = (
-        dyn["x_prop_plus"] if dyn["x_prop_plus"] is not None else np.zeros((N, n_x))
-    )
-    E_d = dyn["E_d"] if dyn["E_d"] is not None else np.zeros((N, n_x, n_u))
-    # NumPy path already absorbed D_d into A_d/B_d/C_d; pass zero D_d so the
-    # JAX path's einsum (gated on has_impulsive) is skipped via the matching
-    # static-Python branch — has_impulsive is False for this problem.
-    D_d = np.zeros((N, n_x, n_x))
-
-    x_init = solver._x_init if solver._x_init is not None else np.full(n_x, np.nan)
-    x_term = solver._x_term if solver._x_term is not None else np.full(n_x, np.nan)
-
-    return SubproblemData(
-        x_bar=jnp.asarray(dyn["x_bar"]),
-        u_bar=jnp.asarray(dyn["u_bar"]),
-        A_d=jnp.asarray(dyn["A_d"]),
-        B_d=jnp.asarray(dyn["B_d"]),
-        C_d=jnp.asarray(dyn["C_d"]),
-        x_prop=jnp.asarray(dyn["x_prop"]),
-        x_prop_plus=jnp.asarray(x_prop_plus),
-        D_d=jnp.asarray(D_d),
-        E_d=jnp.asarray(E_d),
-        nodal_g=jnp.asarray(nodal_g),
-        nodal_grad_x=jnp.asarray(nodal_grad_x),
-        nodal_grad_u=jnp.asarray(nodal_grad_u),
-        cross_g=jnp.zeros((0,)),
-        cross_grad_X=jnp.zeros((0, N, n_x)),
-        cross_grad_U=jnp.zeros((0, N, n_u)),
-        lam_prox=jnp.asarray(pen["lam_prox"]),
-        lam_cost=jnp.asarray(pen["lam_cost"]),
-        lam_vc=jnp.asarray(pen["lam_vc"]),
-        lam_vb_nodal=jnp.asarray(pen["lam_vb_nodal"]),
-        lam_vb_cross=jnp.zeros((0,)),
-        x_init=jnp.asarray(x_init),
-        x_term=jnp.asarray(x_term),
+    from tests.solvers._iteration_callback_helpers import (
+        build_brachistochrone,
+        subproblem_data_from_numpy_stash,
     )
 
 
@@ -208,14 +49,14 @@ def test_assemble_conic_jax_matches_numpy_on_brachistochrone(constraint_style):
     precomputed ``csr_to_coo_perm`` — both compose to the same A_data passed
     to Moreau's solver.
     """
-    prob = _build_brachistochrone(n=4, k_max=1, constraint_style=constraint_style)
+    prob = build_brachistochrone("moreau", n=4, k_max=1, constraint_style=constraint_style)
     prob.initialize()
     prob.solve()
     solver = prob.solver
 
     P_np, coo_np, q_np, b_np = solver._assemble_conic()
 
-    data = _subproblem_data_from_solver(solver)
+    data = subproblem_data_from_numpy_stash(solver)
     P_j, coo_j, q_j, b_j = solver._assemble_conic_jax(data)
 
     np.testing.assert_allclose(np.asarray(P_j), P_np, atol=1e-10, rtol=1e-10)
@@ -230,7 +71,7 @@ def test_csr_to_coo_perm_reconstructs_numpy_A_data():
     path would silently send a permuted system to Moreau."""
     import scipy.sparse as sp
 
-    prob = _build_brachistochrone(n=4, k_max=1)
+    prob = build_brachistochrone("moreau", n=4, k_max=1)
     prob.initialize()
     prob.solve()
     solver = prob.solver
@@ -260,14 +101,14 @@ def test_iteration_callback_matches_solve_on_brachistochrone():
     state), so the OO path and the functional path solve identical conic
     programs and must agree to PDIP tolerance.
     """
-    prob = _build_brachistochrone(n=4, k_max=1)
+    prob = build_brachistochrone("moreau", n=4, k_max=1)
     prob.initialize()
     prob.solve()
     solver = prob.solver
 
     reference = solver.solve()
 
-    data = _subproblem_data_from_solver(solver)
+    data = subproblem_data_from_numpy_stash(solver)
     callback = solver.iteration_callback()
     solution = callback(None, data)
 
@@ -293,12 +134,12 @@ def test_iteration_callback_traces_under_jit():
     """The callback is constructed under ``jax.jit`` already; this confirms
     it's callable end-to-end and that repeated calls share the compiled
     trace (no per-call retrace surprises)."""
-    prob = _build_brachistochrone(n=4, k_max=1)
+    prob = build_brachistochrone("moreau", n=4, k_max=1)
     prob.initialize()
     prob.solve()
     solver = prob.solver
 
-    data = _subproblem_data_from_solver(solver)
+    data = subproblem_data_from_numpy_stash(solver)
     callback = solver.iteration_callback()
 
     sol1 = callback(None, data)

--- a/tests/solvers/test_iteration_callback_moreau.py
+++ b/tests/solvers/test_iteration_callback_moreau.py
@@ -1,0 +1,311 @@
+"""Tests for ``MoreauPTRSolver.iteration_callback``.
+
+Two layers of verification:
+
+* **Assembly parity** — the JAX assembly inside ``iteration_callback`` must
+  produce the same ``(P_data, coo_vals, q, b)`` quadruple the NumPy
+  ``_assemble_conic`` produces on a fixed iterate.
+* **Solution parity** — ``iteration_callback()(state, data)`` must produce
+  the same primal trajectory as ``solver.solve()`` on the same iterate.
+  Moreau's functional API is cold-start (no warm-start support per docs),
+  while ``solver.solve()`` uses the OO Solver with warm-start — but on a
+  **single-iterate** call the warm_start is None either way, so the two
+  paths solve identical conic programs and should agree to PDIP tolerance.
+
+These tests gate on ``_MOREAU_OK`` because Moreau is an optional dependency
+with a license requirement; the gate keeps the suite green on machines
+without a license while still exercising on CI / dev hosts that have one.
+"""
+
+import numpy as np
+import pytest
+
+from tests._marks import requires_moreau, _MOREAU_OK
+
+pytestmark = requires_moreau
+
+# Imports below are only reached when _MOREAU_OK is True.
+if _MOREAU_OK:
+    import jax
+    import jax.numpy as jnp
+
+    from openscvx import Problem
+    from openscvx.solvers.ptr_solver import (
+        StatusCode,
+        SubproblemData,
+        SubproblemSolution,
+    )
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+def _build_brachistochrone(n: int = 4, k_max: int = 1, constraint_style: str = "ctcs"):
+    """Build the brachistochrone problem with the Moreau backend.
+
+    Mirrors the QPAX iteration-callback test fixture so the two backends are
+    exercised on the same problem shape — the only delta is ``backend="moreau"``
+    and the constraint-row encoding choice (Moreau uses SOC epigraphs for
+    ``|nu|`` where QPAX uses paired nonneg slacks).
+    """
+    import openscvx as ox
+
+    g = 9.81
+
+    position = ox.State("position", shape=(2,))
+    position.max = np.array([10.0, 10.0])
+    position.min = np.array([0.0, 0.0])
+    position.initial = np.array([0.0, 10.0])
+    position.final = [10.0, 5.0]
+
+    velocity = ox.State("velocity", shape=(1,))
+    velocity.max = np.array([10.0])
+    velocity.min = np.array([0.0])
+    velocity.initial = np.array([0.0])
+    velocity.final = [("free", 10.0)]
+
+    theta = ox.Control("theta", shape=(1,))
+    theta.max = np.array([100.5 * jnp.pi / 180])
+    theta.min = np.array([0.0])
+    theta.guess = np.linspace(5 * jnp.pi / 180, 100.5 * jnp.pi / 180, n).reshape(-1, 1)
+
+    states = [position, velocity]
+    controls = [theta]
+
+    dynamics = {
+        "position": ox.Concat(
+            velocity[0] * ox.Sin(theta[0]),
+            -velocity[0] * ox.Cos(theta[0]),
+        ),
+        "velocity": g * ox.Cos(theta[0]),
+    }
+
+    constraint_exprs = []
+    if constraint_style == "ctcs":
+        for state in states:
+            constraint_exprs.extend(
+                [ox.ctcs(state <= state.max), ox.ctcs(state.min <= state)]
+            )
+    elif constraint_style == "nodal":
+        for state in states:
+            constraint_exprs.extend([state <= state.max, state.min <= state])
+    else:
+        raise ValueError(f"unknown constraint_style {constraint_style!r}")
+
+    time = ox.Time(
+        initial=0.0,
+        final=("minimize", 2.0),
+        min=0.0,
+        max=2.0,
+        uniform_time_grid=True,
+    )
+
+    prob = Problem(
+        dynamics=dynamics,
+        states=states,
+        controls=controls,
+        time=time,
+        constraints=constraint_exprs,
+        N=n,
+        float_dtype="float64",
+        algorithm={
+            "autotuner": "ConstantProximalWeight",
+            "lam_prox": 1e0,
+            "lam_cost": 6e-1,
+            "k_max": k_max,
+        },
+        solver={"backend": "moreau"},
+    )
+    prob.settings.dev.printing = False
+    return prob
+
+
+def _subproblem_data_from_solver(solver) -> "SubproblemData":
+    """Reconstruct the JAX-pure :class:`SubproblemData` from the NumPy stash.
+
+    Mirrors the QPAX-side helper: after one ``update_*`` cycle the solver
+    has every per-iteration array on hand, and the stacked-array layout
+    required by the callback is built here so both assembly paths see the
+    identical iterate.
+    """
+    L = solver.layout
+    N, n_x, n_u = L.N, L.n_x, L.n_u
+    sim = solver._settings.sim
+    has_impulsive = sim.u.slice_impulsive.stop > sim.u.slice_impulsive.start
+
+    dyn = solver._dyn
+    cons = solver._cons
+    pen = solver._pen
+    n_nodal = L.n_nodal
+
+    nodal_g = np.zeros((N, max(n_nodal, 1)), dtype=float)
+    nodal_grad_x = np.zeros((N, max(n_nodal, 1), n_x), dtype=float)
+    nodal_grad_u = np.zeros((N, max(n_nodal, 1), n_u), dtype=float)
+    for c_idx, (constraint, entry) in enumerate(
+        zip(solver._jax_constraints.nodal, cons.get("nodal", []))
+    ):
+        for node in constraint.nodes:
+            nodal_g[node, c_idx] = entry["g"][node]
+            nodal_grad_x[node, c_idx] = entry["grad_g_x"][node]
+            nodal_grad_u[node, c_idx] = entry["grad_g_u"][node]
+    if n_nodal == 0:
+        nodal_g = np.zeros((N, 0))
+        nodal_grad_x = np.zeros((N, 0, n_x))
+        nodal_grad_u = np.zeros((N, 0, n_u))
+
+    x_prop_plus = (
+        dyn["x_prop_plus"] if dyn["x_prop_plus"] is not None else np.zeros((N, n_x))
+    )
+    E_d = dyn["E_d"] if dyn["E_d"] is not None else np.zeros((N, n_x, n_u))
+    # NumPy path already absorbed D_d into A_d/B_d/C_d; pass zero D_d so the
+    # JAX path's einsum (gated on has_impulsive) is skipped via the matching
+    # static-Python branch — has_impulsive is False for this problem.
+    D_d = np.zeros((N, n_x, n_x))
+
+    x_init = solver._x_init if solver._x_init is not None else np.full(n_x, np.nan)
+    x_term = solver._x_term if solver._x_term is not None else np.full(n_x, np.nan)
+
+    return SubproblemData(
+        x_bar=jnp.asarray(dyn["x_bar"]),
+        u_bar=jnp.asarray(dyn["u_bar"]),
+        A_d=jnp.asarray(dyn["A_d"]),
+        B_d=jnp.asarray(dyn["B_d"]),
+        C_d=jnp.asarray(dyn["C_d"]),
+        x_prop=jnp.asarray(dyn["x_prop"]),
+        x_prop_plus=jnp.asarray(x_prop_plus),
+        D_d=jnp.asarray(D_d),
+        E_d=jnp.asarray(E_d),
+        nodal_g=jnp.asarray(nodal_g),
+        nodal_grad_x=jnp.asarray(nodal_grad_x),
+        nodal_grad_u=jnp.asarray(nodal_grad_u),
+        cross_g=jnp.zeros((0,)),
+        cross_grad_X=jnp.zeros((0, N, n_x)),
+        cross_grad_U=jnp.zeros((0, N, n_u)),
+        lam_prox=jnp.asarray(pen["lam_prox"]),
+        lam_cost=jnp.asarray(pen["lam_cost"]),
+        lam_vc=jnp.asarray(pen["lam_vc"]),
+        lam_vb_nodal=jnp.asarray(pen["lam_vb_nodal"]),
+        lam_vb_cross=jnp.zeros((0,)),
+        x_init=jnp.asarray(x_init),
+        x_term=jnp.asarray(x_term),
+    )
+
+
+# ============================================================================
+# Assembly parity (Phase 3)
+# ============================================================================
+
+
+@pytest.mark.parametrize("constraint_style", ["ctcs", "nodal"])
+def test_assemble_conic_jax_matches_numpy_on_brachistochrone(constraint_style):
+    """The JAX assembly must produce the same (P_data, coo_vals, q, b) the
+    NumPy ``_assemble_conic`` produces on a fixed iterate.
+
+    ``coo_vals`` is emitted in COO traversal order on both sides; the
+    NumPy path applies scipy's CSR sort downstream, the JAX path applies the
+    precomputed ``csr_to_coo_perm`` — both compose to the same A_data passed
+    to Moreau's solver.
+    """
+    prob = _build_brachistochrone(n=4, k_max=1, constraint_style=constraint_style)
+    prob.initialize()
+    prob.solve()
+    solver = prob.solver
+
+    P_np, coo_np, q_np, b_np = solver._assemble_conic()
+
+    data = _subproblem_data_from_solver(solver)
+    P_j, coo_j, q_j, b_j = solver._assemble_conic_jax(data)
+
+    np.testing.assert_allclose(np.asarray(P_j), P_np, atol=1e-10, rtol=1e-10)
+    np.testing.assert_allclose(np.asarray(coo_j), coo_np, atol=1e-10, rtol=1e-10)
+    np.testing.assert_allclose(np.asarray(q_j), q_np, atol=1e-10, rtol=1e-10)
+    np.testing.assert_allclose(np.asarray(b_j), b_np, atol=1e-10, rtol=1e-10)
+
+
+def test_csr_to_coo_perm_reconstructs_numpy_A_data():
+    """``coo_vals[csr_to_coo_perm]`` must equal the ``A_data`` that
+    ``solver.solve()`` passes to Moreau. Without this, the iteration_callback
+    path would silently send a permuted system to Moreau."""
+    import scipy.sparse as sp
+
+    prob = _build_brachistochrone(n=4, k_max=1)
+    prob.initialize()
+    prob.solve()
+    solver = prob.solver
+
+    _, coo_np, _, _ = solver._assemble_conic()
+    # Match scipy's CSR sort the way solver.solve() does it.
+    A_csr = sp.csr_matrix(
+        (coo_np, (solver._coo_rows, solver._coo_cols)),
+        shape=(solver._n_con, solver.layout.n_z),
+    )
+    A_csr.sort_indices()
+
+    A_data_via_perm = coo_np[solver._csr_to_coo_perm]
+    np.testing.assert_allclose(A_data_via_perm, A_csr.data, atol=0.0)
+
+
+# ============================================================================
+# Solution parity (Phase 6)
+# ============================================================================
+
+
+def test_iteration_callback_matches_solve_on_brachistochrone():
+    """``iteration_callback()(state, data)`` must produce the same primal
+    trajectory as ``solver.solve()`` on the same iterate.
+
+    On a single-iterate call the OO Solver's warm-start is ``None`` (initial
+    state), so the OO path and the functional path solve identical conic
+    programs and must agree to PDIP tolerance.
+    """
+    prob = _build_brachistochrone(n=4, k_max=1)
+    prob.initialize()
+    prob.solve()
+    solver = prob.solver
+
+    reference = solver.solve()
+
+    data = _subproblem_data_from_solver(solver)
+    callback = solver.iteration_callback()
+    solution = callback(None, data)
+
+    assert isinstance(solution, SubproblemSolution)
+    np.testing.assert_allclose(
+        np.asarray(solution.x), reference.x, atol=1e-7, rtol=1e-7
+    )
+    np.testing.assert_allclose(
+        np.asarray(solution.u), reference.u, atol=1e-7, rtol=1e-7
+    )
+    np.testing.assert_allclose(
+        np.asarray(solution.nu), reference.nu, atol=1e-7, rtol=1e-7
+    )
+    assert solution.nu_vb.shape == (solver.layout.N, solver.layout.n_nodal)
+    np.testing.assert_allclose(
+        float(solution.cost), reference.cost, atol=1e-7, rtol=1e-7
+    )
+    # Optimal solves should map to StatusCode.OPTIMAL.
+    assert int(solution.status_code) == int(StatusCode.OPTIMAL)
+    # moreau_carry is a zero-length triple — placeholder, not consumed.
+    for leaf in solution.moreau_carry:
+        assert leaf.shape == (0,)
+
+
+def test_iteration_callback_traces_under_jit():
+    """The callback is constructed under ``jax.jit`` already; this confirms
+    it's callable end-to-end and that repeated calls share the compiled
+    trace (no per-call retrace surprises)."""
+    prob = _build_brachistochrone(n=4, k_max=1)
+    prob.initialize()
+    prob.solve()
+    solver = prob.solver
+
+    data = _subproblem_data_from_solver(solver)
+    callback = solver.iteration_callback()
+
+    sol1 = callback(None, data)
+    sol2 = callback(None, data)
+
+    np.testing.assert_allclose(np.asarray(sol1.x), np.asarray(sol2.x), atol=0.0)
+    np.testing.assert_allclose(np.asarray(sol1.u), np.asarray(sol2.u), atol=0.0)

--- a/tests/solvers/test_iteration_callback_moreau.py
+++ b/tests/solvers/test_iteration_callback_moreau.py
@@ -287,9 +287,6 @@ def test_iteration_callback_matches_solve_on_brachistochrone():
     )
     # Optimal solves should map to StatusCode.OPTIMAL.
     assert int(solution.status_code) == int(StatusCode.OPTIMAL)
-    # moreau_carry is a zero-length triple — placeholder, not consumed.
-    for leaf in solution.moreau_carry:
-        assert leaf.shape == (0,)
 
 
 def test_iteration_callback_traces_under_jit():

--- a/tests/solvers/test_iteration_callback_qpax.py
+++ b/tests/solvers/test_iteration_callback_qpax.py
@@ -22,12 +22,10 @@ import pytest
 pytest.importorskip("qpax")
 
 from openscvx.solvers.ptr_solver import StatusCode, SubproblemSolution
-
 from tests.solvers._iteration_callback_helpers import (
     build_brachistochrone,
     subproblem_data_from_numpy_stash,
 )
-
 
 # ============================================================================
 # Assembly parity (Phase 2)
@@ -94,15 +92,9 @@ def test_iteration_callback_matches_solve_on_brachistochrone():
     solution = callback(state, data)
 
     assert isinstance(solution, SubproblemSolution)
-    np.testing.assert_allclose(
-        np.asarray(solution.x), reference.x, atol=1e-8, rtol=1e-8
-    )
-    np.testing.assert_allclose(
-        np.asarray(solution.u), reference.u, atol=1e-8, rtol=1e-8
-    )
-    np.testing.assert_allclose(
-        np.asarray(solution.nu), reference.nu, atol=1e-8, rtol=1e-8
-    )
+    np.testing.assert_allclose(np.asarray(solution.x), reference.x, atol=1e-8, rtol=1e-8)
+    np.testing.assert_allclose(np.asarray(solution.u), reference.u, atol=1e-8, rtol=1e-8)
+    np.testing.assert_allclose(np.asarray(solution.nu), reference.nu, atol=1e-8, rtol=1e-8)
     # nu_vb is stacked (N, n_nodal) in the JAX path, list-of-arrays on NumPy.
     assert solution.nu_vb.shape == (solver.layout.N, solver.layout.n_nodal)
     # Cost reconstruction is independent of the QP solve — should match the

--- a/tests/solvers/test_iteration_callback_qpax.py
+++ b/tests/solvers/test_iteration_callback_qpax.py
@@ -21,180 +21,12 @@ import pytest
 
 pytest.importorskip("qpax")
 
-import jax
-import jax.numpy as jnp
+from openscvx.solvers.ptr_solver import StatusCode, SubproblemSolution
 
-from openscvx import Problem
-from openscvx.solvers.ptr_solver import (
-    StatusCode,
-    SubproblemData,
-    SubproblemSolution,
+from tests.solvers._iteration_callback_helpers import (
+    build_brachistochrone,
+    subproblem_data_from_numpy_stash,
 )
-
-
-# ============================================================================
-# Fixtures
-# ============================================================================
-
-
-def _build_brachistochrone(n=4, k_max=1, constraint_style: str = "ctcs"):
-    """Build the brachistochrone problem at a small ``N`` for assembly tests.
-
-    Mirrors ``examples/abstract/brachistochrone.py`` but rebuilds the symbolic
-    state in-test so the cached problem from the example doesn't carry over.
-    ``constraint_style`` toggles between CTCS box rows (the default) and
-    plain nodal inequalities; the latter exercises the nodal-constraint
-    assembly block which is otherwise dormant under CTCS-only setups.
-    """
-    import openscvx as ox
-
-    g = 9.81
-
-    position = ox.State("position", shape=(2,))
-    position.max = np.array([10.0, 10.0])
-    position.min = np.array([0.0, 0.0])
-    position.initial = np.array([0.0, 10.0])
-    position.final = [10.0, 5.0]
-
-    velocity = ox.State("velocity", shape=(1,))
-    velocity.max = np.array([10.0])
-    velocity.min = np.array([0.0])
-    velocity.initial = np.array([0.0])
-    velocity.final = [("free", 10.0)]
-
-    theta = ox.Control("theta", shape=(1,))
-    theta.max = np.array([100.5 * jnp.pi / 180])
-    theta.min = np.array([0.0])
-    theta.guess = np.linspace(5 * jnp.pi / 180, 100.5 * jnp.pi / 180, n).reshape(-1, 1)
-
-    states = [position, velocity]
-    controls = [theta]
-
-    dynamics = {
-        "position": ox.Concat(
-            velocity[0] * ox.Sin(theta[0]),
-            -velocity[0] * ox.Cos(theta[0]),
-        ),
-        "velocity": g * ox.Cos(theta[0]),
-    }
-
-    constraint_exprs = []
-    if constraint_style == "ctcs":
-        for state in states:
-            constraint_exprs.extend(
-                [ox.ctcs(state <= state.max), ox.ctcs(state.min <= state)]
-            )
-    elif constraint_style == "nodal":
-        for state in states:
-            constraint_exprs.extend([state <= state.max, state.min <= state])
-    else:
-        raise ValueError(f"unknown constraint_style {constraint_style!r}")
-
-    time = ox.Time(
-        initial=0.0,
-        final=("minimize", 2.0),
-        min=0.0,
-        max=2.0,
-        uniform_time_grid=True,
-    )
-
-    prob = Problem(
-        dynamics=dynamics,
-        states=states,
-        controls=controls,
-        time=time,
-        constraints=constraint_exprs,
-        N=n,
-        float_dtype="float64",
-        algorithm={
-            "autotuner": "ConstantProximalWeight",
-            "lam_prox": 1e0,
-            "lam_cost": 6e-1,
-            "k_max": k_max,
-        },
-        solver={"backend": "qpax"},
-    )
-    prob.settings.dev.printing = False
-    return prob
-
-
-def _subproblem_data_from_solver(solver) -> SubproblemData:
-    """Reconstruct the JAX-pure ``SubproblemData`` from the NumPy stash.
-
-    After one ``update_dynamics_linearization`` / ``update_constraint_linearizations``
-    / ``update_penalties`` / ``update_boundary_conditions`` cycle, the solver
-    has every per-iteration array on hand. The stacked-array layout the
-    callback expects is built here so the two assembly paths see the same
-    iterate.
-
-    The NumPy path absorbs ``D_d`` into ``A_d`` / ``B_d`` / ``C_d`` at update
-    time; the JAX path's ``_assemble_qp_jax`` does the same absorption inline
-    when ``has_impulsive`` is true. For non-impulsive problems both paths see
-    the same raw ``A_d`` / ``B_d`` / ``C_d`` and ``D_d`` is the all-zeros
-    placeholder.
-    """
-    L = solver.layout
-    N, n_x, n_u = L.N, L.n_x, L.n_u
-    sim = solver._settings.sim
-    has_impulsive = sim.u.slice_impulsive.stop > sim.u.slice_impulsive.start
-
-    dyn = solver._dyn
-    cons = solver._cons
-    pen = solver._pen
-    n_nodal = L.n_nodal
-
-    # Stack nodal linearizations into (N, n_nodal*) layout with zero-fill
-    # for nodes outside each constraint's static ``nodes`` tuple.
-    nodal_g = np.zeros((N, max(n_nodal, 1)), dtype=float)
-    nodal_grad_x = np.zeros((N, max(n_nodal, 1), n_x), dtype=float)
-    nodal_grad_u = np.zeros((N, max(n_nodal, 1), n_u), dtype=float)
-    for c_idx, (constraint, entry) in enumerate(
-        zip(solver._jax_constraints.nodal, cons.get("nodal", []))
-    ):
-        for node in constraint.nodes:
-            nodal_g[node, c_idx] = entry["g"][node]
-            nodal_grad_x[node, c_idx] = entry["grad_g_x"][node]
-            nodal_grad_u[node, c_idx] = entry["grad_g_u"][node]
-    if n_nodal == 0:
-        nodal_g = np.zeros((N, 0))
-        nodal_grad_x = np.zeros((N, 0, n_x))
-        nodal_grad_u = np.zeros((N, 0, n_u))
-
-    x_prop_plus = (
-        dyn["x_prop_plus"] if dyn["x_prop_plus"] is not None else np.zeros((N, n_x))
-    )
-    E_d = dyn["E_d"] if dyn["E_d"] is not None else np.zeros((N, n_x, n_u))
-    # The NumPy path absorbed D_d already, so we pass zero D_d to the JAX
-    # path and let it skip the einsum (has_impulsive=False for this problem).
-    D_d = np.zeros((N, n_x, n_x))
-
-    x_init = solver._x_init if solver._x_init is not None else np.full(n_x, np.nan)
-    x_term = solver._x_term if solver._x_term is not None else np.full(n_x, np.nan)
-
-    return SubproblemData(
-        x_bar=jnp.asarray(dyn["x_bar"]),
-        u_bar=jnp.asarray(dyn["u_bar"]),
-        A_d=jnp.asarray(dyn["A_d"]),
-        B_d=jnp.asarray(dyn["B_d"]),
-        C_d=jnp.asarray(dyn["C_d"]),
-        x_prop=jnp.asarray(dyn["x_prop"]),
-        x_prop_plus=jnp.asarray(x_prop_plus),
-        D_d=jnp.asarray(D_d),
-        E_d=jnp.asarray(E_d),
-        nodal_g=jnp.asarray(nodal_g),
-        nodal_grad_x=jnp.asarray(nodal_grad_x),
-        nodal_grad_u=jnp.asarray(nodal_grad_u),
-        cross_g=jnp.zeros((0,)),
-        cross_grad_X=jnp.zeros((0, N, n_x)),
-        cross_grad_U=jnp.zeros((0, N, n_u)),
-        lam_prox=jnp.asarray(pen["lam_prox"]),
-        lam_cost=jnp.asarray(pen["lam_cost"]),
-        lam_vc=jnp.asarray(pen["lam_vc"]),
-        lam_vb_nodal=jnp.asarray(pen["lam_vb_nodal"]),
-        lam_vb_cross=jnp.zeros((0,)),
-        x_init=jnp.asarray(x_init),
-        x_term=jnp.asarray(x_term),
-    )
 
 
 # ============================================================================
@@ -213,7 +45,7 @@ def test_assemble_qp_jax_matches_numpy_on_brachistochrone(constraint_style):
     (exercises the per-constraint nodal block) so both code paths get
     parity-checked.
     """
-    prob = _build_brachistochrone(n=4, k_max=1, constraint_style=constraint_style)
+    prob = build_brachistochrone("qpax", n=4, k_max=1, constraint_style=constraint_style)
     prob.initialize()
     # One SCP iteration populates _dyn / _cons / _pen / _x_init / _x_term on
     # the solver — both assembly paths read from the same iterate after this.
@@ -222,7 +54,7 @@ def test_assemble_qp_jax_matches_numpy_on_brachistochrone(constraint_style):
     solver = prob.solver
     Q_np, q_np, A_np, b_np, G_np, h_np = solver._assemble_qp()
 
-    data = _subproblem_data_from_solver(solver)
+    data = subproblem_data_from_numpy_stash(solver)
     Q_j, q_j, A_j, b_j, G_j, h_j = solver._assemble_qp_jax(data)
 
     np.testing.assert_allclose(np.asarray(Q_j), Q_np, atol=1e-10, rtol=1e-10)
@@ -244,7 +76,7 @@ def test_iteration_callback_matches_solve_on_brachistochrone():
     and ``solve_qp`` differ only in what they return (primal-only vs
     full primal-dual), so on a convergent QP they must produce the same
     primal up to PDIP tolerance."""
-    prob = _build_brachistochrone(n=4, k_max=1)
+    prob = build_brachistochrone("qpax", n=4, k_max=1)
     prob.initialize()
     prob.solve()
     solver = prob.solver
@@ -253,7 +85,7 @@ def test_iteration_callback_matches_solve_on_brachistochrone():
     reference = solver.solve()
 
     # JAX callback path.
-    data = _subproblem_data_from_solver(solver)
+    data = subproblem_data_from_numpy_stash(solver)
     callback = solver.iteration_callback()
     # state is unused by QPAX's callback, but it has to be a valid JAX pytree
     # so ``jit``'s argument-tracing doesn't trip. ``None`` is the canonical
@@ -284,12 +116,12 @@ def test_iteration_callback_traces_under_jit():
     """The callback is constructed under ``jax.jit`` already; this test
     just confirms it's callable end-to-end and that the compilation cost
     amortizes across repeated calls (no per-call re-tracing surprises)."""
-    prob = _build_brachistochrone(n=4, k_max=1)
+    prob = build_brachistochrone("qpax", n=4, k_max=1)
     prob.initialize()
     prob.solve()
     solver = prob.solver
 
-    data = _subproblem_data_from_solver(solver)
+    data = subproblem_data_from_numpy_stash(solver)
     callback = solver.iteration_callback()
     state = None
 

--- a/tests/solvers/test_iteration_callback_qpax.py
+++ b/tests/solvers/test_iteration_callback_qpax.py
@@ -1,0 +1,301 @@
+"""Tests for ``QPAXPTRSolver.iteration_callback``.
+
+Two layers of verification:
+
+* **Assembly parity** — the JAX assembly inside ``iteration_callback`` must
+  produce the same ``(Q, q, A, b, G, h)`` matrices the NumPy ``_assemble_qp``
+  produces on a fixed iterate. Without this, no downstream test result is
+  trustworthy.
+* **Solution parity** — running ``iteration_callback()(state, data)`` on the
+  same iterate must yield the same primal trajectory as
+  ``solver.solve()``. ``solve_qp_primal`` and ``solve_qp`` may take slightly
+  different paths through PDIP, so we hold this to a loose-but-tight tolerance.
+
+Built on the brachistochrone problem (small N, nonlinear dynamics, CTCS
+constraints, no impulsive controls) — exercises the full QPAX assembly path
+except impulsive coupling.
+"""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("qpax")
+
+import jax
+import jax.numpy as jnp
+
+from openscvx import Problem
+from openscvx.solvers.ptr_solver import (
+    StatusCode,
+    SubproblemData,
+    SubproblemSolution,
+)
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+def _build_brachistochrone(n=4, k_max=1, constraint_style: str = "ctcs"):
+    """Build the brachistochrone problem at a small ``N`` for assembly tests.
+
+    Mirrors ``examples/abstract/brachistochrone.py`` but rebuilds the symbolic
+    state in-test so the cached problem from the example doesn't carry over.
+    ``constraint_style`` toggles between CTCS box rows (the default) and
+    plain nodal inequalities; the latter exercises the nodal-constraint
+    assembly block which is otherwise dormant under CTCS-only setups.
+    """
+    import openscvx as ox
+
+    g = 9.81
+
+    position = ox.State("position", shape=(2,))
+    position.max = np.array([10.0, 10.0])
+    position.min = np.array([0.0, 0.0])
+    position.initial = np.array([0.0, 10.0])
+    position.final = [10.0, 5.0]
+
+    velocity = ox.State("velocity", shape=(1,))
+    velocity.max = np.array([10.0])
+    velocity.min = np.array([0.0])
+    velocity.initial = np.array([0.0])
+    velocity.final = [("free", 10.0)]
+
+    theta = ox.Control("theta", shape=(1,))
+    theta.max = np.array([100.5 * jnp.pi / 180])
+    theta.min = np.array([0.0])
+    theta.guess = np.linspace(5 * jnp.pi / 180, 100.5 * jnp.pi / 180, n).reshape(-1, 1)
+
+    states = [position, velocity]
+    controls = [theta]
+
+    dynamics = {
+        "position": ox.Concat(
+            velocity[0] * ox.Sin(theta[0]),
+            -velocity[0] * ox.Cos(theta[0]),
+        ),
+        "velocity": g * ox.Cos(theta[0]),
+    }
+
+    constraint_exprs = []
+    if constraint_style == "ctcs":
+        for state in states:
+            constraint_exprs.extend(
+                [ox.ctcs(state <= state.max), ox.ctcs(state.min <= state)]
+            )
+    elif constraint_style == "nodal":
+        for state in states:
+            constraint_exprs.extend([state <= state.max, state.min <= state])
+    else:
+        raise ValueError(f"unknown constraint_style {constraint_style!r}")
+
+    time = ox.Time(
+        initial=0.0,
+        final=("minimize", 2.0),
+        min=0.0,
+        max=2.0,
+        uniform_time_grid=True,
+    )
+
+    prob = Problem(
+        dynamics=dynamics,
+        states=states,
+        controls=controls,
+        time=time,
+        constraints=constraint_exprs,
+        N=n,
+        float_dtype="float64",
+        algorithm={
+            "autotuner": "ConstantProximalWeight",
+            "lam_prox": 1e0,
+            "lam_cost": 6e-1,
+            "k_max": k_max,
+        },
+        solver={"backend": "qpax"},
+    )
+    prob.settings.dev.printing = False
+    return prob
+
+
+def _subproblem_data_from_solver(solver) -> SubproblemData:
+    """Reconstruct the JAX-pure ``SubproblemData`` from the NumPy stash.
+
+    After one ``update_dynamics_linearization`` / ``update_constraint_linearizations``
+    / ``update_penalties`` / ``update_boundary_conditions`` cycle, the solver
+    has every per-iteration array on hand. The stacked-array layout the
+    callback expects is built here so the two assembly paths see the same
+    iterate.
+
+    The NumPy path absorbs ``D_d`` into ``A_d`` / ``B_d`` / ``C_d`` at update
+    time; the JAX path's ``_assemble_qp_jax`` does the same absorption inline
+    when ``has_impulsive`` is true. For non-impulsive problems both paths see
+    the same raw ``A_d`` / ``B_d`` / ``C_d`` and ``D_d`` is the all-zeros
+    placeholder.
+    """
+    L = solver.layout
+    N, n_x, n_u = L.N, L.n_x, L.n_u
+    sim = solver._settings.sim
+    has_impulsive = sim.u.slice_impulsive.stop > sim.u.slice_impulsive.start
+
+    dyn = solver._dyn
+    cons = solver._cons
+    pen = solver._pen
+    n_nodal = L.n_nodal
+
+    # Stack nodal linearizations into (N, n_nodal*) layout with zero-fill
+    # for nodes outside each constraint's static ``nodes`` tuple.
+    nodal_g = np.zeros((N, max(n_nodal, 1)), dtype=float)
+    nodal_grad_x = np.zeros((N, max(n_nodal, 1), n_x), dtype=float)
+    nodal_grad_u = np.zeros((N, max(n_nodal, 1), n_u), dtype=float)
+    for c_idx, (constraint, entry) in enumerate(
+        zip(solver._jax_constraints.nodal, cons.get("nodal", []))
+    ):
+        for node in constraint.nodes:
+            nodal_g[node, c_idx] = entry["g"][node]
+            nodal_grad_x[node, c_idx] = entry["grad_g_x"][node]
+            nodal_grad_u[node, c_idx] = entry["grad_g_u"][node]
+    if n_nodal == 0:
+        nodal_g = np.zeros((N, 0))
+        nodal_grad_x = np.zeros((N, 0, n_x))
+        nodal_grad_u = np.zeros((N, 0, n_u))
+
+    x_prop_plus = (
+        dyn["x_prop_plus"] if dyn["x_prop_plus"] is not None else np.zeros((N, n_x))
+    )
+    E_d = dyn["E_d"] if dyn["E_d"] is not None else np.zeros((N, n_x, n_u))
+    # The NumPy path absorbed D_d already, so we pass zero D_d to the JAX
+    # path and let it skip the einsum (has_impulsive=False for this problem).
+    D_d = np.zeros((N, n_x, n_x))
+
+    x_init = solver._x_init if solver._x_init is not None else np.full(n_x, np.nan)
+    x_term = solver._x_term if solver._x_term is not None else np.full(n_x, np.nan)
+
+    return SubproblemData(
+        x_bar=jnp.asarray(dyn["x_bar"]),
+        u_bar=jnp.asarray(dyn["u_bar"]),
+        A_d=jnp.asarray(dyn["A_d"]),
+        B_d=jnp.asarray(dyn["B_d"]),
+        C_d=jnp.asarray(dyn["C_d"]),
+        x_prop=jnp.asarray(dyn["x_prop"]),
+        x_prop_plus=jnp.asarray(x_prop_plus),
+        D_d=jnp.asarray(D_d),
+        E_d=jnp.asarray(E_d),
+        nodal_g=jnp.asarray(nodal_g),
+        nodal_grad_x=jnp.asarray(nodal_grad_x),
+        nodal_grad_u=jnp.asarray(nodal_grad_u),
+        cross_g=jnp.zeros((0,)),
+        cross_grad_X=jnp.zeros((0, N, n_x)),
+        cross_grad_U=jnp.zeros((0, N, n_u)),
+        lam_prox=jnp.asarray(pen["lam_prox"]),
+        lam_cost=jnp.asarray(pen["lam_cost"]),
+        lam_vc=jnp.asarray(pen["lam_vc"]),
+        lam_vb_nodal=jnp.asarray(pen["lam_vb_nodal"]),
+        lam_vb_cross=jnp.zeros((0,)),
+        x_init=jnp.asarray(x_init),
+        x_term=jnp.asarray(x_term),
+    )
+
+
+# ============================================================================
+# Assembly parity (Phase 2)
+# ============================================================================
+
+
+@pytest.mark.parametrize("constraint_style", ["ctcs", "nodal"])
+def test_assemble_qp_jax_matches_numpy_on_brachistochrone(constraint_style):
+    """The JAX assembly must produce the same (Q, q, A, b, G, h) matrices
+    the NumPy ``_assemble_qp`` produces on a fixed iterate. Tolerance is
+    tight (atol=1e-10) — any drift would indicate a numerical-formula
+    divergence between the two paths.
+
+    Parametrized across CTCS (only LICQ rows, no nodal assembly) and nodal
+    (exercises the per-constraint nodal block) so both code paths get
+    parity-checked.
+    """
+    prob = _build_brachistochrone(n=4, k_max=1, constraint_style=constraint_style)
+    prob.initialize()
+    # One SCP iteration populates _dyn / _cons / _pen / _x_init / _x_term on
+    # the solver — both assembly paths read from the same iterate after this.
+    prob.solve()
+
+    solver = prob.solver
+    Q_np, q_np, A_np, b_np, G_np, h_np = solver._assemble_qp()
+
+    data = _subproblem_data_from_solver(solver)
+    Q_j, q_j, A_j, b_j, G_j, h_j = solver._assemble_qp_jax(data)
+
+    np.testing.assert_allclose(np.asarray(Q_j), Q_np, atol=1e-10, rtol=1e-10)
+    np.testing.assert_allclose(np.asarray(q_j), q_np, atol=1e-10, rtol=1e-10)
+    np.testing.assert_allclose(np.asarray(A_j), A_np, atol=1e-10, rtol=1e-10)
+    np.testing.assert_allclose(np.asarray(b_j), b_np, atol=1e-10, rtol=1e-10)
+    np.testing.assert_allclose(np.asarray(G_j), G_np, atol=1e-10, rtol=1e-10)
+    np.testing.assert_allclose(np.asarray(h_j), h_np, atol=1e-10, rtol=1e-10)
+
+
+# ============================================================================
+# Solution parity (Phase 6)
+# ============================================================================
+
+
+def test_iteration_callback_matches_solve_on_brachistochrone():
+    """``iteration_callback()(state, data)`` must produce the same primal
+    trajectory as ``solver.solve()`` on the same iterate. ``solve_qp_primal``
+    and ``solve_qp`` differ only in what they return (primal-only vs
+    full primal-dual), so on a convergent QP they must produce the same
+    primal up to PDIP tolerance."""
+    prob = _build_brachistochrone(n=4, k_max=1)
+    prob.initialize()
+    prob.solve()
+    solver = prob.solver
+
+    # NumPy reference: re-call _assemble_qp + qpax.solve_qp on the stash.
+    reference = solver.solve()
+
+    # JAX callback path.
+    data = _subproblem_data_from_solver(solver)
+    callback = solver.iteration_callback()
+    # state is unused by QPAX's callback, but it has to be a valid JAX pytree
+    # so ``jit``'s argument-tracing doesn't trip. ``None`` is the canonical
+    # empty pytree.
+    state = None
+    solution = callback(state, data)
+
+    assert isinstance(solution, SubproblemSolution)
+    np.testing.assert_allclose(
+        np.asarray(solution.x), reference.x, atol=1e-8, rtol=1e-8
+    )
+    np.testing.assert_allclose(
+        np.asarray(solution.u), reference.u, atol=1e-8, rtol=1e-8
+    )
+    np.testing.assert_allclose(
+        np.asarray(solution.nu), reference.nu, atol=1e-8, rtol=1e-8
+    )
+    # nu_vb is stacked (N, n_nodal) in the JAX path, list-of-arrays on NumPy.
+    assert solution.nu_vb.shape == (solver.layout.N, solver.layout.n_nodal)
+    # Cost reconstruction is independent of the QP solve — should match the
+    # NumPy path's _reconstruct_cost output directly.
+    np.testing.assert_allclose(float(solution.cost), reference.cost, atol=1e-8, rtol=1e-8)
+    # solve_qp_primal exposes no convergence diagnostic.
+    assert int(solution.status_code) == int(StatusCode.UNKNOWN)
+
+
+def test_iteration_callback_traces_under_jit():
+    """The callback is constructed under ``jax.jit`` already; this test
+    just confirms it's callable end-to-end and that the compilation cost
+    amortizes across repeated calls (no per-call re-tracing surprises)."""
+    prob = _build_brachistochrone(n=4, k_max=1)
+    prob.initialize()
+    prob.solve()
+    solver = prob.solver
+
+    data = _subproblem_data_from_solver(solver)
+    callback = solver.iteration_callback()
+    state = None
+
+    sol1 = callback(state, data)
+    sol2 = callback(state, data)
+
+    # Both calls should produce structurally identical solutions.
+    np.testing.assert_allclose(np.asarray(sol1.x), np.asarray(sol2.x), atol=0.0)
+    np.testing.assert_allclose(np.asarray(sol1.u), np.asarray(sol2.u), atol=0.0)

--- a/tests/solvers/test_iteration_callback_vmap.py
+++ b/tests/solvers/test_iteration_callback_vmap.py
@@ -16,14 +16,12 @@ the pattern there is structurally different from QPAX / Moreau and stays in
 its own module.
 """
 
+import jax
+import jax.numpy as jnp
 import numpy as np
 import pytest
 
-import jax
-import jax.numpy as jnp
-
 from openscvx.solvers.ptr_solver import SubproblemData, SubproblemSolution
-
 from tests._marks import requires_moreau
 from tests.solvers._iteration_callback_helpers import (
     build_brachistochrone,
@@ -50,9 +48,7 @@ def _make_batch(data: SubproblemData, scales) -> SubproblemData:
     def stack_other(leaf):
         return jnp.broadcast_to(leaf, (B,) + leaf.shape)
 
-    leaves = {
-        f.name: getattr(data, f.name) for f in data.__dataclass_fields__.values()
-    }
+    leaves = {f.name: getattr(data, f.name) for f in data.__dataclass_fields__.values()}
     leaves["lam_prox"] = stack_lam_prox(leaves["lam_prox"])
     for name in list(leaves):
         if name == "lam_prox":
@@ -107,9 +103,7 @@ def test_qpax_iteration_callback_composes_with_vmap():
         np.testing.assert_allclose(
             np.asarray(batched.u[i]), np.asarray(bare.u), atol=1e-8, rtol=1e-8
         )
-        np.testing.assert_allclose(
-            float(batched.cost[i]), float(bare.cost), atol=1e-8, rtol=1e-8
-        )
+        np.testing.assert_allclose(float(batched.cost[i]), float(bare.cost), atol=1e-8, rtol=1e-8)
 
 
 # ============================================================================
@@ -156,6 +150,4 @@ def test_moreau_iteration_callback_composes_with_vmap():
         np.testing.assert_allclose(
             np.asarray(batched.u[i]), np.asarray(bare.u), atol=1e-7, rtol=1e-7
         )
-        np.testing.assert_allclose(
-            float(batched.cost[i]), float(bare.cost), atol=1e-7, rtol=1e-7
-        )
+        np.testing.assert_allclose(float(batched.cost[i]), float(bare.cost), atol=1e-7, rtol=1e-7)

--- a/tests/solvers/test_iteration_callback_vmap.py
+++ b/tests/solvers/test_iteration_callback_vmap.py
@@ -22,150 +22,13 @@ import pytest
 import jax
 import jax.numpy as jnp
 
-from openscvx import Problem
 from openscvx.solvers.ptr_solver import SubproblemData, SubproblemSolution
 
 from tests._marks import requires_moreau
-
-
-# ============================================================================
-# Fixtures (mirror tests/solvers/test_iteration_callback_{qpax,moreau}.py)
-# ============================================================================
-
-
-def _build_brachistochrone(backend: str, n: int = 4, k_max: int = 1):
-    """Build the brachistochrone problem with the named backend.
-
-    Kept in-test rather than imported from the per-backend test modules so
-    each file remains independently runnable.
-    """
-    import openscvx as ox
-
-    g = 9.81
-
-    position = ox.State("position", shape=(2,))
-    position.max = np.array([10.0, 10.0])
-    position.min = np.array([0.0, 0.0])
-    position.initial = np.array([0.0, 10.0])
-    position.final = [10.0, 5.0]
-
-    velocity = ox.State("velocity", shape=(1,))
-    velocity.max = np.array([10.0])
-    velocity.min = np.array([0.0])
-    velocity.initial = np.array([0.0])
-    velocity.final = [("free", 10.0)]
-
-    theta = ox.Control("theta", shape=(1,))
-    theta.max = np.array([100.5 * jnp.pi / 180])
-    theta.min = np.array([0.0])
-    theta.guess = np.linspace(5 * jnp.pi / 180, 100.5 * jnp.pi / 180, n).reshape(-1, 1)
-
-    states = [position, velocity]
-    controls = [theta]
-
-    dynamics = {
-        "position": ox.Concat(
-            velocity[0] * ox.Sin(theta[0]),
-            -velocity[0] * ox.Cos(theta[0]),
-        ),
-        "velocity": g * ox.Cos(theta[0]),
-    }
-
-    constraint_exprs = []
-    for state in states:
-        constraint_exprs.extend(
-            [ox.ctcs(state <= state.max), ox.ctcs(state.min <= state)]
-        )
-
-    time = ox.Time(
-        initial=0.0,
-        final=("minimize", 2.0),
-        min=0.0,
-        max=2.0,
-        uniform_time_grid=True,
-    )
-
-    prob = Problem(
-        dynamics=dynamics,
-        states=states,
-        controls=controls,
-        time=time,
-        constraints=constraint_exprs,
-        N=n,
-        float_dtype="float64",
-        algorithm={
-            "autotuner": "ConstantProximalWeight",
-            "lam_prox": 1e0,
-            "lam_cost": 6e-1,
-            "k_max": k_max,
-        },
-        solver={"backend": backend},
-    )
-    prob.settings.dev.printing = False
-    return prob
-
-
-def _subproblem_data_from_solver(solver) -> SubproblemData:
-    """Reconstruct the JAX-pure ``SubproblemData`` from the NumPy stash.
-
-    Identical to the helper in ``test_iteration_callback_{qpax,moreau}.py``;
-    duplicated here to keep this module independently runnable.
-    """
-    L = solver.layout
-    N, n_x, n_u = L.N, L.n_x, L.n_u
-    dyn = solver._dyn
-    cons = solver._cons
-    pen = solver._pen
-    n_nodal = L.n_nodal
-
-    nodal_g = np.zeros((N, max(n_nodal, 1)), dtype=float)
-    nodal_grad_x = np.zeros((N, max(n_nodal, 1), n_x), dtype=float)
-    nodal_grad_u = np.zeros((N, max(n_nodal, 1), n_u), dtype=float)
-    for c_idx, (constraint, entry) in enumerate(
-        zip(solver._jax_constraints.nodal, cons.get("nodal", []))
-    ):
-        for node in constraint.nodes:
-            nodal_g[node, c_idx] = entry["g"][node]
-            nodal_grad_x[node, c_idx] = entry["grad_g_x"][node]
-            nodal_grad_u[node, c_idx] = entry["grad_g_u"][node]
-    if n_nodal == 0:
-        nodal_g = np.zeros((N, 0))
-        nodal_grad_x = np.zeros((N, 0, n_x))
-        nodal_grad_u = np.zeros((N, 0, n_u))
-
-    x_prop_plus = (
-        dyn["x_prop_plus"] if dyn["x_prop_plus"] is not None else np.zeros((N, n_x))
-    )
-    E_d = dyn["E_d"] if dyn["E_d"] is not None else np.zeros((N, n_x, n_u))
-    D_d = np.zeros((N, n_x, n_x))
-
-    x_init = solver._x_init if solver._x_init is not None else np.full(n_x, np.nan)
-    x_term = solver._x_term if solver._x_term is not None else np.full(n_x, np.nan)
-
-    return SubproblemData(
-        x_bar=jnp.asarray(dyn["x_bar"]),
-        u_bar=jnp.asarray(dyn["u_bar"]),
-        A_d=jnp.asarray(dyn["A_d"]),
-        B_d=jnp.asarray(dyn["B_d"]),
-        C_d=jnp.asarray(dyn["C_d"]),
-        x_prop=jnp.asarray(dyn["x_prop"]),
-        x_prop_plus=jnp.asarray(x_prop_plus),
-        D_d=jnp.asarray(D_d),
-        E_d=jnp.asarray(E_d),
-        nodal_g=jnp.asarray(nodal_g),
-        nodal_grad_x=jnp.asarray(nodal_grad_x),
-        nodal_grad_u=jnp.asarray(nodal_grad_u),
-        cross_g=jnp.zeros((0,)),
-        cross_grad_X=jnp.zeros((0, N, n_x)),
-        cross_grad_U=jnp.zeros((0, N, n_u)),
-        lam_prox=jnp.asarray(pen["lam_prox"]),
-        lam_cost=jnp.asarray(pen["lam_cost"]),
-        lam_vc=jnp.asarray(pen["lam_vc"]),
-        lam_vb_nodal=jnp.asarray(pen["lam_vb_nodal"]),
-        lam_vb_cross=jnp.zeros((0,)),
-        x_init=jnp.asarray(x_init),
-        x_term=jnp.asarray(x_term),
-    )
+from tests.solvers._iteration_callback_helpers import (
+    build_brachistochrone,
+    subproblem_data_from_numpy_stash,
+)
 
 
 def _make_batch(data: SubproblemData, scales) -> SubproblemData:
@@ -215,12 +78,12 @@ def test_qpax_iteration_callback_composes_with_vmap():
     must match a bare call on the corresponding unbatched data within PDIP
     tolerance.
     """
-    prob = _build_brachistochrone("qpax", n=4, k_max=1)
+    prob = build_brachistochrone("qpax", n=4, k_max=1)
     prob.initialize()
     prob.solve()
     solver = prob.solver
 
-    base = _subproblem_data_from_solver(solver)
+    base = subproblem_data_from_numpy_stash(solver)
     scales = jnp.array([0.5, 1.0, 1.5, 2.0])
     batch = _make_batch(base, scales)
 
@@ -264,12 +127,12 @@ def test_moreau_iteration_callback_composes_with_vmap():
     sequentially fanned out. Each batch element solves an independent conic
     program; per-element results must match unbatched calls.
     """
-    prob = _build_brachistochrone("moreau", n=4, k_max=1)
+    prob = build_brachistochrone("moreau", n=4, k_max=1)
     prob.initialize()
     prob.solve()
     solver = prob.solver
 
-    base = _subproblem_data_from_solver(solver)
+    base = subproblem_data_from_numpy_stash(solver)
     scales = jnp.array([0.5, 1.0, 1.5, 2.0])
     batch = _make_batch(base, scales)
 

--- a/tests/solvers/test_iteration_callback_vmap.py
+++ b/tests/solvers/test_iteration_callback_vmap.py
@@ -1,0 +1,298 @@
+"""``jax.vmap`` composition for QPAX and Moreau iteration callbacks.
+
+Each backend's per-iteration callback must compose with ``jax.vmap`` and
+produce per-element-correct outputs over a stack of distinct
+``SubproblemData`` inputs — the precondition for the downstream
+``jax.vmap(problem.solve)`` path in ``plans/batchable-problem.md``.
+
+Per-element correctness is verified by perturbing ``lam_prox`` across batch
+elements (the cheapest knob that meaningfully changes the QP / cone solution
+without altering its sparsity pattern). Each batched output slice must match
+a bare call on the corresponding unbatched ``SubproblemData``.
+
+CVXPy's vmap composition lives in ``test_iteration_callback_cvxpy.py`` with
+``vmap_method="sequential"`` — it can't ingest a batched parameter set, so
+the pattern there is structurally different from QPAX / Moreau and stays in
+its own module.
+"""
+
+import numpy as np
+import pytest
+
+import jax
+import jax.numpy as jnp
+
+from openscvx import Problem
+from openscvx.solvers.ptr_solver import SubproblemData, SubproblemSolution
+
+from tests._marks import requires_moreau
+
+
+# ============================================================================
+# Fixtures (mirror tests/solvers/test_iteration_callback_{qpax,moreau}.py)
+# ============================================================================
+
+
+def _build_brachistochrone(backend: str, n: int = 4, k_max: int = 1):
+    """Build the brachistochrone problem with the named backend.
+
+    Kept in-test rather than imported from the per-backend test modules so
+    each file remains independently runnable.
+    """
+    import openscvx as ox
+
+    g = 9.81
+
+    position = ox.State("position", shape=(2,))
+    position.max = np.array([10.0, 10.0])
+    position.min = np.array([0.0, 0.0])
+    position.initial = np.array([0.0, 10.0])
+    position.final = [10.0, 5.0]
+
+    velocity = ox.State("velocity", shape=(1,))
+    velocity.max = np.array([10.0])
+    velocity.min = np.array([0.0])
+    velocity.initial = np.array([0.0])
+    velocity.final = [("free", 10.0)]
+
+    theta = ox.Control("theta", shape=(1,))
+    theta.max = np.array([100.5 * jnp.pi / 180])
+    theta.min = np.array([0.0])
+    theta.guess = np.linspace(5 * jnp.pi / 180, 100.5 * jnp.pi / 180, n).reshape(-1, 1)
+
+    states = [position, velocity]
+    controls = [theta]
+
+    dynamics = {
+        "position": ox.Concat(
+            velocity[0] * ox.Sin(theta[0]),
+            -velocity[0] * ox.Cos(theta[0]),
+        ),
+        "velocity": g * ox.Cos(theta[0]),
+    }
+
+    constraint_exprs = []
+    for state in states:
+        constraint_exprs.extend(
+            [ox.ctcs(state <= state.max), ox.ctcs(state.min <= state)]
+        )
+
+    time = ox.Time(
+        initial=0.0,
+        final=("minimize", 2.0),
+        min=0.0,
+        max=2.0,
+        uniform_time_grid=True,
+    )
+
+    prob = Problem(
+        dynamics=dynamics,
+        states=states,
+        controls=controls,
+        time=time,
+        constraints=constraint_exprs,
+        N=n,
+        float_dtype="float64",
+        algorithm={
+            "autotuner": "ConstantProximalWeight",
+            "lam_prox": 1e0,
+            "lam_cost": 6e-1,
+            "k_max": k_max,
+        },
+        solver={"backend": backend},
+    )
+    prob.settings.dev.printing = False
+    return prob
+
+
+def _subproblem_data_from_solver(solver) -> SubproblemData:
+    """Reconstruct the JAX-pure ``SubproblemData`` from the NumPy stash.
+
+    Identical to the helper in ``test_iteration_callback_{qpax,moreau}.py``;
+    duplicated here to keep this module independently runnable.
+    """
+    L = solver.layout
+    N, n_x, n_u = L.N, L.n_x, L.n_u
+    dyn = solver._dyn
+    cons = solver._cons
+    pen = solver._pen
+    n_nodal = L.n_nodal
+
+    nodal_g = np.zeros((N, max(n_nodal, 1)), dtype=float)
+    nodal_grad_x = np.zeros((N, max(n_nodal, 1), n_x), dtype=float)
+    nodal_grad_u = np.zeros((N, max(n_nodal, 1), n_u), dtype=float)
+    for c_idx, (constraint, entry) in enumerate(
+        zip(solver._jax_constraints.nodal, cons.get("nodal", []))
+    ):
+        for node in constraint.nodes:
+            nodal_g[node, c_idx] = entry["g"][node]
+            nodal_grad_x[node, c_idx] = entry["grad_g_x"][node]
+            nodal_grad_u[node, c_idx] = entry["grad_g_u"][node]
+    if n_nodal == 0:
+        nodal_g = np.zeros((N, 0))
+        nodal_grad_x = np.zeros((N, 0, n_x))
+        nodal_grad_u = np.zeros((N, 0, n_u))
+
+    x_prop_plus = (
+        dyn["x_prop_plus"] if dyn["x_prop_plus"] is not None else np.zeros((N, n_x))
+    )
+    E_d = dyn["E_d"] if dyn["E_d"] is not None else np.zeros((N, n_x, n_u))
+    D_d = np.zeros((N, n_x, n_x))
+
+    x_init = solver._x_init if solver._x_init is not None else np.full(n_x, np.nan)
+    x_term = solver._x_term if solver._x_term is not None else np.full(n_x, np.nan)
+
+    return SubproblemData(
+        x_bar=jnp.asarray(dyn["x_bar"]),
+        u_bar=jnp.asarray(dyn["u_bar"]),
+        A_d=jnp.asarray(dyn["A_d"]),
+        B_d=jnp.asarray(dyn["B_d"]),
+        C_d=jnp.asarray(dyn["C_d"]),
+        x_prop=jnp.asarray(dyn["x_prop"]),
+        x_prop_plus=jnp.asarray(x_prop_plus),
+        D_d=jnp.asarray(D_d),
+        E_d=jnp.asarray(E_d),
+        nodal_g=jnp.asarray(nodal_g),
+        nodal_grad_x=jnp.asarray(nodal_grad_x),
+        nodal_grad_u=jnp.asarray(nodal_grad_u),
+        cross_g=jnp.zeros((0,)),
+        cross_grad_X=jnp.zeros((0, N, n_x)),
+        cross_grad_U=jnp.zeros((0, N, n_u)),
+        lam_prox=jnp.asarray(pen["lam_prox"]),
+        lam_cost=jnp.asarray(pen["lam_cost"]),
+        lam_vc=jnp.asarray(pen["lam_vc"]),
+        lam_vb_nodal=jnp.asarray(pen["lam_vb_nodal"]),
+        lam_vb_cross=jnp.zeros((0,)),
+        x_init=jnp.asarray(x_init),
+        x_term=jnp.asarray(x_term),
+    )
+
+
+def _make_batch(data: SubproblemData, scales) -> SubproblemData:
+    """Stack ``data`` ``B`` times, perturbing ``lam_prox`` by ``scales[b]``.
+
+    Perturbing a penalty weight rather than a structural array keeps every
+    batch element a well-posed subproblem with the same sparsity pattern,
+    while guaranteeing the optimum genuinely differs across batch elements
+    (otherwise the test would only verify broadcasting, not per-element
+    correctness under vmap).
+    """
+    scales = jnp.asarray(scales)
+    B = scales.shape[0]
+
+    def stack_lam_prox(lam_prox):
+        # (B, 1, 1) * (N, n_x+n_u) -> (B, N, n_x+n_u)
+        return scales[:, None, None] * jnp.broadcast_to(lam_prox, (B,) + lam_prox.shape)
+
+    def stack_other(leaf):
+        return jnp.broadcast_to(leaf, (B,) + leaf.shape)
+
+    leaves = {
+        f.name: getattr(data, f.name) for f in data.__dataclass_fields__.values()
+    }
+    leaves["lam_prox"] = stack_lam_prox(leaves["lam_prox"])
+    for name in list(leaves):
+        if name == "lam_prox":
+            continue
+        leaves[name] = stack_other(leaves[name])
+    return SubproblemData(**leaves)
+
+
+# ============================================================================
+# QPAX
+# ============================================================================
+
+
+pytest.importorskip("qpax")
+
+
+def test_qpax_iteration_callback_composes_with_vmap():
+    """``jax.vmap(cb)`` over a batch of distinct ``SubproblemData`` must
+    yield per-element-correct ``SubproblemSolution`` slices.
+
+    Batch elements differ by a ``lam_prox`` scale — the cheapest perturbation
+    that meaningfully changes the QP solution. Each batched output slice
+    must match a bare call on the corresponding unbatched data within PDIP
+    tolerance.
+    """
+    prob = _build_brachistochrone("qpax", n=4, k_max=1)
+    prob.initialize()
+    prob.solve()
+    solver = prob.solver
+
+    base = _subproblem_data_from_solver(solver)
+    scales = jnp.array([0.5, 1.0, 1.5, 2.0])
+    batch = _make_batch(base, scales)
+
+    callback = solver.iteration_callback()
+    batched = jax.vmap(callback, in_axes=(None, 0))(None, batch)
+
+    assert isinstance(batched, SubproblemSolution)
+    assert batched.x.shape[0] == scales.shape[0]
+
+    for i, s in enumerate(scales):
+        per_element_data = SubproblemData(
+            **{
+                **{f.name: getattr(base, f.name) for f in base.__dataclass_fields__.values()},
+                "lam_prox": float(s) * base.lam_prox,
+            }
+        )
+        bare = callback(None, per_element_data)
+        np.testing.assert_allclose(
+            np.asarray(batched.x[i]), np.asarray(bare.x), atol=1e-8, rtol=1e-8
+        )
+        np.testing.assert_allclose(
+            np.asarray(batched.u[i]), np.asarray(bare.u), atol=1e-8, rtol=1e-8
+        )
+        np.testing.assert_allclose(
+            float(batched.cost[i]), float(bare.cost), atol=1e-8, rtol=1e-8
+        )
+
+
+# ============================================================================
+# Moreau (gated on license availability)
+# ============================================================================
+
+
+@requires_moreau
+def test_moreau_iteration_callback_composes_with_vmap():
+    """Same contract as the QPAX variant — ``jax.vmap`` over distinct
+    ``SubproblemData`` instances yields per-element-correct solutions.
+
+    Moreau's functional API supports batched solves natively (per the docs),
+    so unlike CVXPy this path is genuinely vectorized rather than
+    sequentially fanned out. Each batch element solves an independent conic
+    program; per-element results must match unbatched calls.
+    """
+    prob = _build_brachistochrone("moreau", n=4, k_max=1)
+    prob.initialize()
+    prob.solve()
+    solver = prob.solver
+
+    base = _subproblem_data_from_solver(solver)
+    scales = jnp.array([0.5, 1.0, 1.5, 2.0])
+    batch = _make_batch(base, scales)
+
+    callback = solver.iteration_callback()
+    batched = jax.vmap(callback, in_axes=(None, 0))(None, batch)
+
+    assert isinstance(batched, SubproblemSolution)
+    assert batched.x.shape[0] == scales.shape[0]
+
+    for i, s in enumerate(scales):
+        per_element_data = SubproblemData(
+            **{
+                **{f.name: getattr(base, f.name) for f in base.__dataclass_fields__.values()},
+                "lam_prox": float(s) * base.lam_prox,
+            }
+        )
+        bare = callback(None, per_element_data)
+        np.testing.assert_allclose(
+            np.asarray(batched.x[i]), np.asarray(bare.x), atol=1e-7, rtol=1e-7
+        )
+        np.testing.assert_allclose(
+            np.asarray(batched.u[i]), np.asarray(bare.u), atol=1e-7, rtol=1e-7
+        )
+        np.testing.assert_allclose(
+            float(batched.cost[i]), float(bare.cost), atol=1e-7, rtol=1e-7
+        )

--- a/tests/solvers/test_subproblem_pytree.py
+++ b/tests/solvers/test_subproblem_pytree.py
@@ -57,7 +57,7 @@ def _dummy_subproblem_data(N=4, n_x=3, n_u=2, n_nodal=2, n_cross=1):
     )
 
 
-def _dummy_subproblem_solution(N=4, n_x=3, n_u=2, n_nodal=2, n_cross=1, n_z=10, n_cone=8):
+def _dummy_subproblem_solution(N=4, n_x=3, n_u=2, n_nodal=2, n_cross=1):
     return SubproblemSolution(
         x=jnp.ones((N, n_x)),
         u=jnp.ones((N, n_u)),
@@ -66,7 +66,6 @@ def _dummy_subproblem_solution(N=4, n_x=3, n_u=2, n_nodal=2, n_cross=1, n_z=10, 
         nu_vb_cross=jnp.zeros((n_cross,)),
         cost=jnp.asarray(1.23),
         status_code=jnp.asarray(int(StatusCode.OPTIMAL), dtype=jnp.int32),
-        moreau_carry=(jnp.zeros((n_z,)), jnp.zeros((n_cone,)), jnp.zeros((n_cone,))),
     )
 
 
@@ -111,25 +110,9 @@ def test_subproblem_solution_roundtrip():
 
     assert isinstance(rebuilt, SubproblemSolution)
     assert jnp.array_equal(rebuilt.x, sol.x)
+    assert jnp.array_equal(rebuilt.u, sol.u)
+    assert jnp.array_equal(rebuilt.nu_vb, sol.nu_vb)
     assert int(rebuilt.status_code) == int(StatusCode.OPTIMAL)
-    # ``moreau_carry`` is a nested tuple of arrays — must round-trip as one.
-    assert isinstance(rebuilt.moreau_carry, tuple)
-    assert len(rebuilt.moreau_carry) == 3
-    for a, b in zip(rebuilt.moreau_carry, sol.moreau_carry):
-        assert jnp.array_equal(a, b)
-
-
-def test_subproblem_solution_zeros_like():
-    sol = _dummy_subproblem_solution()
-    zeros = jax.tree.map(jnp.zeros_like, sol)
-
-    assert isinstance(zeros, SubproblemSolution)
-    assert zeros.cost.shape == sol.cost.shape
-    assert int(zeros.status_code) == 0  # int32 zero
-    assert isinstance(zeros.moreau_carry, tuple)
-    for leaf, original in zip(zeros.moreau_carry, sol.moreau_carry):
-        assert leaf.shape == original.shape
-        assert jnp.all(leaf == 0)
 
 
 # ============================================================================

--- a/tests/solvers/test_subproblem_pytree.py
+++ b/tests/solvers/test_subproblem_pytree.py
@@ -1,0 +1,152 @@
+"""Pytree contract tests for ``SubproblemData`` / ``SubproblemSolution``.
+
+These are the JAX-pure I/O containers exchanged between the SCP loop and
+each backend's ``iteration_callback``. They must:
+
+* Round-trip through ``jax.tree_util.tree_flatten`` / ``tree_unflatten``.
+* Compose with ``jax.tree.map`` (e.g. ``jnp.zeros_like``) so downstream JAX
+  transforms can build sentinel/zero values structurally.
+
+The shapes used below are arbitrary; the contract being tested is that the
+pytree registration preserves identity and field order. Backend-specific
+shape conventions are exercised by the per-backend iteration_callback tests
+landing in later phases.
+"""
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+from openscvx.solvers.ptr_solver import (
+    StatusCode,
+    SubproblemData,
+    SubproblemSolution,
+    status_code_to_str,
+)
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+
+def _dummy_subproblem_data(N=4, n_x=3, n_u=2, n_nodal=2, n_cross=1):
+    """Fill a SubproblemData with deterministic, shape-correct test values."""
+    return SubproblemData(
+        x_bar=jnp.ones((N, n_x)),
+        u_bar=jnp.full((N, n_u), 2.0),
+        A_d=jnp.zeros((N - 1, n_x, n_x)),
+        B_d=jnp.zeros((N - 1, n_x, n_u)),
+        C_d=jnp.zeros((N - 1, n_x, n_u)),
+        x_prop=jnp.zeros((N - 1, n_x)),
+        x_prop_plus=jnp.zeros((N, n_x)),
+        D_d=jnp.zeros((N, n_x, n_x)),
+        E_d=jnp.zeros((N, n_x, n_u)),
+        nodal_g=jnp.zeros((N, n_nodal)),
+        nodal_grad_x=jnp.zeros((N, n_nodal, n_x)),
+        nodal_grad_u=jnp.zeros((N, n_nodal, n_u)),
+        cross_g=jnp.zeros((n_cross,)),
+        cross_grad_X=jnp.zeros((n_cross, N, n_x)),
+        cross_grad_U=jnp.zeros((n_cross, N, n_u)),
+        lam_prox=jnp.ones((N, n_x + n_u)),
+        lam_cost=jnp.ones((n_x,)),
+        lam_vc=jnp.ones((N - 1, n_x)),
+        lam_vb_nodal=jnp.ones((N, n_nodal)),
+        lam_vb_cross=jnp.ones((n_cross,)),
+        x_init=jnp.array([0.0, jnp.nan, 1.0]),
+        x_term=jnp.full((n_x,), jnp.nan),
+    )
+
+
+def _dummy_subproblem_solution(N=4, n_x=3, n_u=2, n_nodal=2, n_cross=1, n_z=10, n_cone=8):
+    return SubproblemSolution(
+        x=jnp.ones((N, n_x)),
+        u=jnp.ones((N, n_u)),
+        nu=jnp.zeros((N - 1, n_x)),
+        nu_vb=jnp.zeros((N, n_nodal)),
+        nu_vb_cross=jnp.zeros((n_cross,)),
+        cost=jnp.asarray(1.23),
+        status_code=jnp.asarray(int(StatusCode.OPTIMAL), dtype=jnp.int32),
+        moreau_carry=(jnp.zeros((n_z,)), jnp.zeros((n_cone,)), jnp.zeros((n_cone,))),
+    )
+
+
+# ============================================================================
+# SubproblemData
+# ============================================================================
+
+
+def test_subproblem_data_roundtrip():
+    data = _dummy_subproblem_data()
+    leaves, treedef = jax.tree_util.tree_flatten(data)
+    rebuilt = jax.tree_util.tree_unflatten(treedef, leaves)
+
+    assert isinstance(rebuilt, SubproblemData)
+    assert jnp.array_equal(rebuilt.x_bar, data.x_bar)
+    assert jnp.array_equal(rebuilt.u_bar, data.u_bar)
+    # NaN equality: x_init has sentinel NaNs, so compare via isnan masks.
+    assert jnp.array_equal(jnp.isnan(rebuilt.x_init), jnp.isnan(data.x_init))
+    assert jnp.array_equal(rebuilt.x_init[~jnp.isnan(rebuilt.x_init)], jnp.array([0.0, 1.0]))
+
+
+def test_subproblem_data_zeros_like():
+    data = _dummy_subproblem_data()
+    zeros = jax.tree.map(jnp.zeros_like, data)
+
+    assert isinstance(zeros, SubproblemData)
+    assert zeros.x_bar.shape == data.x_bar.shape
+    assert jnp.all(zeros.x_bar == 0)
+    assert jnp.all(zeros.lam_prox == 0)
+    assert zeros.x_init.shape == data.x_init.shape
+
+
+# ============================================================================
+# SubproblemSolution
+# ============================================================================
+
+
+def test_subproblem_solution_roundtrip():
+    sol = _dummy_subproblem_solution()
+    leaves, treedef = jax.tree_util.tree_flatten(sol)
+    rebuilt = jax.tree_util.tree_unflatten(treedef, leaves)
+
+    assert isinstance(rebuilt, SubproblemSolution)
+    assert jnp.array_equal(rebuilt.x, sol.x)
+    assert int(rebuilt.status_code) == int(StatusCode.OPTIMAL)
+    # ``moreau_carry`` is a nested tuple of arrays — must round-trip as one.
+    assert isinstance(rebuilt.moreau_carry, tuple)
+    assert len(rebuilt.moreau_carry) == 3
+    for a, b in zip(rebuilt.moreau_carry, sol.moreau_carry):
+        assert jnp.array_equal(a, b)
+
+
+def test_subproblem_solution_zeros_like():
+    sol = _dummy_subproblem_solution()
+    zeros = jax.tree.map(jnp.zeros_like, sol)
+
+    assert isinstance(zeros, SubproblemSolution)
+    assert zeros.cost.shape == sol.cost.shape
+    assert int(zeros.status_code) == 0  # int32 zero
+    assert isinstance(zeros.moreau_carry, tuple)
+    for leaf, original in zip(zeros.moreau_carry, sol.moreau_carry):
+        assert leaf.shape == original.shape
+        assert jnp.all(leaf == 0)
+
+
+# ============================================================================
+# StatusCode
+# ============================================================================
+
+
+@pytest.mark.parametrize(
+    "code,label",
+    [
+        (StatusCode.OPTIMAL, "optimal"),
+        (StatusCode.INFEASIBLE, "infeasible"),
+        (StatusCode.UNBOUNDED, "unbounded"),
+        (StatusCode.UNKNOWN, "unknown"),
+    ],
+)
+def test_status_code_to_str(code, label):
+    assert status_code_to_str(int(code)) == label
+    # Accepts 0-d jax arrays as well — that's the JAX-pure call site.
+    assert status_code_to_str(jnp.asarray(int(code), dtype=jnp.int32)) == label


### PR DESCRIPTION
## Summary
- Add JAX-pure `iteration_callback()` to every `PTRSolver` backend (QPAX, Moreau, CVXPy) so a single SCP iteration — assemble → solve → unpack — happens on the JAX boundary instead of bouncing through NumPy each step. Prerequisite for `jax.vmap` / `jax.jit` / `lax.while_loop` composition in the downstream batchable-problem work.
- Introduce `SubproblemData` / `SubproblemSolution` registered pytrees and a `StatusCode` int-enum on `ptr_solver.py` so all three backends share a uniform input/output contract.
- **QPAX:** rewrite `_assemble_qp` as `_assemble_qp_jax` (JAX-pure, `.at[...].set(...)` vectorization); dispatch via `qpax.solve_qp_primal` (the `jax.custom_vjp`-differentiable variant). NumPy `solve()` path retains `qpax.solve_qp` for diagnostics.
- **Moreau:** rewrite `_assemble_conic` as JAX-pure; dispatch via the functional `moreau.jax.solver(...)` factory (no warm-start — see Decision Log). NumPy `solve()` path retains the OO `Solver` with warm-start.
- **CVXPy:** wrap host solve in `jax.pure_callback(..., vmap_method="sequential")` — CVXPy can't trace, so batched vmap is serial.
- Collapse `nu_vb` raggedness to stacked `(N, n_nodal)` at the callback output boundary across all three backends; `PTRSolveResult.nu_vb` keeps `List[np.ndarray]` for the NumPy path.

## Test plan
- [x] `tests/solvers/test_subproblem_pytree.py` — pytree round-trip + `StatusCode` mapping
- [x] `tests/solvers/test_cvxpy_callback_jit_spike.py` — `pure_callback` + `jit` + `vmap` go/no-go gate
- [x] `tests/solvers/test_iteration_callback_{qpax,moreau,cvxpy}.py` — assembly parity to `atol=1e-10` + solution parity vs `solver.solve()` + JIT tracing
- [x] `tests/solvers/test_iteration_callback_vmap.py` — per-element correctness under `jax.vmap` for QPAX and Moreau
- [x] `pytest tests/solvers/ -n auto` — 33 passed, 22 skipped (Moreau-gated on license)
- [ ] Impulsive-coupling parity test (brachistochrone has no impulsive controls, so the JAX-pure `has_impulsive` branch is untested — follow-up before `plans/batchable-problem.md` relies on it)


---

Retroactive link: part of the batchable-solve line for #493 and #494.
