### PR TITLE
Removed redundant variables from subproblem formulation

### DIFF
--- a/openscvx/algorithms/scvx/penalized_trust_region.py
+++ b/openscvx/algorithms/scvx/penalized_trust_region.py
@@ -701,6 +701,7 @@ class PenalizedTrustRegion(Algorithm):
             lam_vb_nodal=np.asarray(state.lam_vb_nodal),
             lam_vb_cross=np.asarray(state.lam_vb_cross),
         )
+        self._solver.update_proximal_terms()
 
         t0 = time.time()
         result = self._solver.solve()

--- a/openscvx/integrators/diffrax.py
+++ b/openscvx/integrators/diffrax.py
@@ -129,7 +129,7 @@ def solve_ivp_diffrax_prop(
     dt0 = user_kwargs.pop("dt0", (tau_final - tau_0) / 1)
     solve_kwargs = {
         "stepsize_controller": dfx.PIDController(rtol=rtol, atol=atol),
-        "saveat": dfx.SaveAt(dense=True),
+        "saveat": dfx.SaveAt(dense=True, t1=True),
     }
     solve_kwargs.update(user_kwargs)
     if isinstance(solve_kwargs["stepsize_controller"], dfx.StepTo):
@@ -147,5 +147,8 @@ def solve_ivp_diffrax_prop(
     )
 
     all_evals = jax.vmap(solution.evaluate)(save_time)
+    terminal_state = jnp.asarray(solution.ys)[-1]
+    at_terminal = jnp.isclose(save_time, tau_final)
+    all_evals = jnp.where(at_terminal[:, None], terminal_state, all_evals)
     masked_array = jnp.where(mask[:, None], all_evals, jnp.zeros_like(all_evals))
     return masked_array

--- a/openscvx/lowered/cvxpy_variables.py
+++ b/openscvx/lowered/cvxpy_variables.py
@@ -35,13 +35,11 @@ class CVXPyVariables:
         lam_vb_cross: Virtual buffer penalty weights for cross-node constraints (n_cross, nonneg)
 
         x: State variable (N x n_states)
-        dx: State error variable (N x n_states)
         x_bar: Previous SCP state parameter (N x n_states)
         x_init: Initial state parameter (n_states,)
         x_term: Terminal state parameter (n_states,)
 
         u: Control variable (N x n_controls)
-        du: Control error variable (N x n_controls)
         u_bar: Previous SCP control parameter (N x n_controls)
 
         A_d: Discretized state Jacobian parameter (N-1 x n_states*n_states)
@@ -72,8 +70,6 @@ class CVXPyVariables:
 
         x_nonscaled: List of scaled state expressions at each node
         u_nonscaled: List of scaled control expressions at each node
-        dx_nonscaled: List of scaled state error expressions at each node
-        du_nonscaled: List of scaled control error expressions at each node
     """
 
     # SCP weight parameters
@@ -85,14 +81,12 @@ class CVXPyVariables:
 
     # State variables and parameters
     x: "cp.Variable"
-    dx: "cp.Variable"
     x_bar: "cp.Parameter"
     x_init: "cp.Parameter"
     x_term: "cp.Parameter"
 
     # Control variables and parameters
     u: "cp.Variable"
-    du: "cp.Variable"
     u_bar: "cp.Parameter"
 
     # Dynamics discretization parameters
@@ -128,5 +122,3 @@ class CVXPyVariables:
     # Scaled CVXPy expressions at each node (lists of length N)
     x_nonscaled: List = field(default_factory=list)
     u_nonscaled: List = field(default_factory=list)
-    dx_nonscaled: List = field(default_factory=list)
-    du_nonscaled: List = field(default_factory=list)

--- a/openscvx/lowered/cvxpy_variables.py
+++ b/openscvx/lowered/cvxpy_variables.py
@@ -29,12 +29,15 @@ class CVXPyVariables:
 
     Attributes:
         lam_prox: Trust region weight parameter (N x (n_states+n_controls), nonneg)
-        prox_c: Linear proximal coefficient parameter (N x (n_states+n_controls))
-        prox_cc: Constant proximal offset parameter (N,)
         lam_cost: Cost function weight parameter (n_states, nonneg)
         lam_vc: Virtual control penalty weights (N-1 x n_states, nonneg)
         lam_vb_nodal: Virtual buffer penalty weights for nodal constraints (N x n_nodal, nonneg)
         lam_vb_cross: Virtual buffer penalty weights for cross-node constraints (n_cross, nonneg)
+
+        prox_c: Linear proximal coefficient parameter (N x (n_states+n_controls))
+        prox_cc: Constant proximal offset parameter (N,)
+        dyn_bias: Dynamics affine bias parameter (N-1 x n_states)
+        x0_imp_bias: Initial impulsive affine bias parameter (n_states,)
 
         x: State variable (N x n_states)
         x_bar: Previous SCP state parameter (N x n_states)
@@ -82,7 +85,6 @@ class CVXPyVariables:
     lam_vb_cross: "cp.Parameter"
     prox_c: "cp.Parameter"
     prox_cc: "cp.Parameter"
-    
     # State variables and parameters
     x: "cp.Variable"
     x_bar: "cp.Parameter"
@@ -102,7 +104,9 @@ class CVXPyVariables:
     E_d: "cp.Parameter | None"
     x_prop: "cp.Parameter"
     nu: "cp.Variable"
-
+    dyn_bias: "cp.Parameter"
+    x0_imp_bias: "cp.Parameter"
+    
     # Nodal constraint linearization (lists, one per constraint)
     g: List["cp.Parameter"] = field(default_factory=list)
     grad_g_x: List["cp.Parameter"] = field(default_factory=list)

--- a/openscvx/lowered/cvxpy_variables.py
+++ b/openscvx/lowered/cvxpy_variables.py
@@ -50,10 +50,7 @@ class CVXPyVariables:
         A_d: Discretized state Jacobian parameter (N-1 x n_states*n_states)
         B_d: Discretized control Jacobian parameter (N-1 x n_states*n_controls)
         C_d: Discretized control Jacobian (next node) parameter
-        x_prop_plus: Discrete dynamics propagated state parameter
-        D_d: Jacobian of impulsive/discrete dynamics w.r.t. state
         E_d: Jacobian of impulsive/discrete dynamics w.r.t. control
-        x_prop: Propagated state parameter (N-1 x n_states)
         nu: Virtual control variable (N-1 x n_states)
 
         g: List of constraint value parameters (one per nodal constraint)
@@ -99,14 +96,11 @@ class CVXPyVariables:
     A_d: "cp.Parameter"
     B_d: "cp.Parameter"
     C_d: "cp.Parameter"
-    x_prop_plus: "cp.Parameter | None"
-    D_d: "cp.Parameter | None"
     E_d: "cp.Parameter | None"
-    x_prop: "cp.Parameter"
     nu: "cp.Variable"
     dyn_bias: "cp.Parameter"
     x0_imp_bias: "cp.Parameter"
-    
+
     # Nodal constraint linearization (lists, one per constraint)
     g: List["cp.Parameter"] = field(default_factory=list)
     grad_g_x: List["cp.Parameter"] = field(default_factory=list)

--- a/openscvx/lowered/cvxpy_variables.py
+++ b/openscvx/lowered/cvxpy_variables.py
@@ -29,6 +29,8 @@ class CVXPyVariables:
 
     Attributes:
         lam_prox: Trust region weight parameter (N x (n_states+n_controls), nonneg)
+        prox_c: Linear proximal coefficient parameter (N x (n_states+n_controls))
+        prox_cc: Constant proximal offset parameter (N,)
         lam_cost: Cost function weight parameter (n_states, nonneg)
         lam_vc: Virtual control penalty weights (N-1 x n_states, nonneg)
         lam_vb_nodal: Virtual buffer penalty weights for nodal constraints (N x n_nodal, nonneg)
@@ -78,7 +80,9 @@ class CVXPyVariables:
     lam_vc: "cp.Parameter"
     lam_vb_nodal: "cp.Parameter"
     lam_vb_cross: "cp.Parameter"
-
+    prox_c: "cp.Parameter"
+    prox_cc: "cp.Parameter"
+    
     # State variables and parameters
     x: "cp.Variable"
     x_bar: "cp.Parameter"

--- a/openscvx/propagation/post_processing.py
+++ b/openscvx/propagation/post_processing.py
@@ -109,6 +109,12 @@ def propagate_trajectory_results(
         # Always restore original x_prop, even if propagation fails
         settings.sim.x_prop = original_x_prop
 
+    # Use optimizer nodal values at available timesteps.
+    for node_idx, node_time in enumerate(np.asarray(t).reshape(-1)):
+        matching_rows = np.isclose(t_full, node_time)
+        if np.any(matching_rows):
+            x_full[matching_rows, :n_opt_states] = x[node_idx, :]
+
     # Calculate cost using utility function and metadata from settings
     # dynamics_discrete operates on optimization states only; when propagation has
     # extra states, pass only the opt-state portion and then reattach the prop-only tail

--- a/openscvx/propagation/post_processing.py
+++ b/openscvx/propagation/post_processing.py
@@ -109,12 +109,6 @@ def propagate_trajectory_results(
         # Always restore original x_prop, even if propagation fails
         settings.sim.x_prop = original_x_prop
 
-    # Use optimizer nodal values at available timesteps.
-    for node_idx, node_time in enumerate(np.asarray(t).reshape(-1)):
-        matching_rows = np.isclose(t_full, node_time)
-        if np.any(matching_rows):
-            x_full[matching_rows, :n_opt_states] = x[node_idx, :]
-
     # Calculate cost using utility function and metadata from settings
     # dynamics_discrete operates on optimization states only; when propagation has
     # extra states, pass only the opt-state portion and then reattach the prop-only tail

--- a/openscvx/solvers/base.py
+++ b/openscvx/solvers/base.py
@@ -217,6 +217,17 @@ class ConvexSolver(ABC):
         """
         raise NotImplementedError
 
+    def update_proximal_terms(self) -> None:
+        """Update optional proximal-expansion parameters.
+
+        Called after ``update_penalties()`` and before ``solve()``. Solvers
+        that formulate trust-region penalties via expanded quadratic forms can
+        override this hook to refresh any derived coefficients.
+
+        Default implementation is a no-op.
+        """
+        return None
+
     @abstractmethod
     def update_boundary_conditions(self, **kwargs) -> None:
         """Update boundary condition parameters.

--- a/openscvx/solvers/cvxpy_ptr_solver.py
+++ b/openscvx/solvers/cvxpy_ptr_solver.py
@@ -851,11 +851,7 @@ class CVXPyPTRSolver(PTRSolver):
                 grad_X_arr = np.asarray(constraint_data["grad_g_X"])
                 grad_U_arr = np.asarray(constraint_data["grad_g_U"])
 
-                g_tilde = (
-                    g_val
-                    - np.sum(grad_X_arr * x_bar_arr)
-                    - np.sum(grad_U_arr * u_bar_arr)
-                )
+                g_tilde = g_val - np.sum(grad_X_arr * x_bar_arr) - np.sum(grad_U_arr * u_bar_arr)
 
                 self._set_param(f"g_cross_{g_id}", g_tilde)
                 self._set_param(f"grad_g_X_cross_{g_id}", grad_X_arr)

--- a/openscvx/solvers/cvxpy_ptr_solver.py
+++ b/openscvx/solvers/cvxpy_ptr_solver.py
@@ -742,13 +742,9 @@ class CVXPyPTRSolver(PTRSolver):
         self._set_param("B_d", B_eff)
         self._set_param("C_d", C_eff)
         x_prop_arr = np.asarray(x_prop)
-        self._ocp_vars.x_prop.value = x_prop_arr
-        x_prop_plus_arr = None
-        if x_prop_plus is not None and self._ocp_vars.x_prop_plus is not None:
-            x_prop_plus_arr = np.asarray(x_prop_plus)
-            self._ocp_vars.x_prop_plus.value = x_prop_plus_arr
+        x_prop_plus_arr = np.asarray(x_prop_plus) if x_prop_plus is not None else None
         E_arr = None
-        if E_d is not None and self._ocp_vars.E_d is not None:
+        if E_d is not None:
             E_arr = np.asarray(E_d)
             self._ocp_vars.E_d.value = E_arr
 
@@ -909,9 +905,9 @@ class CVXPyPTRSolver(PTRSolver):
         prox_cc = np.sum(lam_prox * np.square(z_ref), axis=1)
         return prox_c, prox_cc
 
-    def update_proximal_cost_terms(self) -> None:
+    def update_proximal_terms(self) -> None:
         """Update proximal expansion parameters from current references and weights."""
-        lam_prox_arr = np.asarray(self._problem.param_dict["lam_prox"].value)
+        lam_prox_arr = np.asarray(self._ocp_vars.lam_prox.value)
         x_bar = np.asarray(self._ocp_vars.x_bar.value)
         u_bar = np.asarray(self._ocp_vars.u_bar.value)
         prox_c, prox_cc = self.proximal_cost_terms(lam_prox_arr, x_bar, u_bar)

--- a/openscvx/solvers/cvxpy_ptr_solver.py
+++ b/openscvx/solvers/cvxpy_ptr_solver.py
@@ -556,8 +556,8 @@ class CVXPyPTRSolver(PTRSolver):
                 for node in nodes:
                     residual = (
                         g[idx_ncvx][node]
-                        + grad_g_x[idx_ncvx][node] @ dx[node]
-                        + grad_g_u[idx_ncvx][node] @ du[node]
+                        + grad_g_x[idx_ncvx][node] @ x_nonscaled[node]
+                        + grad_g_u[idx_ncvx][node] @ u_nonscaled[node]
                     )
                     constr += [residual == nu_vb[idx_ncvx][node]]
                 idx_ncvx += 1
@@ -566,14 +566,15 @@ class CVXPyPTRSolver(PTRSolver):
         idx_cross = 0
         if jax_constraints.cross_node:
             for constraint in jax_constraints.cross_node:
-                # Linearization: g(X_bar, U_bar) + ∇g_X @ dX + ∇g_U @ dU == nu_vb
+                # Linearization in affine form:
+                # g_tilde + Σ_k(∇g_X[k]·X[k] + ∇g_U[k]·U[k]) == nu_vb
                 # Sum over all trajectory nodes to couple multiple nodes
                 residual = g_cross[idx_cross]
                 for k in range(settings.sim.n):
                     # Contribution from state at node k
-                    residual += grad_g_X_cross[idx_cross][k, :] @ dx[k]
+                    residual += grad_g_X_cross[idx_cross][k, :] @ x_nonscaled[k]
                     # Contribution from control at node k
-                    residual += grad_g_U_cross[idx_cross][k, :] @ du[k]
+                    residual += grad_g_U_cross[idx_cross][k, :] @ u_nonscaled[k]
                 # Add constraint: residual == slack variable
                 constr += [residual == nu_vb_cross[idx_cross]]
                 idx_cross += 1
@@ -780,16 +781,47 @@ class CVXPyPTRSolver(PTRSolver):
                 - ``grad_g_U``: Gradient w.r.t. full control trajectory
         """
         if nodal:
+            x_bar = self._ocp_vars.x_bar.value
+            u_bar = self._ocp_vars.u_bar.value
+            x_bar_arr = np.asarray(x_bar)
+            u_bar_arr = np.asarray(u_bar)
             for g_id, constraint_data in enumerate(nodal):
-                self._set_param(f"g_{g_id}", constraint_data["g"])
-                self._set_param(f"grad_g_x_{g_id}", constraint_data["grad_g_x"])
-                self._set_param(f"grad_g_u_{g_id}", constraint_data["grad_g_u"])
+                g_arr = np.asarray(constraint_data["g"])
+                grad_x_arr = np.asarray(constraint_data["grad_g_x"])
+                grad_u_arr = np.asarray(constraint_data["grad_g_u"])
+
+                # Convert to affine form in (X, U):
+                # g_tilde + grad_x·X + grad_u·U, where
+                # g_tilde = g(X_bar, U_bar) - grad_x·X_bar - grad_u·U_bar.
+                g_tilde = (
+                    g_arr
+                    - np.sum(grad_x_arr * x_bar_arr, axis=1)
+                    - np.sum(grad_u_arr * u_bar_arr, axis=1)
+                )
+
+                self._set_param(f"g_{g_id}", g_tilde)
+                self._set_param(f"grad_g_x_{g_id}", grad_x_arr)
+                self._set_param(f"grad_g_u_{g_id}", grad_u_arr)
 
         if cross_node:
+            x_bar = self._ocp_vars.x_bar.value
+            u_bar = self._ocp_vars.u_bar.value
+            x_bar_arr = np.asarray(x_bar)
+            u_bar_arr = np.asarray(u_bar)
             for g_id, constraint_data in enumerate(cross_node):
-                self._set_param(f"g_cross_{g_id}", constraint_data["g"])
-                self._set_param(f"grad_g_X_cross_{g_id}", constraint_data["grad_g_X"])
-                self._set_param(f"grad_g_U_cross_{g_id}", constraint_data["grad_g_U"])
+                g_val = np.asarray(constraint_data["g"])
+                grad_X_arr = np.asarray(constraint_data["grad_g_X"])
+                grad_U_arr = np.asarray(constraint_data["grad_g_U"])
+
+                g_tilde = (
+                    g_val
+                    - np.sum(grad_X_arr * x_bar_arr)
+                    - np.sum(grad_U_arr * u_bar_arr)
+                )
+
+                self._set_param(f"g_cross_{g_id}", g_tilde)
+                self._set_param(f"grad_g_X_cross_{g_id}", grad_X_arr)
+                self._set_param(f"grad_g_U_cross_{g_id}", grad_U_arr)
 
     def update_penalties(
         self,

--- a/openscvx/solvers/cvxpy_ptr_solver.py
+++ b/openscvx/solvers/cvxpy_ptr_solver.py
@@ -205,6 +205,8 @@ class CVXPyPTRSolver(PTRSolver):
         # ``settings`` arguments each iteration.
         self._jax_constraints: Optional["LoweredJaxConstraints"] = None
         self._settings: Optional[Config] = None
+        self._slice_cont = slice(0, 0)
+        self._slice_imp = slice(0, 0)
 
     @property
     def ocp_vars(self) -> "CVXPyVariables":
@@ -255,6 +257,8 @@ class CVXPyPTRSolver(PTRSolver):
                 "Unified control slices are inconsistent with control dimension. "
                 f"continuous={n_controls_cont}, impulsive={n_controls_imp}, total={n_controls}."
             )
+        self._slice_cont = slice_cont
+        self._slice_imp = slice_imp
 
         S_x, c_x = self._scaling(x_unified)
         S_u, c_u = self._scaling(u_unified)
@@ -417,20 +421,14 @@ class CVXPyPTRSolver(PTRSolver):
         jax_constraints = lowered.jax_constraints
 
         lam_prox = ocp_vars.lam_prox
+        prox_c = ocp_vars.prox_c
+        prox_cc = ocp_vars.prox_cc
         lam_cost = ocp_vars.lam_cost
         lam_vc = ocp_vars.lam_vc
         lam_vb_nodal = ocp_vars.lam_vb_nodal
         lam_vb_cross = ocp_vars.lam_vb_cross
         x = ocp_vars.x
         u = ocp_vars.u
-        x_bar = ocp_vars.x_bar
-        u_bar = ocp_vars.u_bar
-        inv_S_x = ocp_vars.inv_S_x
-        c_x = ocp_vars.c_x
-        inv_S_u = ocp_vars.inv_S_u
-        c_u = ocp_vars.c_u
-        dx = [x[i] - inv_S_x @ (x_bar[i] - c_x) for i in range(settings.sim.n)]
-        du = [u[i] - inv_S_u @ (u_bar[i] - c_u) for i in range(settings.sim.n)]
         nu = ocp_vars.nu
         nu_vb = ocp_vars.nu_vb
         nu_vb_cross = ocp_vars.nu_vb_cross
@@ -450,9 +448,12 @@ class CVXPyPTRSolver(PTRSolver):
             if settings.sim.x.final_type[i] == "Maximize":
                 cost -= lam_cost[i] * x[-1][i]
 
-        # Trust Region Cost (per-variable weighting)
+        # Trust-region cost in expanded form:
+        #   sum_i [lam_i * z_i^2 + prox_c_i * z_i + prox_cc_i], z_i = [x_i, u_i].
         cost += sum(
-            cp.sum(cp.multiply(lam_prox[i], cp.square(cp.hstack((dx[i], du[i])))))
+            cp.sum(cp.multiply(lam_prox[i], cp.square(cp.hstack((x[i], u[i])))))
+            + cp.sum(cp.multiply(prox_c[i], cp.hstack((x[i], u[i]))))
+            + prox_cc[i]
             for i in range(settings.sim.n)
         )
 
@@ -509,18 +510,14 @@ class CVXPyPTRSolver(PTRSolver):
         jax_constraints = lowered.jax_constraints
         cvxpy_constraints = lowered.cvxpy_constraints
 
-        x = ocp_vars.x
-        x_bar = ocp_vars.x_bar
         x_init = ocp_vars.x_init
         x_term = ocp_vars.x_term
-        u = ocp_vars.u
-        u_bar = ocp_vars.u_bar
         A_d = ocp_vars.A_d
         B_d = ocp_vars.B_d
         C_d = ocp_vars.C_d
-        x_prop = ocp_vars.x_prop
-        x_prop_plus = ocp_vars.x_prop_plus
         E_d = ocp_vars.E_d
+        dyn_bias = ocp_vars.dyn_bias
+        x0_imp_bias = ocp_vars.x0_imp_bias
         nu = ocp_vars.nu
         g = ocp_vars.g
         grad_g_x = ocp_vars.grad_g_x
@@ -536,13 +533,8 @@ class CVXPyPTRSolver(PTRSolver):
         c_u = ocp_vars.c_u
         x_nonscaled = ocp_vars.x_nonscaled
         u_nonscaled = ocp_vars.u_nonscaled
-        dx = [x[i] - inv_S_x @ (x_bar[i] - c_x) for i in range(settings.sim.n)]
-        du = [u[i] - inv_S_u @ (u_bar[i] - c_u) for i in range(settings.sim.n)]
-        dx_nonscaled = [x_nonscaled[i] - x_bar[i] for i in range(settings.sim.n)]
-        du_nonscaled = [u_nonscaled[i] - u_bar[i] for i in range(settings.sim.n)]
         slice_cont = settings.sim.u.slice_continuous
         slice_imp = settings.sim.u.slice_impulsive
-        has_continuous = bool(slice_cont.stop > slice_cont.start)
         has_impulsive = bool(slice_imp.stop > slice_imp.start)
 
         constr = []
@@ -589,7 +581,7 @@ class CVXPyPTRSolver(PTRSolver):
                 if has_impulsive:
                     constr += [
                         x_nonscaled[0][i]
-                        == x_prop_plus[0][i] + E_d[0][i, slice_imp] @ du_nonscaled[0][slice_imp]
+                        == x0_imp_bias[i] + E_d[0][i, slice_imp] @ u_nonscaled[0][slice_imp]
                     ]
                 else:
                     constr += [x_nonscaled[0][i] == x_init[i]]  # Initial Boundary Conditions
@@ -609,15 +601,11 @@ class CVXPyPTRSolver(PTRSolver):
             inv_S_x @ (x_nonscaled[i] - c_x)
             == inv_S_x
             @ (
-                A_d[i - 1] @ dx_nonscaled[i - 1]
-                + (
-                    B_d[i - 1][:, slice_cont] @ du_nonscaled[i - 1][slice_cont]
-                    if has_continuous
-                    else 0
-                )
-                + (C_d[i - 1][:, slice_cont] @ du_nonscaled[i][slice_cont] if has_continuous else 0)
-                + (E_d[i][:, slice_imp] @ du_nonscaled[i][slice_imp] if has_impulsive else 0)
-                + (x_prop_plus[i] if has_impulsive else x_prop[i - 1])
+                A_d[i - 1] @ x_nonscaled[i - 1]
+                + B_d[i - 1][:, slice_cont] @ u_nonscaled[i - 1][slice_cont]
+                + C_d[i - 1][:, slice_cont] @ u_nonscaled[i][slice_cont]
+                + (E_d[i][:, slice_imp] @ u_nonscaled[i][slice_imp] if has_impulsive else 0)
+                + dyn_bias[i - 1]
                 - c_x
             )
             + nu[i - 1]
@@ -721,8 +709,10 @@ class CVXPyPTRSolver(PTRSolver):
             D_d: Optional impulsive/discrete Jacobian wrt state, shape (N, n_states, n_states)
             E_d: Optional impulsive/discrete Jacobian wrt control, shape (N, n_states, n_controls)
         """
-        self._set_param("x_bar", x_bar)
-        self._set_param("u_bar", u_bar)
+        x_bar_arr = np.asarray(x_bar)
+        u_bar_arr = np.asarray(u_bar)
+        self._ocp_vars.x_bar.value = x_bar_arr
+        self._ocp_vars.u_bar.value = u_bar_arr
 
         A_eff = np.asarray(A_d)
         B_eff = np.asarray(B_d)
@@ -751,14 +741,66 @@ class CVXPyPTRSolver(PTRSolver):
         self._set_param("A_d", A_eff)
         self._set_param("B_d", B_eff)
         self._set_param("C_d", C_eff)
-        if "x_prop" in self._problem.param_dict:
-            self._set_param("x_prop", x_prop)
-        elif self._ocp_vars.x_prop is not None:
-            self._ocp_vars.x_prop.value = np.asarray(x_prop)
+        x_prop_arr = np.asarray(x_prop)
+        self._ocp_vars.x_prop.value = x_prop_arr
+        x_prop_plus_arr = None
         if x_prop_plus is not None and self._ocp_vars.x_prop_plus is not None:
-            self._ocp_vars.x_prop_plus.value = np.asarray(x_prop_plus)
+            x_prop_plus_arr = np.asarray(x_prop_plus)
+            self._ocp_vars.x_prop_plus.value = x_prop_plus_arr
+        E_arr = None
         if E_d is not None and self._ocp_vars.E_d is not None:
-            self._ocp_vars.E_d.value = np.asarray(E_d)
+            E_arr = np.asarray(E_d)
+            self._ocp_vars.E_d.value = E_arr
+
+        self.dynamics_biases(
+            A_d=A_eff,
+            B_d=B_eff,
+            C_d=C_eff,
+            x_bar=x_bar_arr,
+            u_bar=u_bar_arr,
+            x_prop=x_prop_arr,
+            x_prop_plus=x_prop_plus_arr,
+            E_d=E_arr,
+        )
+
+    def dynamics_biases(
+        self,
+        A_d: np.ndarray,
+        B_d: np.ndarray,
+        C_d: np.ndarray,
+        x_bar: np.ndarray,
+        u_bar: np.ndarray,
+        x_prop: np.ndarray,
+        x_prop_plus: np.ndarray | None = None,
+        E_d: np.ndarray | None = None,
+    ) -> None:
+        """Update affine dynamics bias parameters for the current linearization.
+
+        Computes and stores:
+            - ``dyn_bias``: per-step affine bias in linearized dynamics
+            - ``x0_imp_bias``: initial-node impulsive affine bias
+        """
+        has_impulsive = bool(self._slice_imp.stop > self._slice_imp.start)
+
+        dyn_bias = np.zeros((A_d.shape[0], A_d.shape[1]), dtype=float)
+        for k in range(A_d.shape[0]):
+            i = k + 1
+            base = x_prop_plus[i] if has_impulsive else x_prop[k]
+            bias_k = (
+                base
+                - A_d[k] @ x_bar[k]
+                - B_d[k][:, self._slice_cont] @ u_bar[k][self._slice_cont]
+                - C_d[k][:, self._slice_cont] @ u_bar[i][self._slice_cont]
+                - (E_d[i][:, self._slice_imp] @ u_bar[i][self._slice_imp] if has_impulsive else 0)
+            )
+            dyn_bias[k] = bias_k
+        self._ocp_vars.dyn_bias.value = dyn_bias
+
+        if has_impulsive:
+            x0_imp_bias = x_prop_plus[0] - E_d[0][:, self._slice_imp] @ u_bar[0][self._slice_imp]
+        else:
+            x0_imp_bias = np.zeros(A_d.shape[1], dtype=float)
+        self._ocp_vars.x0_imp_bias.value = x0_imp_bias
 
     def update_constraint_linearizations(
         self,
@@ -846,11 +888,35 @@ class CVXPyPTRSolver(PTRSolver):
             lam_vb_cross: Virtual buffer penalty weights for cross-node
                 constraints, shape ``(n_cross_node_constraints,)``.
         """
-        self._set_param("lam_prox", lam_prox)
+        lam_prox_arr = np.asarray(lam_prox)
+        self._set_param("lam_prox", lam_prox_arr)
         self._set_param("lam_cost", lam_cost)
         self._set_param("lam_vc", lam_vc)
         self._set_param("lam_vb_nodal", lam_vb_nodal)
         self._set_param("lam_vb_cross", lam_vb_cross)
+
+    def proximal_cost_terms(
+        self,
+        lam_prox: np.ndarray,
+        x_bar: np.ndarray,
+        u_bar: np.ndarray,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Compute linear and constant proximal cost terms."""
+        x_ref = (self._ocp_vars.inv_S_x @ (x_bar.T - self._ocp_vars.c_x[:, None])).T
+        u_ref = (self._ocp_vars.inv_S_u @ (u_bar.T - self._ocp_vars.c_u[:, None])).T
+        z_ref = np.hstack((x_ref, u_ref))
+        prox_c = -2.0 * lam_prox * z_ref
+        prox_cc = np.sum(lam_prox * np.square(z_ref), axis=1)
+        return prox_c, prox_cc
+
+    def update_proximal_cost_terms(self) -> None:
+        """Update proximal expansion parameters from current references and weights."""
+        lam_prox_arr = np.asarray(self._problem.param_dict["lam_prox"].value)
+        x_bar = np.asarray(self._ocp_vars.x_bar.value)
+        u_bar = np.asarray(self._ocp_vars.u_bar.value)
+        prox_c, prox_cc = self.proximal_cost_terms(lam_prox_arr, x_bar, u_bar)
+        self._set_param("prox_c", prox_c)
+        self._set_param("prox_cc", prox_cc)
 
     def update_boundary_conditions(
         self,

--- a/openscvx/solvers/cvxpy_ptr_solver.py
+++ b/openscvx/solvers/cvxpy_ptr_solver.py
@@ -421,9 +421,16 @@ class CVXPyPTRSolver(PTRSolver):
         lam_vc = ocp_vars.lam_vc
         lam_vb_nodal = ocp_vars.lam_vb_nodal
         lam_vb_cross = ocp_vars.lam_vb_cross
-        _ = ocp_vars.x_nonscaled
-        dx = ocp_vars.dx
-        du = ocp_vars.du
+        x = ocp_vars.x
+        u = ocp_vars.u
+        x_bar = ocp_vars.x_bar
+        u_bar = ocp_vars.u_bar
+        inv_S_x = ocp_vars.inv_S_x
+        c_x = ocp_vars.c_x
+        inv_S_u = ocp_vars.inv_S_u
+        c_u = ocp_vars.c_u
+        dx = [x[i] - inv_S_x @ (x_bar[i] - c_x) for i in range(settings.sim.n)]
+        du = [u[i] - inv_S_u @ (u_bar[i] - c_u) for i in range(settings.sim.n)]
         nu = ocp_vars.nu
         nu_vb = ocp_vars.nu_vb
         nu_vb_cross = ocp_vars.nu_vb_cross
@@ -433,7 +440,6 @@ class CVXPyPTRSolver(PTRSolver):
         cost += cp.sum(lam_vb_cross) * 0
 
         # Boundary condition cost terms (use scaled x for numerical conditioning)
-        x = ocp_vars.x
         for i in range(settings.sim.true_state_slice.start, settings.sim.true_state_slice.stop):
             if settings.sim.x.initial_type[i] == "Minimize":
                 cost += lam_cost[i] * x[0][i]
@@ -504,12 +510,10 @@ class CVXPyPTRSolver(PTRSolver):
         cvxpy_constraints = lowered.cvxpy_constraints
 
         x = ocp_vars.x
-        dx = ocp_vars.dx
         x_bar = ocp_vars.x_bar
         x_init = ocp_vars.x_init
         x_term = ocp_vars.x_term
         u = ocp_vars.u
-        du = ocp_vars.du
         u_bar = ocp_vars.u_bar
         A_d = ocp_vars.A_d
         B_d = ocp_vars.B_d
@@ -532,8 +536,10 @@ class CVXPyPTRSolver(PTRSolver):
         c_u = ocp_vars.c_u
         x_nonscaled = ocp_vars.x_nonscaled
         u_nonscaled = ocp_vars.u_nonscaled
-        dx_nonscaled = ocp_vars.dx_nonscaled
-        du_nonscaled = ocp_vars.du_nonscaled
+        dx = [x[i] - inv_S_x @ (x_bar[i] - c_x) for i in range(settings.sim.n)]
+        du = [u[i] - inv_S_u @ (u_bar[i] - c_u) for i in range(settings.sim.n)]
+        dx_nonscaled = [x_nonscaled[i] - x_bar[i] for i in range(settings.sim.n)]
+        du_nonscaled = [u_nonscaled[i] - u_bar[i] for i in range(settings.sim.n)]
         slice_cont = settings.sim.u.slice_continuous
         slice_imp = settings.sim.u.slice_impulsive
         has_continuous = bool(slice_cont.stop > slice_cont.start)
@@ -597,13 +603,6 @@ class CVXPyPTRSolver(PTRSolver):
                 == S_u_inv_td @ (u_nonscaled[i - 1][settings.sim.time_dilation_slice] - c_u_td)
                 for i in range(1, settings.sim.n)
             ]
-
-        constr += [
-            (x[i] - inv_S_x @ (x_bar[i] - c_x) - dx[i]) == 0 for i in range(settings.sim.n)
-        ]  # State Error
-        constr += [
-            (u[i] - inv_S_u @ (u_bar[i] - c_u) - du[i]) == 0 for i in range(settings.sim.n)
-        ]  # Control Error
 
         constr += [
             inv_S_x @ (x_nonscaled[i] - c_x)

--- a/openscvx/symbolic/lower.py
+++ b/openscvx/symbolic/lower.py
@@ -300,10 +300,7 @@ def create_cvxpy_variables(
     A_d = cp.Parameter((N - 1, n_states, n_states), name="A_d", sparsity=A_d_sparsity)
     B_d = cp.Parameter((N - 1, n_states, n_controls), name="B_d", sparsity=B_d_sparsity)
     C_d = cp.Parameter((N - 1, n_states, n_controls), name="C_d", sparsity=C_d_sparsity)
-    x_prop_plus = cp.Parameter((N, n_states), name="x_prop_plus")
-    D_d = cp.Parameter((N, n_states, n_states), name="D_d")
     E_d = cp.Parameter((N, n_states, n_controls), name="E_d")
-    x_prop = cp.Parameter((N - 1, n_states), name="x_prop")
     dyn_bias = cp.Parameter((N - 1, n_states), name="dyn_bias")
     x0_imp_bias = cp.Parameter(n_states, name="x0_imp_bias")
     nu = cp.Variable((N - 1, n_states), name="nu")  # Virtual Control
@@ -369,10 +366,7 @@ def create_cvxpy_variables(
         A_d=A_d,
         B_d=B_d,
         C_d=C_d,
-        x_prop_plus=x_prop_plus,
-        D_d=D_d,
         E_d=E_d,
-        x_prop=x_prop,
         dyn_bias=dyn_bias,
         x0_imp_bias=x0_imp_bias,
         nu=nu,

--- a/openscvx/symbolic/lower.py
+++ b/openscvx/symbolic/lower.py
@@ -279,6 +279,8 @@ def create_cvxpy_variables(
 
     # Parameters
     lam_prox = cp.Parameter((N, n_states + n_controls), nonneg=True, name="lam_prox")
+    prox_c = cp.Parameter((N, n_states + n_controls), name="prox_c")
+    prox_cc = cp.Parameter(N, name="prox_cc")
     lam_cost = cp.Parameter(n_states, nonneg=True, name="lam_cost")
     lam_vc = cp.Parameter((N - 1, n_states), nonneg=True, name="lam_vc")
     lam_vb_nodal = cp.Parameter((N, max(n_nodal_constraints, 1)), nonneg=True, name="lam_vb_nodal")
@@ -354,6 +356,8 @@ def create_cvxpy_variables(
         lam_vc=lam_vc,
         lam_vb_nodal=lam_vb_nodal,
         lam_vb_cross=lam_vb_cross,
+        prox_c=prox_c,
+        prox_cc=prox_cc,
         x=x,
         x_bar=x_bar,
         x_init=x_init,

--- a/openscvx/symbolic/lower.py
+++ b/openscvx/symbolic/lower.py
@@ -286,14 +286,12 @@ def create_cvxpy_variables(
 
     # State
     x = cp.Variable((N, n_states), name="x")  # Current State
-    dx = cp.Variable((N, n_states), name="dx")  # State Error
     x_bar = cp.Parameter((N, n_states), name="x_bar")  # Previous SCP State
     x_init = cp.Parameter(n_states, name="x_init")  # Initial State
     x_term = cp.Parameter(n_states, name="x_term")  # Final State
 
     # Control
     u = cp.Variable((N, n_controls), name="u")  # Current Control
-    du = cp.Variable((N, n_controls), name="du")  # Control Error
     u_bar = cp.Parameter((N, n_controls), name="u_bar")  # Previous SCP Control
 
     # Discretized Augmented Dynamics Constraints
@@ -346,13 +344,9 @@ def create_cvxpy_variables(
     # Applying the affine scaling to state and control
     x_nonscaled = []
     u_nonscaled = []
-    dx_nonscaled = []
-    du_nonscaled = []
     for k in range(N):
         x_nonscaled.append(S_x @ x[k] + c_x)
         u_nonscaled.append(S_u @ u[k] + c_u)
-        dx_nonscaled.append(S_x @ dx[k])
-        du_nonscaled.append(S_u @ du[k])
 
     return CVXPyVariables(
         lam_prox=lam_prox,
@@ -361,12 +355,10 @@ def create_cvxpy_variables(
         lam_vb_nodal=lam_vb_nodal,
         lam_vb_cross=lam_vb_cross,
         x=x,
-        dx=dx,
         x_bar=x_bar,
         x_init=x_init,
         x_term=x_term,
         u=u,
-        du=du,
         u_bar=u_bar,
         A_d=A_d,
         B_d=B_d,
@@ -392,8 +384,6 @@ def create_cvxpy_variables(
         c_u=c_u,
         x_nonscaled=x_nonscaled,
         u_nonscaled=u_nonscaled,
-        dx_nonscaled=dx_nonscaled,
-        du_nonscaled=du_nonscaled,
     )
 
 

--- a/openscvx/symbolic/lower.py
+++ b/openscvx/symbolic/lower.py
@@ -304,6 +304,8 @@ def create_cvxpy_variables(
     D_d = cp.Parameter((N, n_states, n_states), name="D_d")
     E_d = cp.Parameter((N, n_states, n_controls), name="E_d")
     x_prop = cp.Parameter((N - 1, n_states), name="x_prop")
+    dyn_bias = cp.Parameter((N - 1, n_states), name="dyn_bias")
+    x0_imp_bias = cp.Parameter(n_states, name="x0_imp_bias")
     nu = cp.Variable((N - 1, n_states), name="nu")  # Virtual Control
 
     # Linearized Nonconvex Nodal Constraints
@@ -371,6 +373,8 @@ def create_cvxpy_variables(
         D_d=D_d,
         E_d=E_d,
         x_prop=x_prop,
+        dyn_bias=dyn_bias,
+        x0_imp_bias=x0_imp_bias,
         nu=nu,
         g=g,
         grad_g_x=grad_g_x,

--- a/tests/solvers/test_iteration_callback_cvxpy.py
+++ b/tests/solvers/test_iteration_callback_cvxpy.py
@@ -63,12 +63,7 @@ def _subproblem_data_from_solver(prob) -> SubproblemData:
         dyn_bias = np.asarray(ocp.dyn_bias.value)
         x_prop = np.zeros((N - 1, n_x))
         for k in range(N - 1):
-            x_prop[k] = (
-                dyn_bias[k]
-                + A_d[k] @ x_bar[k]
-                + B_d[k] @ u_bar[k]
-                + C_d[k] @ u_bar[k + 1]
-            )
+            x_prop[k] = dyn_bias[k] + A_d[k] @ x_bar[k] + B_d[k] @ u_bar[k] + C_d[k] @ u_bar[k + 1]
 
     x_prop_plus = (
         np.asarray(getattr(ocp, "x_prop_plus").value)

--- a/tests/solvers/test_iteration_callback_cvxpy.py
+++ b/tests/solvers/test_iteration_callback_cvxpy.py
@@ -9,11 +9,6 @@ trajectory as a direct :meth:`solve` call (the spike in
 exercises the real PTR pipeline).
 """
 
-import os
-import sys
-import tempfile
-import types
-
 import jax
 import jax.numpy as jnp
 import numpy as np

--- a/tests/solvers/test_iteration_callback_cvxpy.py
+++ b/tests/solvers/test_iteration_callback_cvxpy.py
@@ -9,6 +9,11 @@ trajectory as a direct :meth:`solve` call (the spike in
 exercises the real PTR pipeline).
 """
 
+import os
+import sys
+import tempfile
+import types
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -49,10 +54,27 @@ def _subproblem_data_from_solver(prob) -> SubproblemData:
     A_d = np.asarray(ocp.A_d.value)
     B_d = np.asarray(ocp.B_d.value)
     C_d = np.asarray(ocp.C_d.value)
-    x_prop = np.asarray(ocp.x_prop.value) if ocp.x_prop is not None else np.zeros((N - 1, n_x))
+    # New nomenclature: x_prop/x_prop_plus are not stored directly on CVXPyVariables.
+    # Reconstruct continuous x_prop from affine dynamics bias:
+    # dyn_bias[k] = x_prop[k] - A[k]x_bar[k] - B[k]u_bar[k] - C[k]u_bar[k+1]
+    if hasattr(ocp, "x_prop") and ocp.x_prop is not None and ocp.x_prop.value is not None:
+        x_prop = np.asarray(ocp.x_prop.value)
+    else:
+        dyn_bias = np.asarray(ocp.dyn_bias.value)
+        x_prop = np.zeros((N - 1, n_x))
+        for k in range(N - 1):
+            x_prop[k] = (
+                dyn_bias[k]
+                + A_d[k] @ x_bar[k]
+                + B_d[k] @ u_bar[k]
+                + C_d[k] @ u_bar[k + 1]
+            )
+
     x_prop_plus = (
-        np.asarray(ocp.x_prop_plus.value)
-        if ocp.x_prop_plus is not None and ocp.x_prop_plus.value is not None
+        np.asarray(getattr(ocp, "x_prop_plus").value)
+        if hasattr(ocp, "x_prop_plus")
+        and getattr(ocp, "x_prop_plus") is not None
+        and getattr(ocp, "x_prop_plus").value is not None
         else np.zeros((N, n_x))
     )
     E_d = (


### PR DESCRIPTION
## Summary
The core change removes explicit variation variables `dx` / `du` from the CVXPY formulation path and replaces them with equivalent affine reformulations, while keeping objective/constraint behavior consistent.

## Main Changes
- Removed explicit `dx` / `du` optimization-variable usage from the variation reformulation path.
- Added proximal affine/constant term plumbing (`prox_c`, `prox_cc`) where needed.
- Updated linearized nonconvex constraint handling to compact affine-in-`X/U` form.
- Introduced/updated affine dynamics bias handling used by the reformulated dynamics constraints.
- Cleaned stale lowered CVXPY variable fields and aligned lowered structures with the current solver interfaces.

## Validation
### Performance check (CVXPY solver time per iteration)
Metric used:
- CVXPY-native `solver_stats.solve_time` (from CVXPY), summed over SCP subproblem solves and normalized per iteration.

Comparison:
- 5 runs per `examples/spacecraft/*.py` problem

| Example | Time/Iter Before PR (s) | Time/Iter After PR (s) | Δ Time/Iter |
|---|---:|---:|---:|
| `halo_orbit` | `0.00012106` | `0.00010349` | `-14.51%` |
| `hohmann_transfer` | `0.00201640` | `0.00162327` | `-19.50%` |
| `proxops_cw` | `0.00109454` | `0.00100872` | `-7.84%` |
| `let_transfer` | `0.02811326` | `0.01684637` | `-40.08%` |

## Notes
- This PR is primarily a formulation/refactor-porting change; no intended user-facing API changes.
- Timing numbers are based on repeated local runs and can vary by hardware/load, but directionality was consistently favorable in this benchmark.