### PR TITLE
Fuse the SCP iteration into one JAX-pure iteration_fn

### DIFF
--- a/docs/UnderTheHood/lowering_architecture.md
+++ b/docs/UnderTheHood/lowering_architecture.md
@@ -168,18 +168,28 @@ of the abstract `PTRSolver` base. Three backends ship today:
 | Backend | Class | Selector | Notes |
 |---------|-------|----------|-------|
 | CVXPy (default) | `CVXPyPTRSolver` | `solver={"backend": "cvxpy"}` (default) | DCP graph via CVXPy, dispatched to QOCO / CLARABEL / etc. Supports user `.convex()` constraints, cross-node constraints, CTCS, and impulsive controls. Optional cvxpygen code generation. |
-| QPAX | `QPAXPTRSolver` | `solver={"backend": "qpax"}` | JAX-native QP via `qpax.solve_qp`. Flat `(Q, q, A, b, G, h)` assembly. Supports box / dynamics (continuous and impulsive) / CTCS / boundary-Fix; **rejects** user `.convex()` and cross-node at `initialize()` with a clear "use `CVXPyPTRSolver`" message. Enables a path toward an end-to-end JAX-differentiable SCP loop in follow-up work. |
+| QPAX | `QPAXPTRSolver` | `solver={"backend": "qpax"}` | JAX-native QP via `qpax.solve_qp`. Flat `(Q, q, A, b, G, h)` assembly. Supports box / dynamics (continuous and impulsive) / CTCS / boundary-Fix; **rejects** user `.convex()` and cross-node at `initialize()` with a clear "use `CVXPyPTRSolver`" message. The `iteration_callback` uses `qpax.solve_qp`, whose convergence flag maps to a `status_code` so a diverged solve fails loudly (chosen over the differentiable `solve_qp_primal`, which exposes no such flag). |
 | Moreau | `MoreauPTRSolver` | `solver={"backend": "moreau"}` | JAX-native conic solver (`moreau.jax.Solver`). Sparse CSR assembly; SOC epigraphs for the L1 / pos PTR penalties (fewer variables and rows than QPAX). Warm-starts between SCP iterations. Same supported subset as QPAX (continuous and impulsive dynamics). Paves the way for user `.convex()` SOC support in a follow-up. |
 
 Each backend exposes two per-iteration entry points: the historical NumPy
-`update_*` + `solve()` stages used by today's Python-side SCP loop, and a
+`update_*` + `solve()` stages (kept for direct / interactive solver use), and a
 JAX-pure `iteration_callback()` built once at `initialize()`. The callback
-returns a `(state, SubproblemData) -> SubproblemSolution` callable; all
-three backends emit the same input/output pytree shape so the callable
-composes with `jax.jit` and `jax.vmap` (CVXPy via `jax.pure_callback` with
-`vmap_method="sequential"` — its batched solves are serial). The downstream
-batchable-`Problem.solve()` work wraps this callback in `lax.while_loop` to
-keep the entire SCP iteration on the JAX boundary.
+returns a `(state, SubproblemData) -> SubproblemSolution` callable; all three
+backends emit the same input/output pytree shape (CVXPy host-calls via
+`jax.pure_callback`).
+
+`Problem.initialize()` fuses that callback with discretization, constraint
+linearization, the SCP metrics, and the autotuner into one JAX function —
+`iteration_fn`, built by `make_scp_iteration`
+(`openscvx/algorithms/scvx/iteration.py`). A single JIT'd `iteration_fn` call
+per iteration replaces the former per-step NumPy↔JAX stitching, and the Python
+SCP loop now drives that one fused body. Forward propagation stays a separate
+JAX export, used only by `post_process()` — so a compiled problem holds **one
+`iteration_fn` plus one propagation export**, not three discretization /
+propagation exports stitched together in Python. Because `iteration_fn` is a
+registered pytree in and out, it also composes with `jax.jit`; `make_solve_loop`
+wraps it in `lax.while_loop` as the primitive for a future fully-JAX-driven
+solve.
 
 Picking a backend at construction time:
 

--- a/openscvx/algorithms/base.py
+++ b/openscvx/algorithms/base.py
@@ -373,6 +373,16 @@ class AlgorithmState:
         actual_reduction: Actual reduction in ``J_nonlin`` for this iter.
         acceptance_ratio: ``actual_reduction / predicted_reduction``.
         adaptive_state_code: :class:`AdaptiveStateCode` value as ``int32``.
+        x_init_pin: Initial-state boundary condition, shape ``(n_states,)``.
+            ``jnp.nan`` where the state is not pinned at t0 (``initial_type``
+            is not ``"Fix"``). Carried on the pytree — rather than read from
+            ``settings`` — so the fused SCP iteration body assembles the
+            subproblem's initial boundary rows as a pure function of state,
+            and a future ``jax.vmap`` over problems can batch boundary
+            conditions per element.
+        x_term_pin: Terminal-state boundary condition, shape ``(n_states,)``.
+            ``jnp.nan`` where the state is not pinned at tf (``final_type`` is
+            not ``"Fix"``).
     """
 
     x: jnp.ndarray
@@ -394,6 +404,8 @@ class AlgorithmState:
     actual_reduction: jnp.ndarray
     acceptance_ratio: jnp.ndarray
     adaptive_state_code: jnp.ndarray
+    x_init_pin: jnp.ndarray
+    x_term_pin: jnp.ndarray
 
     # Field order is the source of truth for tree_flatten / tree_unflatten;
     # keep _FIELDS in sync with the dataclass field declarations above.
@@ -417,6 +429,8 @@ class AlgorithmState:
         "actual_reduction",
         "acceptance_ratio",
         "adaptive_state_code",
+        "x_init_pin",
+        "x_term_pin",
     )
 
     def replace(self, **changes) -> "AlgorithmState":
@@ -475,6 +489,17 @@ class AlgorithmState:
         else:
             lam_cost_init = np.full(n_states, weights.lam_cost)
 
+        # Boundary-condition pins: the physical value where the state is fixed
+        # at t0 / tf, ``nan`` elsewhere. The subproblem only reads these at
+        # ``"Fix"`` entries, so the sentinel marks "unpinned" without poisoning
+        # any value the solver consumes.
+        x_initial = np.asarray(settings.sim.x.initial, dtype=float).reshape(-1)
+        x_final = np.asarray(settings.sim.x.final, dtype=float).reshape(-1)
+        init_fixed = np.asarray(settings.sim.x.initial_type) == "Fix"
+        final_fixed = np.asarray(settings.sim.x.final_type) == "Fix"
+        x_init_pin = np.where(init_fixed, x_initial, np.nan)
+        x_term_pin = np.where(final_fixed, x_final, np.nan)
+
         return cls(
             x=put(jnp.asarray(settings.sim.x.guess, dtype=f)),
             u=put(jnp.asarray(settings.sim.u.guess, dtype=f)),
@@ -495,6 +520,8 @@ class AlgorithmState:
             actual_reduction=put(jnp.asarray(0.0, dtype=f)),
             acceptance_ratio=put(jnp.asarray(0.0, dtype=f)),
             adaptive_state_code=put(jnp.asarray(int(AdaptiveStateCode.INITIAL), dtype=i)),
+            x_init_pin=put(jnp.asarray(x_init_pin, dtype=f)),
+            x_term_pin=put(jnp.asarray(x_term_pin, dtype=f)),
         )
 
 

--- a/openscvx/algorithms/base.py
+++ b/openscvx/algorithms/base.py
@@ -29,7 +29,6 @@ from openscvx.utils.printing import Column
 if TYPE_CHECKING:
     from openscvx.config import Config
     from openscvx.lowered.jax_constraints import LoweredJaxConstraints
-    from openscvx.solvers import ConvexSolver
 
     from .weights import Weights
 
@@ -825,15 +824,21 @@ class Algorithm(ABC):
     @abstractmethod
     def initialize(
         self,
-        solver: "ConvexSolver",
-        discretization_solver: callable,
-        jax_constraints: "LoweredJaxConstraints",
+        iteration_fn: Callable,
         emitter: callable,
-        params: dict,
+        jax_constraints: "LoweredJaxConstraints",
         settings: "Config",
-        discretization_solver_impulsive: Optional[Callable] = None,
     ) -> None:
-        """Initialize the algorithm and store compiled infrastructure."""
+        """Store the fused SCP iteration body and per-iteration infrastructure.
+
+        Args:
+            iteration_fn: The JAX-pure ``(state, params) -> (next_state,
+                diagnostics)`` body built by
+                :func:`~openscvx.algorithms.scvx.iteration.make_scp_iteration`.
+            emitter: Per-iteration diagnostics sink (printing queue / no-op).
+            jax_constraints: Lowered JAX constraints the body operates over.
+            settings: Problem configuration.
+        """
         raise NotImplementedError
 
     @abstractmethod

--- a/openscvx/algorithms/scvx/iteration.py
+++ b/openscvx/algorithms/scvx/iteration.py
@@ -347,7 +347,9 @@ def make_solve_loop(
 
     Args:
         iteration_fn: A body built by :func:`make_scp_iteration`.
-        ep_tr, ep_vb, ep_vc: Convergence thresholds on ``J_tr / J_vb / J_vc``.
+        ep_tr: Convergence threshold on ``J_tr`` (trust-region step).
+        ep_vb: Convergence threshold on ``J_vb`` (virtual buffer).
+        ep_vc: Convergence threshold on ``J_vc`` (virtual control).
         k_max: Maximum number of SCP iterations.
 
     Returns:

--- a/openscvx/algorithms/scvx/iteration.py
+++ b/openscvx/algorithms/scvx/iteration.py
@@ -1,0 +1,284 @@
+"""One fused, JAX-pure SCP iteration body.
+
+Historically a single SCP step was stitched together in Python: ``Problem``
+exported three separate JAX callables (continuous discretization, impulsive
+discretization, propagation) and :meth:`PenalizedTrustRegion._subproblem`
+invoked each one, copied NumPy out of every result, pushed the data through
+the solver's ``update_*`` methods, and finally called ``solver.solve()``. Every
+step crossed the NumPy↔JAX boundary several times, and there was no batch axis
+anywhere.
+
+This module collapses that stitching into one function. :func:`make_scp_iteration`
+returns a ``(state, params) -> state`` callable that, on the JAX side end to
+end, discretizes the current iterate, linearizes the constraints, packs a
+:class:`~openscvx.solvers.ptr_solver.SubproblemData`, hands it to the backend's
+:meth:`~openscvx.solvers.ptr_solver.PTRSolver.iteration_callback`, and folds the
+returned :class:`~openscvx.solvers.ptr_solver.SubproblemSolution` through the
+autotuner — producing the next :class:`AlgorithmState`. Because state is a
+registered pytree, the body composes with ``jax.jit`` and ``jax.vmap``.
+
+:func:`make_solve_loop` wraps that body in a ``lax.while_loop`` keyed on the SCP
+convergence metrics. It exists as a primitive for tests and for the JAX-pure
+``.solve()`` path in follow-up work; today's ``Problem.solve()`` still drives the
+body from a Python ``while`` loop, so behavior is unchanged.
+"""
+
+from typing import TYPE_CHECKING, Callable
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from openscvx.discretization import get_impulsive_discretization_solver
+from openscvx.solvers.ptr_solver import SubproblemData, SubproblemSolution
+
+from ..base import AlgorithmState, CandidateIterate
+
+if TYPE_CHECKING:
+    from openscvx.config import Config
+    from openscvx.discretization import Discretizer
+    from openscvx.lowered import Dynamics, LoweredJaxConstraints
+
+    from ..base import AutotuningBase
+
+
+def make_scp_iteration(
+    dynamics: "Dynamics",
+    dynamics_discrete: "Dynamics",
+    jax_constraints: "LoweredJaxConstraints",
+    discretizer: "Discretizer",
+    solver_callback: Callable[[AlgorithmState, SubproblemData], SubproblemSolution],
+    autotuner: "AutotuningBase",
+    settings: "Config",
+) -> Callable[[AlgorithmState, dict], AlgorithmState]:
+    """Build one JAX-pure SCP iteration body.
+
+    The returned ``iteration_fn(state, params)`` performs a single SCP step and
+    returns the next :class:`AlgorithmState`. It is the fused mirror of the
+    legacy discretize → linearize → solve → autotune pipeline:
+
+    1. Discretize the continuous dynamics about the current iterate
+       (``state.x`` / ``state.u``) → ``A_d, B_d, C_d, x_prop``.
+    2. Discretize the impulsive/discrete dynamics about the propagated nodes →
+       ``x_prop_plus, D_d, E_d``.
+    3. Evaluate every nodal / cross-node constraint and its gradients.
+    4. Pack the linearization, penalty weights, and boundary pins into a
+       :class:`SubproblemData`.
+    5. Hand it to ``solver_callback`` (the backend's ``iteration_callback``),
+       which returns a :class:`SubproblemSolution`.
+    6. Compute the ``J_tr / J_vb / J_vc`` metrics and fold the candidate through
+       the autotuner to produce the next state.
+
+    The current-iterate discretization (steps 1–2) is recomputed every call
+    rather than read from a carried ``state.x_prop``; see the plan's decision
+    log. The closure captures the discretization solvers (built here from
+    ``dynamics`` / ``dynamics_discrete`` / ``discretizer``), the constraint
+    linearizers, the per-backend solver callback, the autotuner, and settings.
+
+    Args:
+        dynamics: Lowered continuous dynamics (``dynamics.f``).
+        dynamics_discrete: Lowered impulsive/discrete dynamics.
+        jax_constraints: Lowered nodal / cross-node JAX constraints.
+        discretizer: Discretizer used to build the continuous solver.
+        solver_callback: ``(state, SubproblemData) -> SubproblemSolution`` from
+            the convex backend's :meth:`iteration_callback`.
+        autotuner: Weight-update strategy applied to the candidate.
+        settings: Problem configuration (scaling matrices, boundary types).
+
+    Returns:
+        ``iteration_fn(state, params) -> next_state``.
+    """
+    N = settings.sim.n
+    n_x = settings.sim.n_states
+    n_u = settings.sim.n_controls
+    n_nodal = len(jax_constraints.nodal)
+
+    dis_continuous = jax.jit(discretizer.get_solver(dynamics, settings))
+    dis_impulsive = jax.jit(get_impulsive_discretization_solver(dynamics_discrete))
+
+    # Scaling matrices for the SCP convergence metrics (static, host-side).
+    inv_S_x = jnp.asarray(settings.sim.inv_S_x)
+    inv_S_u = jnp.asarray(settings.sim.inv_S_u)
+
+    # Node-0 prior recovery: fixed initial entries come from the boundary
+    # condition, free entries from the iterate. The impulsive discretization
+    # linearizes about the propagated nodes prefixed with this prior.
+    init_fixed = jnp.asarray(np.asarray(settings.sim.x.initial_type) == "Fix")
+    x_initial = jnp.asarray(np.asarray(settings.sim.x.initial, dtype=float))
+
+    def _discretize(x: jnp.ndarray, u: jnp.ndarray, params: dict):
+        """Discretize ``(x, u)`` through both dynamics; return propagation pieces."""
+        A_d, B_d, C_d, x_prop, _ = dis_continuous(x, u, params)
+        x0_prior = jnp.where(init_fixed, x_initial, x[0])
+        x_nodes_prior = jnp.concatenate([x0_prior[None, :], x_prop], axis=0)
+        x_prop_plus, D_d, E_d, _ = dis_impulsive(x_nodes_prior, u, params)
+        return A_d, B_d, C_d, x_prop, x_prop_plus, D_d, E_d
+
+    def _linearize_constraints(x: jnp.ndarray, u: jnp.ndarray, params: dict):
+        """Stack nodal / cross-node constraint values and gradients.
+
+        Nodal data is laid out ``(N, n_nodal[, ·])`` with zero-fill at nodes
+        outside each constraint's static ``nodes`` set — the backend assembly
+        closes over those node sets and skips the zeros.
+        """
+        nodal_g = jnp.zeros((N, n_nodal))
+        nodal_grad_x = jnp.zeros((N, n_nodal, n_x))
+        nodal_grad_u = jnp.zeros((N, n_nodal, n_u))
+        for c_idx, constraint in enumerate(jax_constraints.nodal):
+            g = jnp.squeeze(jnp.asarray(constraint.func(x, u, 0, params)))
+            if g.ndim == 0:
+                g = jnp.broadcast_to(g, (N,))
+            elif g.ndim > 1:
+                g = g.reshape(g.shape[0], -1).sum(axis=1)
+
+            grad_x = jnp.asarray(constraint.grad_g_x(x, u, 0, params))
+            if grad_x.ndim == 1:
+                grad_x = jnp.broadcast_to(grad_x, (N, grad_x.shape[0]))
+            elif grad_x.ndim > 2:
+                grad_x = grad_x.reshape(grad_x.shape[0], -1)[:, :n_x]
+
+            grad_u = jnp.asarray(constraint.grad_g_u(x, u, 0, params))
+            if grad_u.ndim == 1:
+                grad_u = jnp.broadcast_to(grad_u, (N, grad_u.shape[0]))
+            elif grad_u.ndim > 2:
+                grad_u = grad_u.reshape(grad_u.shape[0], -1)[:, :n_u]
+
+            nodes = jnp.asarray(constraint.nodes) if constraint.nodes is not None else jnp.arange(N)
+            nodal_g = nodal_g.at[nodes, c_idx].set(g[nodes])
+            nodal_grad_x = nodal_grad_x.at[nodes, c_idx].set(grad_x[nodes])
+            nodal_grad_u = nodal_grad_u.at[nodes, c_idx].set(grad_u[nodes])
+
+        if jax_constraints.cross_node:
+            cross_g = jnp.stack(
+                [jnp.asarray(c.func(x, u, params)) for c in jax_constraints.cross_node]
+            )
+            cross_grad_X = jnp.stack(
+                [jnp.asarray(c.grad_g_X(x, u, params)) for c in jax_constraints.cross_node]
+            )
+            cross_grad_U = jnp.stack(
+                [jnp.asarray(c.grad_g_U(x, u, params)) for c in jax_constraints.cross_node]
+            )
+        else:
+            cross_g = jnp.zeros((0,))
+            cross_grad_X = jnp.zeros((0, N, n_x))
+            cross_grad_U = jnp.zeros((0, N, n_u))
+
+        return nodal_g, nodal_grad_x, nodal_grad_u, cross_g, cross_grad_X, cross_grad_U
+
+    def iteration_fn(state: AlgorithmState, params: dict) -> AlgorithmState:
+        # 1–2. Discretize the current iterate for the subproblem linearization.
+        A_d, B_d, C_d, x_prop, x_prop_plus, D_d, E_d = _discretize(state.x, state.u, params)
+
+        # 3. Linearize the constraints about the current iterate.
+        (
+            nodal_g,
+            nodal_grad_x,
+            nodal_grad_u,
+            cross_g,
+            cross_grad_X,
+            cross_grad_U,
+        ) = _linearize_constraints(state.x, state.u, params)
+
+        # 4. Pack the subproblem inputs.
+        data = SubproblemData(
+            x_bar=state.x,
+            u_bar=state.u,
+            A_d=A_d,
+            B_d=B_d,
+            C_d=C_d,
+            x_prop=x_prop,
+            x_prop_plus=x_prop_plus,
+            D_d=D_d,
+            E_d=E_d,
+            nodal_g=nodal_g,
+            nodal_grad_x=nodal_grad_x,
+            nodal_grad_u=nodal_grad_u,
+            cross_g=cross_g,
+            cross_grad_X=cross_grad_X,
+            cross_grad_U=cross_grad_U,
+            lam_prox=state.lam_prox,
+            lam_cost=state.lam_cost,
+            lam_vc=state.lam_vc,
+            lam_vb_nodal=state.lam_vb_nodal,
+            lam_vb_cross=state.lam_vb_cross,
+            x_init=state.x_init_pin,
+            x_term=state.x_term_pin,
+        )
+
+        # 5. Solve the convex subproblem.
+        solution = solver_callback(state, data)
+
+        # 6a. Discretize the candidate for the autotuner's propagation fields.
+        _, _, _, cand_x_prop, cand_x_prop_plus, _, _ = _discretize(
+            solution.x, solution.u, params
+        )
+        candidate = CandidateIterate()
+        candidate.x = solution.x
+        candidate.u = solution.u
+        candidate.x_prop = cand_x_prop
+        candidate.x_prop_plus = cand_x_prop_plus
+        candidate.J_lin = solution.cost
+
+        # 6b. SCP convergence metrics (scaled trust region / virtual control /
+        # virtual buffer), matching the legacy ``_subproblem`` reductions.
+        tr_x = inv_S_x @ (solution.x - state.x).T
+        tr_u = inv_S_u @ (solution.u - state.u).T
+        J_tr = jnp.sum(tr_x**2) + jnp.sum(tr_u**2)
+        J_vc = jnp.sum(jnp.abs(inv_S_x @ solution.nu.T))
+        J_vb = jnp.sum(jnp.maximum(0.0, solution.nu_vb)) + jnp.sum(
+            jnp.maximum(0.0, solution.nu_vb_cross)
+        )
+        state = state.replace(
+            J_tr=jnp.asarray(J_tr, dtype=state.J_tr.dtype),
+            J_vb=jnp.asarray(J_vb, dtype=state.J_vb.dtype),
+            J_vc=jnp.asarray(J_vc, dtype=state.J_vc.dtype),
+        )
+
+        # 6c. Autotuner: pure functional update producing the next iterate.
+        next_state = autotuner.update_weights(state, candidate, jax_constraints, settings, params)
+        return next_state.replace(k=state.k + 1)
+
+    return iteration_fn
+
+
+def _converged(
+    state: AlgorithmState, ep_tr: float, ep_vb: float, ep_vc: float
+) -> jnp.ndarray:
+    """Boolean SCP convergence test from the metrics on ``state``."""
+    return (state.J_tr < ep_tr) & (state.J_vb < ep_vb) & (state.J_vc < ep_vc)
+
+
+def make_solve_loop(
+    iteration_fn: Callable[[AlgorithmState, dict], AlgorithmState],
+    ep_tr: float,
+    ep_vb: float,
+    ep_vc: float,
+    k_max: int,
+) -> Callable[[AlgorithmState, dict], AlgorithmState]:
+    """Wrap ``iteration_fn`` in a ``lax.while_loop`` keyed on convergence.
+
+    The loop runs ``iteration_fn`` until either the SCP metrics fall below the
+    ``ep_*`` thresholds or the iteration counter ``state.k`` exceeds ``k_max`` —
+    matching the Python ``while`` loop in ``Problem.solve()``. It exists as a
+    primitive for tests and the future JAX-pure ``.solve()`` path; the public
+    ``Problem.solve()`` continues to drive ``iteration_fn`` from Python.
+
+    Args:
+        iteration_fn: A body built by :func:`make_scp_iteration`.
+        ep_tr, ep_vb, ep_vc: Convergence thresholds on ``J_tr / J_vb / J_vc``.
+        k_max: Maximum number of SCP iterations.
+
+    Returns:
+        ``solve_loop(state, params) -> final_state``.
+    """
+
+    def solve_loop(state: AlgorithmState, params: dict) -> AlgorithmState:
+        def cond(state: AlgorithmState) -> jnp.ndarray:
+            return (state.k <= k_max) & jnp.logical_not(_converged(state, ep_tr, ep_vb, ep_vc))
+
+        def body(state: AlgorithmState) -> AlgorithmState:
+            return iteration_fn(state, params)
+
+        return jax.lax.while_loop(cond, body, state)
+
+    return solve_loop

--- a/openscvx/algorithms/scvx/iteration.py
+++ b/openscvx/algorithms/scvx/iteration.py
@@ -9,53 +9,96 @@ step crossed the NumPy↔JAX boundary several times, and there was no batch axis
 anywhere.
 
 This module collapses that stitching into one function. :func:`make_scp_iteration`
-returns a ``(state, params) -> state`` callable that, on the JAX side end to
-end, discretizes the current iterate, linearizes the constraints, packs a
-:class:`~openscvx.solvers.ptr_solver.SubproblemData`, hands it to the backend's
-:meth:`~openscvx.solvers.ptr_solver.PTRSolver.iteration_callback`, and folds the
-returned :class:`~openscvx.solvers.ptr_solver.SubproblemSolution` through the
-autotuner — producing the next :class:`AlgorithmState`. Because state is a
-registered pytree, the body composes with ``jax.jit`` and ``jax.vmap``.
+returns a ``(state, params) -> (state, IterationDiagnostics)`` callable that, on
+the JAX side end to end, discretizes the current iterate, linearizes the
+constraints, packs a :class:`~openscvx.solvers.ptr_solver.SubproblemData`, hands
+it to the backend's :meth:`~openscvx.solvers.ptr_solver.PTRSolver.iteration_callback`,
+and folds the returned :class:`~openscvx.solvers.ptr_solver.SubproblemSolution`
+through the autotuner — producing the next :class:`AlgorithmState`. The
+:class:`IterationDiagnostics` riding alongside carry the host-side bookkeeping
+(raw discretization matrices, trust-region / virtual-control matrices, cost,
+status) that the Python-loop ``step()`` records into ``AlgorithmHistory`` and
+emits, exactly as the legacy path did. Because state is a registered pytree, the
+body composes with ``jax.jit`` and ``jax.vmap``.
 
 :func:`make_solve_loop` wraps that body in a ``lax.while_loop`` keyed on the SCP
-convergence metrics. It exists as a primitive for tests and for the JAX-pure
+convergence metrics, projecting the diagnostics away so the loop carry stays
+``state -> state``. It exists as a primitive for tests and for the JAX-pure
 ``.solve()`` path in follow-up work; today's ``Problem.solve()`` still drives the
 body from a Python ``while`` loop, so behavior is unchanged.
 """
 
-from typing import TYPE_CHECKING, Callable
+from dataclasses import dataclass, fields
+from typing import TYPE_CHECKING, Callable, Tuple
 
 import jax
 import jax.numpy as jnp
 import numpy as np
 
-from openscvx.discretization import get_impulsive_discretization_solver
 from openscvx.solvers.ptr_solver import SubproblemData, SubproblemSolution
 
 from ..base import AlgorithmState, CandidateIterate
 
 if TYPE_CHECKING:
     from openscvx.config import Config
-    from openscvx.discretization import Discretizer
-    from openscvx.lowered import Dynamics, LoweredJaxConstraints
+    from openscvx.lowered import LoweredJaxConstraints
 
     from ..base import AutotuningBase
 
 
+@jax.tree_util.register_pytree_node_class
+@dataclass(frozen=True)
+class IterationDiagnostics:
+    """Host-side bookkeeping produced alongside the next :class:`AlgorithmState`.
+
+    These ride beside the state out of :func:`make_scp_iteration` so the
+    Python-loop ``step()`` can populate :class:`AlgorithmHistory` and the
+    emitter exactly as the legacy ``_subproblem`` did — the data they carry is
+    not on the JAX-traceable state pytree (raw discretization matrices are
+    large and host-only; cost / status / ``J_lin`` come from the subproblem
+    solve). :func:`make_solve_loop` projects them away.
+
+    Attributes:
+        cost: Boundary-weighted objective at the candidate (scalar) — the
+            ``cost[-1]`` the emitter prints.
+        status: Subproblem :class:`StatusCode` as ``int32``.
+        J_lin: Subproblem optimal (linearized) cost (scalar).
+        V: Raw continuous discretization matrix of the candidate.
+        W: Raw impulsive discretization matrix of the candidate.
+        TR: Scaled trust-region step matrix, shape ``(n_x + n_u, N)``.
+        VC: Scaled virtual-control matrix, shape ``(N-1, n_x)``.
+    """
+
+    cost: jnp.ndarray
+    status: jnp.ndarray
+    J_lin: jnp.ndarray
+    V: jnp.ndarray
+    W: jnp.ndarray
+    TR: jnp.ndarray
+    VC: jnp.ndarray
+
+    def tree_flatten(self):
+        children = tuple(getattr(self, f.name) for f in fields(self))
+        return children, None
+
+    @classmethod
+    def tree_unflatten(cls, aux, children):
+        return cls(*children)
+
+
 def make_scp_iteration(
-    dynamics: "Dynamics",
-    dynamics_discrete: "Dynamics",
+    dis_continuous: Callable,
+    dis_impulsive: Callable,
     jax_constraints: "LoweredJaxConstraints",
-    discretizer: "Discretizer",
     solver_callback: Callable[[AlgorithmState, SubproblemData], SubproblemSolution],
     autotuner: "AutotuningBase",
     settings: "Config",
-) -> Callable[[AlgorithmState, dict], AlgorithmState]:
+) -> Callable[[AlgorithmState, dict], Tuple[AlgorithmState, IterationDiagnostics]]:
     """Build one JAX-pure SCP iteration body.
 
     The returned ``iteration_fn(state, params)`` performs a single SCP step and
-    returns the next :class:`AlgorithmState`. It is the fused mirror of the
-    legacy discretize → linearize → solve → autotune pipeline:
+    returns ``(next_state, diagnostics)``. It is the fused mirror of the legacy
+    discretize → linearize → solve → autotune pipeline:
 
     1. Discretize the continuous dynamics about the current iterate
        (``state.x`` / ``state.u``) → ``A_d, B_d, C_d, x_prop``.
@@ -67,38 +110,46 @@ def make_scp_iteration(
     5. Hand it to ``solver_callback`` (the backend's ``iteration_callback``),
        which returns a :class:`SubproblemSolution`.
     6. Compute the ``J_tr / J_vb / J_vc`` metrics and fold the candidate through
-       the autotuner to produce the next state.
+       the autotuner to produce the next state, alongside an
+       :class:`IterationDiagnostics`.
 
     The current-iterate discretization (steps 1–2) is recomputed every call
     rather than read from a carried ``state.x_prop``; see the plan's decision
-    log. The closure captures the discretization solvers (built here from
-    ``dynamics`` / ``dynamics_discrete`` / ``discretizer``), the constraint
-    linearizers, the per-backend solver callback, the autotuner, and settings.
+    log. The discretization solvers are built by the caller (``Problem``) and
+    captured here so the caching policy stays in its own layer; the constraint
+    linearizers, per-backend solver callback, autotuner, and settings are
+    likewise closure constants.
 
     Args:
-        dynamics: Lowered continuous dynamics (``dynamics.f``).
-        dynamics_discrete: Lowered impulsive/discrete dynamics.
+        dis_continuous: Continuous discretization solver,
+            ``(x, u, params) -> (A_d, B_d, C_d, x_prop, V)``. A ``jax.jit``
+            callable (vmappable) or a ``jax.export`` wrapper (``.call``).
+        dis_impulsive: Impulsive discretization solver,
+            ``(x_nodes, u, params) -> (x_prop_plus, D_d, E_d, W)``.
         jax_constraints: Lowered nodal / cross-node JAX constraints.
-        discretizer: Discretizer used to build the continuous solver.
         solver_callback: ``(state, SubproblemData) -> SubproblemSolution`` from
             the convex backend's :meth:`iteration_callback`.
         autotuner: Weight-update strategy applied to the candidate.
         settings: Problem configuration (scaling matrices, boundary types).
 
     Returns:
-        ``iteration_fn(state, params) -> next_state``.
+        ``iteration_fn(state, params) -> (next_state, diagnostics)``.
     """
     N = settings.sim.n
     n_x = settings.sim.n_states
     n_u = settings.sim.n_controls
     n_nodal = len(jax_constraints.nodal)
 
-    dis_continuous = jax.jit(discretizer.get_solver(dynamics, settings))
-    dis_impulsive = jax.jit(get_impulsive_discretization_solver(dynamics_discrete))
+    # Accept either a bare ``jax.jit`` callable or a ``jax.export`` wrapper.
+    dis_continuous = dis_continuous.call if hasattr(dis_continuous, "call") else dis_continuous
+    dis_impulsive = dis_impulsive.call if hasattr(dis_impulsive, "call") else dis_impulsive
 
-    # Scaling matrices for the SCP convergence metrics (static, host-side).
+    # Scaling matrices for the SCP convergence / diagnostic metrics (static).
     inv_S_x = jnp.asarray(settings.sim.inv_S_x)
     inv_S_u = jnp.asarray(settings.sim.inv_S_u)
+
+    # Boundary types drive the candidate cost reduction (static, host-side).
+    final_type = list(settings.sim.x.final_type)
 
     # Node-0 prior recovery: fixed initial entries come from the boundary
     # condition, free entries from the iterate. The impulsive discretization
@@ -107,12 +158,16 @@ def make_scp_iteration(
     x_initial = jnp.asarray(np.asarray(settings.sim.x.initial, dtype=float))
 
     def _discretize(x: jnp.ndarray, u: jnp.ndarray, params: dict):
-        """Discretize ``(x, u)`` through both dynamics; return propagation pieces."""
-        A_d, B_d, C_d, x_prop, _ = dis_continuous(x, u, params)
+        """Discretize ``(x, u)`` through both dynamics; return propagation pieces.
+
+        Returns ``(A_d, B_d, C_d, x_prop, x_prop_plus, D_d, E_d, V, W)`` — ``V``
+        / ``W`` are the raw multi-shot matrices the history recorder unpacks.
+        """
+        A_d, B_d, C_d, x_prop, V = dis_continuous(x, u, params)
         x0_prior = jnp.where(init_fixed, x_initial, x[0])
         x_nodes_prior = jnp.concatenate([x0_prior[None, :], x_prop], axis=0)
-        x_prop_plus, D_d, E_d, _ = dis_impulsive(x_nodes_prior, u, params)
-        return A_d, B_d, C_d, x_prop, x_prop_plus, D_d, E_d
+        x_prop_plus, D_d, E_d, W = dis_impulsive(x_nodes_prior, u, params)
+        return A_d, B_d, C_d, x_prop, x_prop_plus, D_d, E_d, V, W
 
     def _linearize_constraints(x: jnp.ndarray, u: jnp.ndarray, params: dict):
         """Stack nodal / cross-node constraint values and gradients.
@@ -165,9 +220,21 @@ def make_scp_iteration(
 
         return nodal_g, nodal_grad_x, nodal_grad_u, cross_g, cross_grad_X, cross_grad_U
 
-    def iteration_fn(state: AlgorithmState, params: dict) -> AlgorithmState:
+    def _candidate_cost(x: jnp.ndarray) -> jnp.ndarray:
+        """Boundary-weighted reduction objective at the candidate's terminal node."""
+        cost = jnp.asarray(0.0)
+        for i, bc_type in enumerate(final_type):
+            if bc_type == "Minimize":
+                cost = cost + x[-1, i]
+            elif bc_type == "Maximize":
+                cost = cost - x[-1, i]
+        return cost
+
+    def iteration_fn(
+        state: AlgorithmState, params: dict
+    ) -> Tuple[AlgorithmState, IterationDiagnostics]:
         # 1–2. Discretize the current iterate for the subproblem linearization.
-        A_d, B_d, C_d, x_prop, x_prop_plus, D_d, E_d = _discretize(state.x, state.u, params)
+        A_d, B_d, C_d, x_prop, x_prop_plus, D_d, E_d, _, _ = _discretize(state.x, state.u, params)
 
         # 3. Linearize the constraints about the current iterate.
         (
@@ -208,8 +275,9 @@ def make_scp_iteration(
         # 5. Solve the convex subproblem.
         solution = solver_callback(state, data)
 
-        # 6a. Discretize the candidate for the autotuner's propagation fields.
-        _, _, _, cand_x_prop, cand_x_prop_plus, _, _ = _discretize(
+        # 6a. Discretize the candidate for the autotuner's propagation fields
+        # and the history's raw discretization matrices.
+        _, _, _, cand_x_prop, cand_x_prop_plus, _, _, V_cand, W_cand = _discretize(
             solution.x, solution.u, params
         )
         candidate = CandidateIterate()
@@ -223,8 +291,10 @@ def make_scp_iteration(
         # virtual buffer), matching the legacy ``_subproblem`` reductions.
         tr_x = inv_S_x @ (solution.x - state.x).T
         tr_u = inv_S_u @ (solution.u - state.u).T
-        J_tr = jnp.sum(tr_x**2) + jnp.sum(tr_u**2)
-        J_vc = jnp.sum(jnp.abs(inv_S_x @ solution.nu.T))
+        TR = jnp.concatenate([tr_x, tr_u], axis=0)
+        VC = jnp.abs(inv_S_x @ solution.nu.T).T
+        J_tr = jnp.sum(TR**2)
+        J_vc = jnp.sum(VC)
         J_vb = jnp.sum(jnp.maximum(0.0, solution.nu_vb)) + jnp.sum(
             jnp.maximum(0.0, solution.nu_vb_cross)
         )
@@ -236,20 +306,29 @@ def make_scp_iteration(
 
         # 6c. Autotuner: pure functional update producing the next iterate.
         next_state = autotuner.update_weights(state, candidate, jax_constraints, settings, params)
-        return next_state.replace(k=state.k + 1)
+        next_state = next_state.replace(k=state.k + 1)
+
+        diagnostics = IterationDiagnostics(
+            cost=_candidate_cost(solution.x),
+            status=solution.status_code,
+            J_lin=solution.cost,
+            V=V_cand,
+            W=W_cand,
+            TR=TR,
+            VC=VC,
+        )
+        return next_state, diagnostics
 
     return iteration_fn
 
 
-def _converged(
-    state: AlgorithmState, ep_tr: float, ep_vb: float, ep_vc: float
-) -> jnp.ndarray:
+def _converged(state: AlgorithmState, ep_tr: float, ep_vb: float, ep_vc: float) -> jnp.ndarray:
     """Boolean SCP convergence test from the metrics on ``state``."""
     return (state.J_tr < ep_tr) & (state.J_vb < ep_vb) & (state.J_vc < ep_vc)
 
 
 def make_solve_loop(
-    iteration_fn: Callable[[AlgorithmState, dict], AlgorithmState],
+    iteration_fn: Callable[[AlgorithmState, dict], Tuple[AlgorithmState, IterationDiagnostics]],
     ep_tr: float,
     ep_vb: float,
     ep_vc: float,
@@ -259,9 +338,12 @@ def make_solve_loop(
 
     The loop runs ``iteration_fn`` until either the SCP metrics fall below the
     ``ep_*`` thresholds or the iteration counter ``state.k`` exceeds ``k_max`` —
-    matching the Python ``while`` loop in ``Problem.solve()``. It exists as a
-    primitive for tests and the future JAX-pure ``.solve()`` path; the public
-    ``Problem.solve()`` continues to drive ``iteration_fn`` from Python.
+    matching the Python ``while`` loop in ``Problem.solve()``. The per-iteration
+    :class:`IterationDiagnostics` are projected away so the loop carry stays
+    ``state -> state`` (XLA dead-code-eliminates their host-only pieces). It
+    exists as a primitive for tests and the future JAX-pure ``.solve()`` path;
+    the public ``Problem.solve()`` continues to drive ``iteration_fn`` from
+    Python.
 
     Args:
         iteration_fn: A body built by :func:`make_scp_iteration`.
@@ -277,7 +359,8 @@ def make_solve_loop(
             return (state.k <= k_max) & jnp.logical_not(_converged(state, ep_tr, ep_vb, ep_vc))
 
         def body(state: AlgorithmState) -> AlgorithmState:
-            return iteration_fn(state, params)
+            next_state, _ = iteration_fn(state, params)
+            return next_state
 
         return jax.lax.while_loop(cond, body, state)
 

--- a/openscvx/algorithms/scvx/penalized_trust_region.py
+++ b/openscvx/algorithms/scvx/penalized_trust_region.py
@@ -9,11 +9,10 @@ import warnings
 from typing import TYPE_CHECKING, Callable, Dict, List, Tuple, Union
 
 import jax
-import jax.numpy as jnp
 import numpy as np
-import numpy.linalg as la
 
 from openscvx.config import Config
+from openscvx.solvers.ptr_solver import StatusCode, status_code_to_str
 from openscvx.utils.printing import (
     Column,
     Verbosity,
@@ -37,7 +36,6 @@ from ..weights import Weights
 
 if TYPE_CHECKING:
     from openscvx.lowered import LoweredJaxConstraints
-    from openscvx.solvers import ConvexSolver
     from openscvx.symbolic.expr.control import Control
     from openscvx.symbolic.expr.state import State
 
@@ -107,34 +105,12 @@ class PenalizedTrustRegion(Algorithm):
         controls: List["Control"] = None,
     ):
         """Initialize PTR with algorithm parameters and optional autotuner."""
-        # Compiled infrastructure (set by initialize())
-        self._solver: "ConvexSolver" = None
-        self._discretization_solver: callable = None
-        self._discretization_solver_impulsive: callable = None
+        # Compiled infrastructure (set by initialize()). ``_iteration_fn`` is
+        # the fused JAX-pure SCP body; ``step()`` is a thin Python wrapper that
+        # calls it, records history, and emits.
+        self._iteration_fn: Callable | None = None
         self._jax_constraints: "LoweredJaxConstraints" = None
         self._emitter: callable = None
-        # The three private fields below — ``_jit_update_weights``,
-        # ``_iter_index``, ``_last_scalars`` — are scaffolding for the
-        # Python-driven SCP loop: they keep the inner JIT cache stable and
-        # dodge per-iteration host/device syncs. Removable once the SCP loop
-        # body is a single JAX trace.
-        #
-        # JIT'd autotuner step (built lazily in initialize() to fuse the
-        # hundreds of small jnp ops in `update_weights` into a single dispatch
-        # per iteration). Captures `nodal_constraints`, `settings`, `weights`
-        # as closure constants — they don't change within a solve.
-        self._jit_update_weights: Callable | None = None
-
-        # Python-side mirror of ``state.k``. Kept in lockstep with the pytree
-        # field so the Python loop can read the iteration index without a
-        # ``int(state.k)`` device sync each step.
-        self._iter_index: int = 1
-
-        # Host-side cache of the diagnostic scalars produced by the last
-        # ``step()`` call. ``record_iteration`` pulls these in one coalesced
-        # ``jax.device_get`` and stashes them here so external readers
-        # (``problem.step()``'s return dict) don't re-sync per iteration.
-        self._last_scalars: dict = {}
 
         # Autotuner
         self.autotuner: "AutotuningBase" = (
@@ -161,70 +137,6 @@ class PenalizedTrustRegion(Algorithm):
         self.ep_tr = ep_tr
         self.ep_vb = ep_vb
         self.ep_vc = ep_vc
-
-    @staticmethod
-    def _invoke_solver(solver: callable, *args):
-        """Call either a compiled solver wrapper (.call) or a plain callable."""
-        if hasattr(solver, "call"):
-            return solver.call(*args)
-        return solver(*args)
-
-    def _build_jit_update_weights(
-        self,
-        jax_constraints: "LoweredJaxConstraints",
-        settings: Config,
-    ) -> Callable:
-        """Compile a JIT'd autotuner step bound to the current solve context.
-
-        ``update_weights`` issues hundreds of small ``jnp`` ops on per-iterate
-        scalars and arrays; outside ``jax.jit`` each one round-trips through
-        the dispatcher. Folding them into a single compiled function gives an
-        order-of-magnitude wall-clock improvement per SCP iteration.
-
-        Closure captures ``jax_constraints`` / ``settings`` only: they're fixed
-        for the duration of a solve and contain non-pytree leaves (dataclasses
-        of compiled closures, pydantic config) that JAX cannot route through
-        positional arguments. The autotuners' reset weights live on
-        ``state.lam_cost_init``, so weight mutations between solves propagate
-        through the pytree without rebuilding the closure.
-
-        Removable once the SCP loop body is a single JAX trace — the loop-level
-        JIT subsumes this inner one and the dict ↔ ``CandidateIterate`` adapter
-        below can be deleted along with the duplicate adapter in ``step()``.
-        """
-        autotuner = self.autotuner
-
-        def fn(state, candidate_dict, params):
-            cand = CandidateIterate()
-            cand.x = candidate_dict["x"]
-            cand.u = candidate_dict["u"]
-            cand.x_prop = candidate_dict["x_prop"]
-            cand.x_prop_plus = candidate_dict["x_prop_plus"]
-            cand.J_lin = candidate_dict["J_lin"]
-            return autotuner.update_weights(state, cand, jax_constraints, settings, params)
-
-        return jax.jit(fn)
-
-    @staticmethod
-    def _block_until_ready_outputs(outputs: Tuple[object, ...]) -> None:
-        """Finish any pending XLA work from discretization exports (warm-up helper).
-
-        Removable once the SCP loop body is a single JAX trace — the warm-up
-        path goes away with it.
-        """
-        jax.block_until_ready(outputs)
-
-    def _recover_prior_node_from_initial(
-        self,
-        settings: Config,
-        x0_fallback: np.ndarray,
-    ) -> np.ndarray:
-        """Build node-0 prior state from initial conditions (fixed entries exact)."""
-        x0_prior = np.asarray(x0_fallback, dtype=float).reshape(-1).copy()
-        x0_init = np.asarray(settings.sim.x.initial, dtype=float).reshape(-1)
-        is_fixed = np.asarray(settings.sim.x.initial_type) == "Fix"
-        x0_prior[is_fixed] = x0_init[is_fixed]
-        return x0_prior.reshape(1, -1)
 
     @property
     def lam_prox(self) -> Union[float, np.ndarray]:
@@ -265,118 +177,22 @@ class PenalizedTrustRegion(Algorithm):
 
     def initialize(
         self,
-        solver: "ConvexSolver",
-        discretization_solver: callable,
-        jax_constraints: "LoweredJaxConstraints",
+        iteration_fn: Callable,
         emitter: callable,
-        params: dict,
+        jax_constraints: "LoweredJaxConstraints",
         settings: Config,
-        discretization_solver_impulsive: Callable[..., object] | None = None,
     ) -> None:
-        """Initialize PTR and warm up the compiled infrastructure."""
-        self._solver = solver
-        self._discretization_solver = discretization_solver
-        self._discretization_solver_impulsive = discretization_solver_impulsive
-        self._jax_constraints = jax_constraints
+        """Store the fused SCP iteration body and per-iteration infrastructure.
+
+        ``iteration_fn`` is built and JIT-warmed by :meth:`Problem.initialize`;
+        :meth:`step` is a thin Python wrapper that calls it, records history,
+        and emits diagnostics. The boundary conditions the subproblem pins are
+        carried on :class:`AlgorithmState` (``x_init_pin`` / ``x_term_pin``), so
+        there is no solver state to prime here.
+        """
+        self._iteration_fn = iteration_fn
         self._emitter = emitter
-        # Cheap autotuners (ConstantProximalWeight / RampProximalWeight) opt out
-        # of the JIT wrapper via ``JIT_UPDATE_WEIGHTS=False`` on the class: their
-        # bodies are a handful of ``jnp`` ops, and JAX's eager dispatch is cheaper
-        # than the pytree-flatten / dict-pack overhead the JIT'd closure adds.
-        if self.autotuner.JIT_UPDATE_WEIGHTS:
-            self._jit_update_weights = self._build_jit_update_weights(jax_constraints, settings)
-        else:
-            self._jit_update_weights = None
-        self._iter_index = 1
-
-        self._solver.update_boundary_conditions(
-            x_init=settings.sim.x.initial,
-            x_term=settings.sim.x.final,
-        )
-
-        # Throwaway state/history for warm-up only.
-        init_state = AlgorithmState.from_settings(settings, self.weights)
-        init_history = AlgorithmHistory.from_settings(settings)
-
-        # Warm up the dynamics discretization on the initial guess.
-        x_init = np.asarray(init_state.x)
-        u_init = np.asarray(init_state.u, dtype=float)
-        _, _, _, x_prop, V_multi_shoot = self._invoke_solver(
-            self._discretization_solver, x_init, u_init, params
-        )
-        init_history.add_discretization(V_multi_shoot.__array__())
-        slice_imp = settings.sim.u.slice_impulsive
-        has_impulsive = bool(slice_imp.stop > slice_imp.start)
-        if has_impulsive and self._discretization_solver_impulsive is not None:
-            x0_prior = self._recover_prior_node_from_initial(settings, x_init[0])
-            x_nodes_prior = np.vstack((x0_prior, np.asarray(x_prop)))
-            _, _, _, W_multi_shoot = self._invoke_solver(
-                self._discretization_solver_impulsive,
-                x_nodes_prior,
-                u_init,
-                params,
-            )
-            init_history.add_impulsive_discretization(W_multi_shoot.__array__())
-
-        # Warm up the subproblem solver (DPP cache, JAX jacobians).
-        (x_sol, u_sol, *_) = self._subproblem(params, init_state, init_history, settings)
-
-        # Prime the post-CVX discretization path so the first real step() does
-        # not pay an XLA cache miss on (x_sol, u_sol).
-        cont_out = self._invoke_solver(
-            self._discretization_solver, x_sol, u_sol.astype(float), params
-        )
-        x_prop_c = cont_out[3]
-        u_candidate = u_sol.astype(float)
-        x0_prior_c = self._recover_prior_node_from_initial(settings, x_sol[0])
-        x_nodes_prior_c = np.vstack((x0_prior_c, np.asarray(x_prop_c)))
-        if self._discretization_solver_impulsive is not None:
-            imp_out = self._invoke_solver(
-                self._discretization_solver_impulsive,
-                x_nodes_prior_c,
-                u_candidate,
-                params,
-            )
-            self._block_until_ready_outputs(cont_out + imp_out)
-        else:
-            self._block_until_ready_outputs(cont_out)
-
-        # Warm up the JIT'd autotuner step so the first real iteration pays
-        # only the cached-dispatch cost. We construct a dummy candidate from
-        # the warm-up subproblem result so the trace sees the actual array
-        # shapes. Eager-dispatch autotuners (``JIT_UPDATE_WEIGHTS=False``) skip
-        # this — there is no JIT cache to prime.
-        if self._jit_update_weights is not None:
-            if self._discretization_solver_impulsive is not None:
-                x_prop_plus_c = imp_out[0]
-            else:
-                x_prop_plus_c = jnp.zeros((settings.sim.n, settings.sim.n_states))
-            warm_candidate = {
-                "x": jnp.asarray(x_sol),
-                "u": jnp.asarray(u_sol),
-                "x_prop": jnp.asarray(x_prop_c),
-                "x_prop_plus": jnp.asarray(x_prop_plus_c),
-                "J_lin": jnp.asarray(0.0),
-            }
-            # Trace under both k=1 (INITIAL branch) and k>1 (acceptance-ratio
-            # branch) so neither path recompiles inside the SCP loop. The first
-            # warm-up traces against an uncommitted state (matching the iter-1
-            # input from ``AlgorithmState.from_settings``); the second traces
-            # against the *returned* state (committed, matching iter ≥ 2 where
-            # the state comes back from the JIT). Without this two-phase warm-
-            # up, JAX caches by argument committedness and the iter-2 dispatch
-            # misses.
-            #
-            # Removable once the SCP loop body is a single JAX trace — the
-            # entire warm-up block below becomes unnecessary.
-            warm_state = init_state.replace(
-                x_prop=jnp.asarray(x_prop_c),
-                x_prop_plus=jnp.asarray(x_prop_plus_c),
-            )
-            warm_out = self._jit_update_weights(warm_state, warm_candidate, params)
-            jax.block_until_ready(warm_out)
-            warm_state_k2 = warm_out.replace(k=jnp.asarray(2, dtype=jnp.int32))
-            jax.block_until_ready(self._jit_update_weights(warm_state_k2, warm_candidate, params))
+        self._jax_constraints = jax_constraints
 
     def step(
         self,
@@ -387,192 +203,69 @@ class PenalizedTrustRegion(Algorithm):
     ) -> Tuple[AlgorithmState, bool]:
         """Execute one PTR iteration and return ``(next_state, converged)``.
 
-        Discretizes the current iterate (on iter 1 only — subsequent iters
-        reuse the candidate discretization stored on history), solves the
-        convex subproblem, discretizes the candidate, hands everything to
-        the autotuner, records history, and emits diagnostics.
+        Calls the fused JAX iteration body, records the per-iteration
+        diagnostics it returns into ``history``, emits progress, and reports
+        convergence from the metrics on the next state.
         """
-        if self._solver is None:
+        if self._iteration_fn is None:
             raise RuntimeError(
                 "PenalizedTrustRegion.step() called before initialize(). "
-                "Call initialize() first to set up compiled infrastructure."
+                "Call initialize() first to set up the iteration body."
             )
 
-        x_state = np.asarray(state.x)
-        u_state = np.asarray(state.u, dtype=float)
+        iter_index = int(state.k)
 
-        # Parallel Python iteration counter. ``state.k`` is a jnp scalar; on
-        # tiny problems the ``int(state.k)`` cast dominates each step because
-        # it forces a CPU<->device sync. We track the same value as a Python
-        # int and only re-sync into ``state.k`` once per step.
-        iter_index = self._iter_index
-
-        # Iter 1: discretize the initial guess so the subproblem and the
-        # autotuner have something to linearize about. Subsequent iters
-        # reuse the candidate discretization from the previous iter.
-        if iter_index == 1:
-            t0 = time.time()
-            _, _, _, x_prop_init, V_multi_shoot = self._invoke_solver(
-                self._discretization_solver, x_state, u_state, params
-            )
-            x0_prior = self._recover_prior_node_from_initial(settings, x_state[0])
-            x_nodes_prior = np.vstack((x0_prior, np.asarray(x_prop_init)))
-            x_prop_plus_init, _, _, W_multi_shoot = self._invoke_solver(
-                self._discretization_solver_impulsive, x_nodes_prior, u_state, params
-            )
-            history.add_discretization(V_multi_shoot.__array__())
-            history.add_impulsive_discretization(W_multi_shoot.__array__())
-
-            # Mirror the discretization onto the state pytree so the autotuner
-            # can read it as the "previous iterate" propagation on iter 2. Keep
-            # the JAX arrays as-is (committed sharding) so the JIT cache hit
-            # established by the ``initialize()`` warm-up survives.
-            state = state.replace(
-                x_prop=x_prop_init,
-                x_prop_plus=x_prop_plus_init,
-            )
-            iter1_dis_time = time.time() - t0
-        else:
-            iter1_dis_time = 0.0
-
-        # Subproblem.
-        (
-            x_sol,
-            u_sol,
-            cost,
-            J_total,
-            J_vb_vec,
-            J_vc_vec,
-            J_tr_vec,
-            prob_stat,
-            subprop_time,
-            vc_mat,
-            tr_mat,
-        ) = self._subproblem(params, state, history, settings)
-
-        candidate = CandidateIterate()
-        candidate.x = x_sol
-        candidate.u = u_sol
-        candidate.J_lin = J_total
-
-        # Discretize candidate.
         t0 = time.time()
-        _, _, _, x_prop, V_multi_shoot = self._invoke_solver(
-            self._discretization_solver, candidate.x, candidate.u.astype(float), params
-        )
-        u_candidate = candidate.u.astype(float)
-        x0_prior = self._recover_prior_node_from_initial(settings, candidate.x[0])
-        x_nodes_prior = np.vstack((x0_prior, np.asarray(x_prop)))
-        x_prop_plus, D_d, E_d, W_multi_shoot = self._invoke_solver(
-            self._discretization_solver_impulsive, x_nodes_prior, u_candidate, params
-        )
-        dis_time = iter1_dis_time + (time.time() - t0)
+        next_state, diag = self._iteration_fn(state, params)
+        jax.block_until_ready((next_state, diag))
+        step_time = time.time() - t0
 
-        # V, W, D_d, E_d are consumed host-side by ``history.record_iteration``
-        # only — pull them off the device once here so the recorder doesn't have
-        # to. x_prop / x_prop_plus stay as JAX arrays: they flow straight back
-        # into the JIT'd autotuner closure, and round-tripping them through a
-        # numpy array would lose their committed sharding and miss the JIT cache
-        # established by the ``initialize()`` warm-up.
-        candidate.V = V_multi_shoot.__array__()
-        candidate.W = W_multi_shoot.__array__()
-        candidate.x_prop = x_prop
-        candidate.x_prop_plus = x_prop_plus
-        candidate.D_d = D_d.__array__()
-        candidate.E_d = E_d.__array__()
-        candidate.VC = vc_mat
-        candidate.TR = tr_mat
-
-        # Roll J_* scalars onto the pytree before the autotuner runs; the
-        # autotuner returns the next-iterate state, which we then thread back
-        # to history and the emitter. On the JIT path the values are strong-
-        # typed and committed (matching the rest of the pytree, which comes
-        # back from the JIT'd ``update_weights`` already committed) so the JIT
-        # cache key is stable across iterations.
-        #
-        # The numpy → float → jnp → device_put round-trip is removable once the
-        # SCP loop body is a single JAX trace; the J_* sums can then live on
-        # the pytree directly with no cache-key gymnastics.
-        if self._jit_update_weights is not None:
-            dev = state.x.sharding
-            state = state.replace(
-                J_tr=jax.device_put(
-                    jnp.asarray(float(np.sum(np.array(J_tr_vec))), dtype=state.J_tr.dtype), dev
-                ),
-                J_vb=jax.device_put(
-                    jnp.asarray(float(np.sum(np.array(J_vb_vec))), dtype=state.J_vb.dtype), dev
-                ),
-                J_vc=jax.device_put(
-                    jnp.asarray(float(np.sum(np.array(J_vc_vec))), dtype=state.J_vc.dtype), dev
-                ),
+        # Fail loudly on a bad subproblem solve before it becomes the next
+        # linearization point. Two gates: a non-OPTIMAL status from the backend
+        # (e.g. QPAX divergence, CVXPy infeasibility) and a non-finite iterate
+        # (NaN/Inf from anywhere in the body). Either would silently corrupt the
+        # rest of the SCP run.
+        if int(diag.status) != int(StatusCode.OPTIMAL):
+            raise RuntimeError(
+                f"Convex subproblem did not solve to optimality "
+                f"(status={status_code_to_str(int(diag.status))!r}). The backend failed "
+                f"to converge or the subproblem is infeasible — adjust solver tolerances, "
+                f"rescale the problem, or use float_dtype='float64'."
+            )
+        if not bool(np.all(np.isfinite(np.asarray(next_state.x)))):
+            raise RuntimeError(
+                "Subproblem solve produced a non-finite iterate (NaN/Inf in the state)."
             )
 
-            # Autotuner: pure functional update on the pytree. We dispatch
-            # through the JIT'd closure built in initialize() so the hundreds
-            # of small jnp ops inside `update_weights` fuse into a single
-            # compiled call. The candidate is bounced through a dict because
-            # `CandidateIterate` is a mutable dataclass not registered as a JAX
-            # pytree. Match the JIT-closure trace signature established in
-            # initialize()'s warm-up: pre-converted JAX f32 arrays for the
-            # array leaves and a weak-typed jnp scalar for J_lin. CVXPy
-            # returns x/u as f64 numpy and J_lin as a Python float; passing
-            # them raw would miss the warm-up's cache key (f32/strong vs
-            # f64/weak). x_prop / x_prop_plus already come off the JAX
-            # discretizer with committed sharding — keep them as-is.
-            #
-            # Removable once the SCP loop body is a single JAX trace:
-            # ``candidate`` flows in as a registered pytree and the dict
-            # adapter (duplicated in ``_build_jit_update_weights``)
-            # disappears along with the wrapping JIT.
-            candidate_dict = {
-                "x": jnp.asarray(candidate.x),
-                "u": jnp.asarray(candidate.u),
-                "x_prop": candidate.x_prop,
-                "x_prop_plus": candidate.x_prop_plus,
-                "J_lin": jnp.asarray(float(candidate.J_lin)),
-            }
-            state = self._jit_update_weights(state, candidate_dict, params)
-        else:
-            # Eager-dispatch path for cheap autotuners (a few jnp ops; the
-            # JIT'd closure's pytree-flatten overhead would dominate). Skip
-            # the JIT-cache-stability gymnastics: the J_* fields are written
-            # as plain jnp scalars (``record_iteration`` pulls them off the
-            # device in a single coalesced ``jax.device_get`` either way), the
-            # candidate stays a ``CandidateIterate`` (no dict pack), and
-            # ``update_weights`` is called directly.
-            state = state.replace(
-                J_tr=jnp.asarray(np.sum(np.asarray(J_tr_vec)), dtype=state.J_tr.dtype),
-                J_vb=jnp.asarray(np.sum(np.asarray(J_vb_vec)), dtype=state.J_vb.dtype),
-                J_vc=jnp.asarray(np.sum(np.asarray(J_vc_vec)), dtype=state.J_vc.dtype),
-            )
-            state = self.autotuner.update_weights(
-                state, candidate, self._jax_constraints, settings, params
-            )
+        # Recompose the host-side candidate from the JAX diagnostics for the
+        # history recorder: it reads the accepted iterate off ``next_state`` and
+        # the raw discretization / trust-region / virtual-control matrices off
+        # the candidate.
+        candidate = CandidateIterate()
+        candidate.V = np.asarray(diag.V)
+        candidate.W = np.asarray(diag.W)
+        candidate.VC = np.asarray(diag.VC)
+        candidate.TR = np.asarray(diag.TR)
+        candidate.J_lin = float(diag.J_lin)
 
-        # History bookkeeping (Python-side, never traced). The recorder
-        # transfers everything it needs (diagnostic scalars, weight arrays,
-        # adaptive-state code) off the device in one coalesced
-        # ``jax.device_get`` so we only pay one CPU<->device synchronization
-        # per iteration, no matter how many fields it reads.
         use_full_metrics = not isinstance(
             self.autotuner, (ConstantProximalWeight, RampProximalWeight)
         )
         scalars, lam_prox_np = history.record_iteration(
-            state, candidate, record_diagnostics=use_full_metrics
+            next_state, candidate, record_diagnostics=use_full_metrics
         )
-        self._last_scalars = scalars
 
         emission_data = {
             "iter": iter_index,
-            "dis_time": dis_time * 1000.0,
-            "subprop_time": subprop_time * 1000.0,
+            "dis_time": 0.0,
+            "subprop_time": step_time * 1000.0,
             "J_tr": scalars["J_tr"],
             "J_vb": scalars["J_vb"],
             "J_vc": scalars["J_vc"],
-            "cost": cost[-1],
+            "cost": float(diag.cost),
             # TODO: (haynec) log per-variable lam_prox detail (e.g. min/max range)
             "lam_prox": float(np.max(lam_prox_np)),
-            "prob_stat": prob_stat,
+            "prob_stat": status_code_to_str(int(diag.status)),
             "adaptive_state": adaptive_state_code_to_str(scalars["adaptive_state_code"]),
             "ep_tr": self.ep_tr,
             "ep_vb": self.ep_vb,
@@ -583,7 +276,7 @@ class PenalizedTrustRegion(Algorithm):
             emission_data.update(
                 {
                     "J_nonlin": scalars["J_nonlin"],
-                    "J_lin": float(candidate.J_lin),
+                    "J_lin": float(diag.J_lin),
                     "pred_reduction": scalars["predicted_reduction"],
                     "actual_reduction": scalars["actual_reduction"],
                     "acceptance_ratio": scalars["acceptance_ratio"],
@@ -592,169 +285,12 @@ class PenalizedTrustRegion(Algorithm):
 
         self._emitter(emission_data)
 
-        # Advance the Python iteration mirror and bump ``state.k`` so external
-        # readers (``problem.py``'s loop, ``OptimizationResults.scp_k``) stay
-        # in sync. ``state.k + 1`` dispatches a JIT'd add — compiled once at
-        # iter 1 (~10 ms one-time) and then a cheap kernel; doing this on the
-        # device keeps the result committed and matches the rest of the pytree
-        # so the autotuner's cache key is stable.
-        self._iter_index = iter_index + 1
-        state = state.replace(k=state.k + 1)
-
         converged = (
             (scalars["J_tr"] < self.ep_tr)
             and (scalars["J_vb"] < self.ep_vb)
             and (scalars["J_vc"] < self.ep_vc)
         )
-        return state, converged
-
-    def _subproblem(
-        self,
-        params: dict,
-        state: AlgorithmState,
-        history: AlgorithmHistory,
-        settings: Config,
-    ):
-        """Solve a single convex subproblem against the latest linearization.
-
-        Reads the dynamics linearization from ``history.discretizations[-1]``
-        and the iterate / weight values from ``state``.
-        """
-        param_dict = params
-
-        x_bar = np.asarray(state.x)
-        u_bar = np.asarray(state.u)
-
-        self._solver.update_dynamics_linearization(
-            x_bar=x_bar,
-            u_bar=u_bar,
-            A_d=history.A_d(),
-            B_d=history.B_d(),
-            C_d=history.C_d(),
-            x_prop=history.x_prop(),
-            x_prop_plus=history.x_prop_plus(),
-            D_d=history.D_d(),
-            E_d=history.E_d(),
-        )
-
-        nodal_linearizations = []
-        if self._jax_constraints.nodal:
-            for constraint in self._jax_constraints.nodal:
-                g_full = np.asarray(constraint.func(x_bar, u_bar, 0, param_dict))
-                grad_g_x_full = np.asarray(constraint.grad_g_x(x_bar, u_bar, 0, param_dict))
-                grad_g_u_full = np.asarray(constraint.grad_g_u(x_bar, u_bar, 0, param_dict))
-
-                g_full = np.squeeze(g_full)
-                if g_full.ndim == 0:
-                    g_full = np.broadcast_to(g_full, (x_bar.shape[0],))
-                elif g_full.ndim > 1:
-                    g_full = g_full.reshape(g_full.shape[0], -1).sum(axis=1)
-
-                if grad_g_x_full.ndim == 1:
-                    grad_g_x_full = np.broadcast_to(
-                        grad_g_x_full, (x_bar.shape[0], grad_g_x_full.shape[0])
-                    )
-                elif grad_g_x_full.ndim > 2:
-                    grad_g_x_full = grad_g_x_full.reshape(grad_g_x_full.shape[0], -1)
-                    n_x = x_bar.shape[1]
-                    if grad_g_x_full.shape[1] > n_x:
-                        grad_g_x_full = grad_g_x_full[:, :n_x]
-
-                if grad_g_u_full.ndim == 1:
-                    grad_g_u_full = np.broadcast_to(
-                        grad_g_u_full, (u_bar.shape[0], grad_g_u_full.shape[0])
-                    )
-                elif grad_g_u_full.ndim > 2:
-                    grad_g_u_full = grad_g_u_full.reshape(grad_g_u_full.shape[0], -1)
-                    n_u = u_bar.shape[1]
-                    if grad_g_u_full.shape[1] > n_u:
-                        grad_g_u_full = grad_g_u_full[:, :n_u]
-
-                nodal_linearizations.append(
-                    {
-                        "g": g_full,
-                        "grad_g_x": grad_g_x_full,
-                        "grad_g_u": grad_g_u_full,
-                    }
-                )
-
-        cross_node_linearizations = []
-        if self._jax_constraints.cross_node:
-            for constraint in self._jax_constraints.cross_node:
-                cross_node_linearizations.append(
-                    {
-                        "g": np.asarray(constraint.func(x_bar, u_bar, param_dict)),
-                        "grad_g_X": np.asarray(constraint.grad_g_X(x_bar, u_bar, param_dict)),
-                        "grad_g_U": np.asarray(constraint.grad_g_U(x_bar, u_bar, param_dict)),
-                    }
-                )
-
-        self._solver.update_constraint_linearizations(
-            nodal=nodal_linearizations if nodal_linearizations else None,
-            cross_node=cross_node_linearizations if cross_node_linearizations else None,
-        )
-
-        self._solver.update_penalties(
-            lam_prox=np.asarray(state.lam_prox),
-            lam_cost=np.asarray(state.lam_cost),
-            lam_vc=np.asarray(state.lam_vc),
-            lam_vb_nodal=np.asarray(state.lam_vb_nodal),
-            lam_vb_cross=np.asarray(state.lam_vb_cross),
-        )
-        self._solver.update_proximal_terms()
-
-        t0 = time.time()
-        result = self._solver.solve()
-        subprop_time = time.time() - t0
-
-        x_new_guess = result.x
-        u_new_guess = result.u
-
-        costs = [0]
-        for i, bc_type in enumerate(settings.sim.x.final_type):
-            if bc_type == "Minimize":
-                costs += x_new_guess[:, i]
-            elif bc_type == "Maximize":
-                costs -= x_new_guess[:, i]
-
-        inv_block_diag = np.block(
-            [
-                [
-                    settings.sim.inv_S_x,
-                    np.zeros((settings.sim.inv_S_x.shape[0], settings.sim.inv_S_u.shape[1])),
-                ],
-                [
-                    np.zeros((settings.sim.inv_S_u.shape[0], settings.sim.inv_S_x.shape[1])),
-                    settings.sim.inv_S_u,
-                ],
-            ]
-        )
-
-        tr_mat = inv_block_diag @ np.hstack((x_new_guess - x_bar, u_new_guess - u_bar)).T
-        J_tr_vec = la.norm(tr_mat, axis=0) ** 2
-        vc_mat = np.abs(settings.sim.inv_S_x @ result.nu.T).T
-        J_vc_vec = np.sum(vc_mat, axis=1)
-
-        J_vb_vec = 0
-        for nu_vb_arr in result.nu_vb:
-            J_vb_vec += np.maximum(0, nu_vb_arr)
-
-        for nu_vb_cross_val in result.nu_vb_cross:
-            J_vb_vec += np.maximum(0, nu_vb_cross_val)
-
-        return (
-            x_new_guess,
-            u_new_guess,
-            costs,
-            result.cost,
-            J_vb_vec,
-            J_vc_vec,
-            J_tr_vec,
-            result.status,
-            subprop_time,
-            vc_mat,
-            tr_mat,
-        )
+        return next_state, converged
 
     def citation(self) -> List[str]:
         """Return BibTeX citations for the PTR algorithm."""

--- a/openscvx/problem.py
+++ b/openscvx/problem.py
@@ -790,9 +790,7 @@ class Problem:
         # Generate discretization solvers via the discretizer (handles Jacobians
         # + vmapping). These are locals: they're captured by the fused
         # ``iteration_fn`` closure below, not stored on the problem.
-        discretization_solver = self._discretizer.get_solver(
-            self._lowered.dynamics, self.settings
-        )
+        discretization_solver = self._discretizer.get_solver(self._lowered.dynamics, self.settings)
         discretization_solver_impulsive = get_impulsive_discretization_solver(
             self._lowered.dynamics_discrete
         )

--- a/openscvx/problem.py
+++ b/openscvx/problem.py
@@ -32,6 +32,7 @@ from openscvx.algorithms import (
     OptimizationResults,
     PenalizedTrustRegionConfig,
 )
+from openscvx.algorithms.scvx.iteration import make_scp_iteration
 from openscvx.config import (
     Config,
     DevConfig,
@@ -365,8 +366,8 @@ class Problem:
         if isinstance(time, Time):
             self.settings.sim._uniform_time_grid = time.uniform_time_grid
 
-        self._discretization_solver: callable = None
-        self._discretization_solver_impulsive: callable = None
+        # Fused JAX-pure SCP iteration body (built in initialize()).
+        self._iteration_fn: callable = None
 
         # Set up emitter & queue (thread started in initialize() after columns are known)
         if self.settings.dev.printing:
@@ -786,11 +787,13 @@ class Problem:
             ctcs=self._lowered.jax_constraints.ctcs,  # CTCS aren't JIT-compiled here
         )
 
-        # Generate discretization solver via the discretizer (handles Jacobians + vmapping)
-        self._discretization_solver = self._discretizer.get_solver(
+        # Generate discretization solvers via the discretizer (handles Jacobians
+        # + vmapping). These are locals: they're captured by the fused
+        # ``iteration_fn`` closure below, not stored on the problem.
+        discretization_solver = self._discretizer.get_solver(
             self._lowered.dynamics, self.settings
         )
-        self._discretization_solver_impulsive = get_impulsive_discretization_solver(
+        discretization_solver_impulsive = get_impulsive_discretization_solver(
             self._lowered.dynamics_discrete
         )
         self._propagation_solver = get_propagation_solver(
@@ -818,9 +821,10 @@ class Problem:
             byof=self._byof,
         )
 
-        # Compile the discretization solver
-        self._discretization_solver = load_or_compile_discretization_solver(
-            self._discretization_solver,
+        # Compile the discretization solver (``jax.jit`` for the no-disk path,
+        # ``jax.export`` when ``save_compiled``). Local — captured by iteration_fn.
+        discretization_solver = load_or_compile_discretization_solver(
+            discretization_solver,
             dis_solver_file,
             self._parameters,  # Plain dict for JAX
             self.settings.sim.n,
@@ -832,12 +836,11 @@ class Problem:
 
         # Compile the impulsive/discrete discretization solver with the same pipeline.
         # This solver is evaluated on node-wise inputs (x_nodes, u_nodes), shape (N, ...).
-        # if has_impulsive and self._discretization_solver_impulsive is not None:
         dis_imp_solver_file = dis_solver_file.with_name(
             f"{dis_solver_file.stem}_impulsive{dis_solver_file.suffix}"
         )
-        self._discretization_solver_impulsive = load_or_compile_discretization_solver(
-            self._discretization_solver_impulsive,
+        discretization_solver_impulsive = load_or_compile_discretization_solver(
+            discretization_solver_impulsive,
             dis_imp_solver_file,
             self._parameters,  # Plain dict for JAX
             self.settings.sim.n,
@@ -878,17 +881,34 @@ class Problem:
             n_byof_cross=n_byof_cross,
         )
 
-        # Initialize the SCP algorithm
+        # Build the fused JAX-pure SCP iteration body: it discretizes, linearizes
+        # the constraints, solves the convex subproblem (via the backend's
+        # iteration_callback), and folds the result through the autotuner — one
+        # JIT'd call per SCP step in place of the old NumPy↔JAX stitching.
         print("Initializing the SCvx Subproblem Solver...")
-        self._algorithm.initialize(
-            self._solver,
-            self._discretization_solver,
-            self._compiled_constraints,
-            self.emitter_function,
-            self._parameters,  # For warm-start only
-            self.settings,  # For warm-start only
-            discretization_solver_impulsive=self._discretization_solver_impulsive,
+        self._iteration_fn = jax.jit(
+            make_scp_iteration(
+                dis_continuous=discretization_solver,
+                dis_impulsive=discretization_solver_impulsive,
+                jax_constraints=self._compiled_constraints,
+                solver_callback=self._solver.iteration_callback(),
+                autotuner=self._algorithm.autotuner,
+                settings=self.settings,
+            )
         )
+        self._algorithm.initialize(
+            self._iteration_fn,
+            self.emitter_function,
+            self._compiled_constraints,
+            self.settings,
+        )
+
+        # Warm the JIT cache so the first ``.solve()`` doesn't pay the compile
+        # cost. A single concrete call populates ``jax.jit``'s shape-keyed cache;
+        # subsequent bare calls hit it (and a future vmap retraces to batched
+        # shapes the first time, same as if no warmup had happened).
+        warmup_state = AlgorithmState.from_settings(self.settings, self._algorithm.weights)
+        jax.block_until_ready(self._iteration_fn(warmup_state, self._parameters))
         print("✓ SCvx Subproblem Solver initialized")
 
         # Get columns from algorithm (now that autotuner is set) and start print thread
@@ -964,16 +984,6 @@ class Problem:
         self._state = AlgorithmState.from_settings(self.settings, self._algorithm.weights)
         self._history = AlgorithmHistory.from_settings(self.settings)
 
-        # Re-seed the algorithm's host-side iteration mirror so it matches
-        # ``state.k == 1`` for the next solve. The hasattr-guarded probe is
-        # itself scaffolding — ``Problem`` reaching into private fields of
-        # ``PenalizedTrustRegion`` to dodge per-iteration device syncs.
-        # Removable once the SCP loop body is a single JAX trace.
-        if hasattr(self._algorithm, "_iter_index"):
-            self._algorithm._iter_index = 1
-        if hasattr(self._algorithm, "_last_scalars"):
-            self._algorithm._last_scalars = {}
-
         # Reset solution
         self._solution = None
         self._solution_history = None
@@ -1012,21 +1022,14 @@ class Problem:
             self.settings,  # May change between steps
         )
 
-        # Pull k and the J scalars from the algorithm's host-side mirror set
-        # by ``record_iteration``; avoids a per-step device sync. ``dict.get``
-        # with a fallback would evaluate the default eagerly (a host-device
-        # round-trip on every iteration), so branch on presence explicitly.
-        # Removable once the SCP loop body is a single JAX trace — the mirror
-        # and the per-step sync it avoids go away together.
-        scalars = getattr(self._algorithm, "_last_scalars", None) or {}
+        # ``state.k`` is bumped to ``k + 1`` inside ``step()``; the J scalars on
+        # the returned state are the metrics for the iteration just completed.
         return {
             "converged": converged,
-            # ``_iter_index`` was bumped to ``k + 1`` at the end of ``step()``,
-            # matching the post-increment value of ``state.k``.
-            "scp_k": self._algorithm._iter_index,
-            "scp_J_tr": scalars["J_tr"] if "J_tr" in scalars else float(self._state.J_tr),
-            "scp_J_vb": scalars["J_vb"] if "J_vb" in scalars else float(self._state.J_vb),
-            "scp_J_vc": scalars["J_vc"] if "J_vc" in scalars else float(self._state.J_vc),
+            "scp_k": int(self._state.k),
+            "scp_J_tr": float(self._state.J_tr),
+            "scp_J_vb": float(self._state.J_vb),
+            "scp_J_vc": float(self._state.J_vc),
         }
 
     def solve(
@@ -1056,7 +1059,7 @@ class Problem:
             self._compiled_dynamics_prop,
             self._compiled_constraints,
             self._solver,
-            self._discretization_solver,
+            self._iteration_fn,
             self._state,
         ]
         if any(r is None for r in required):
@@ -1073,12 +1076,11 @@ class Problem:
         k_max = max_iters if max_iters is not None else self._algorithm.k_max
         t_max = time_limit if time_limit is not None else self._algorithm.t_max
 
-        # Use the algorithm's Python-side iter mirror (kept in sync with
-        # ``state.k``) so the loop predicate doesn't force a device sync on
-        # every iteration.
-        # Removable once the SCP loop body is a single JAX trace — this whole
-        # Python while-loop is then replaced by a single ``lax.while_loop``.
-        while self._algorithm._iter_index <= k_max:
+        # ``state.k`` is the iteration counter (bumped inside each ``step()``).
+        # Plan 2 replaces this Python ``while`` with a single ``lax.while_loop``
+        # over ``make_solve_loop``; here it still drives ``iteration_fn`` step by
+        # step so the interactive / printing path is unchanged.
+        while int(self._state.k) <= k_max:
             result = self.step()
             if result["converged"] and not continuous:
                 break
@@ -1107,7 +1109,7 @@ class Problem:
         return self._format_result(
             self._state,
             self._history,
-            self._algorithm._iter_index <= k_max and not timed_out,
+            int(self._state.k) <= k_max and not timed_out,
         )
 
     def post_process(self) -> OptimizationResults:

--- a/openscvx/solvers/cvxpy_ptr_solver.py
+++ b/openscvx/solvers/cvxpy_ptr_solver.py
@@ -22,6 +22,7 @@ from openscvx.config import Config
 from .ptr_solver import (
     PTRSolver,
     PTRSolveResult,
+    StatusCode,
     SubproblemData,
     SubproblemSolution,
     status_str_to_code,
@@ -1154,12 +1155,42 @@ class CVXPyPTRSolver(PTRSolver):
                 lam_vb_nodal=np.asarray(data.lam_vb_nodal),
                 lam_vb_cross=np.asarray(data.lam_vb_cross),
             )
+            # Set the proximal-term parameter (``prox_c``) from the freshly
+            # updated penalties; the legacy ``_subproblem`` called this between
+            # ``update_penalties`` and ``solve``, and without it ``prox_c`` has
+            # no value on the first solve of a process.
+            self.update_proximal_terms()
             self.update_boundary_conditions(
                 x_init=_unmask_bc(data.x_init),
                 x_term=_unmask_bc(data.x_term),
             )
 
-            result = self.solve()
+            try:
+                result = self.solve()
+            except cp.error.SolverError:
+                # Infeasible / numerical failure. Surface it as a non-OPTIMAL
+                # status on a finite (zero) solution so the SCP loop fails
+                # loudly at the step() boundary, instead of the exception
+                # propagating through pure_callback as an opaque CpuCallback
+                # error.
+                return SubproblemSolution(
+                    x=jnp.zeros((N, n_x), dtype=f),
+                    u=jnp.zeros((N, n_u), dtype=f),
+                    nu=jnp.zeros((N - 1, n_x), dtype=f),
+                    nu_vb=jnp.zeros((N, n_nodal), dtype=f),
+                    nu_vb_cross=jnp.zeros((n_cross,), dtype=f),
+                    cost=jnp.asarray(0.0, dtype=f),
+                    status_code=jnp.asarray(int(StatusCode.INFEASIBLE), dtype=jnp.int32),
+                )
+
+            # ``optimal_inaccurate`` is a usable solution — the legacy path
+            # consumed it without error — so treat it as OPTIMAL; the step()
+            # status gate would otherwise reject the UNKNOWN it maps to.
+            code = (
+                StatusCode.OPTIMAL
+                if result.status == "optimal_inaccurate"
+                else status_str_to_code(result.status)
+            )
             return SubproblemSolution(
                 x=jnp.asarray(result.x, dtype=f),
                 u=jnp.asarray(result.u, dtype=f),
@@ -1180,7 +1211,7 @@ class CVXPyPTRSolver(PTRSolver):
                     dtype=f,
                 ),
                 cost=jnp.asarray(result.cost, dtype=f),
-                status_code=jnp.asarray(int(status_str_to_code(result.status)), dtype=jnp.int32),
+                status_code=jnp.asarray(int(code), dtype=jnp.int32),
             )
 
         def step(state, data: SubproblemData) -> SubproblemSolution:

--- a/openscvx/solvers/qpax_ptr_solver.py
+++ b/openscvx/solvers/qpax_ptr_solver.py
@@ -871,11 +871,13 @@ class QPAXPTRSolver(PTRSolver):
         once at :meth:`initialize` time. The closure is reusable across SCP
         iterations — only the ``SubproblemData`` pytree changes between calls.
 
-        ``qpax.solve_qp_primal`` is the differentiable primal-only variant of
-        ``qpax.solve_qp``. It returns only the primal ``z`` (no convergence
-        diagnostics), so the returned :class:`SubproblemSolution` reports
-        ``status_code = StatusCode.UNKNOWN`` unconditionally — the SCP
-        trust-region check catches divergence at the algorithm layer instead.
+        Uses ``qpax.solve_qp``, whose ``converged`` flag is mapped onto the
+        returned :class:`SubproblemSolution`'s ``status_code`` so the SCP loop
+        can fail loudly on a diverged solve. (``qpax.solve_qp_primal`` is the
+        reverse-mode-differentiable variant but exposes no convergence flag —
+        qpax cannot provide both at once, and reliable non-convergence
+        detection was chosen over differentiability here; see
+        ``plans/iteration-fn-primitive.md``.)
 
         The returned callable takes ``(state, data)``: ``state`` is the
         :class:`AlgorithmState` pytree, accepted for cross-backend signature
@@ -895,8 +897,10 @@ class QPAXPTRSolver(PTRSolver):
         def step(state, data: SubproblemData) -> SubproblemSolution:
             del state  # every input the QP needs already lives on ``data``.
             Q, q, A, b, G, h = self._assemble_qp_jax(data)
-            z = qpax.solve_qp_primal(Q, q, A, b, G, h, **solver_args)
-            return self._build_solution_jax(z, data)
+            z, _s, _z_dual, _y_dual, converged, _iters = qpax.solve_qp(
+                Q, q, A, b, G, h, **solver_args
+            )
+            return self._build_solution_jax(z, data, converged)
 
         return jax.jit(step)
 
@@ -1318,13 +1322,15 @@ class QPAXPTRSolver(PTRSolver):
         self,
         z: "jnp.ndarray",
         data: SubproblemData,
+        converged: "jnp.ndarray",
     ) -> SubproblemSolution:
         """Unpack a primal ``z`` into a :class:`SubproblemSolution` pytree.
 
         Mirrors :meth:`_unpack` but stays JAX-pure: returns scaled-to-physical
         trajectories, the collapsed ``(N, n_nodal)`` ``nu_vb`` layout, and a
-        ``status_code = UNKNOWN`` (``solve_qp_primal`` exposes no convergence
-        diagnostic — the SCP trust-region check is the gate).
+        ``status_code`` of ``OPTIMAL`` when ``qpax.solve_qp`` reported
+        convergence and the primal is finite, else ``UNKNOWN`` (which the SCP
+        loop turns into a hard failure).
         """
         L = self.layout
         N, n_x, n_u = L.N, L.n_x, L.n_u
@@ -1342,6 +1348,11 @@ class QPAXPTRSolver(PTRSolver):
 
         cost = self._reconstruct_cost_jax(z, data)
 
+        ok = jnp.logical_and(jnp.asarray(converged, dtype=bool), jnp.all(jnp.isfinite(z)))
+        status_code = jnp.where(
+            ok, jnp.int32(StatusCode.OPTIMAL), jnp.int32(StatusCode.UNKNOWN)
+        )
+
         return SubproblemSolution(
             x=x,
             u=u,
@@ -1349,7 +1360,7 @@ class QPAXPTRSolver(PTRSolver):
             nu_vb=nu_vb,
             nu_vb_cross=jnp.zeros((0,), dtype=f),
             cost=cost,
-            status_code=jnp.asarray(int(StatusCode.UNKNOWN), dtype=jnp.int32),
+            status_code=status_code,
         )
 
     def _reconstruct_cost_jax(

--- a/openscvx/solvers/qpax_ptr_solver.py
+++ b/openscvx/solvers/qpax_ptr_solver.py
@@ -1,14 +1,15 @@
 """JAX-native QP backend for the PTR convex subproblem.
 
 Assembles each SCP subproblem as a flat ``(Q, q, A, b, G, h)`` quadratic
-program and dispatches it to ``qpax.solve_qp``. This backend is the wedge
-toward an end-to-end JAX-differentiable SCP loop: ``qpax.solve_qp_primal``
-exposes a ``jax.custom_vjp`` rule that lets gradients flow through the QP via
-the implicit function theorem on the relaxed KKT system. The surrounding
-pipeline (discretizer, algorithm, parameter sync) still breaks out of JIT
-today; making it ``jit``-friendly is future work that turns this backend
-from "another solver" into "differentiable SCvx", and would also enable
-``jax.vmap`` batching across scenarios.
+program and dispatches it to ``qpax.solve_qp``. The JAX-pure
+:meth:`iteration_callback` path composes with ``jax.jit`` and ``jax.vmap``,
+which makes it the wedge toward batched, end-to-end-JAX SCvx. It uses
+``qpax.solve_qp`` for its reliable convergence flag rather than the
+``jax.custom_vjp``-differentiable ``qpax.solve_qp_primal``: qpax exposes one
+or the other, not both, and the SCP loop needs to fail loudly on a diverged
+solve (see :meth:`iteration_callback`). ``solve_qp_primal`` remains the seam
+toward a ``jax.grad``-differentiable loop — future work, see
+``plans/jax-pure-solve.md``.
 
 Scope
 -----
@@ -169,9 +170,10 @@ class QPAXPTRSolver(PTRSolver):
 
     The JAX-pure entry point :meth:`iteration_callback` performs the same
     ``assemble → solve → unpack`` cycle entirely on the JAX boundary using
-    ``qpax.solve_qp_primal`` — the ``jax.custom_vjp``-differentiable variant
-    — so the backend composes with ``jax.jit``, ``jax.vmap``, and
-    (downstream) ``jax.grad``.
+    ``qpax.solve_qp``, so the backend composes with ``jax.jit`` and
+    ``jax.vmap``. It is not reverse-mode differentiable: ``solve_qp`` carries
+    the convergence flag the SCP loop needs but no ``custom_vjp`` rule (see
+    :meth:`iteration_callback`).
 
     Scope:
         Supported — state/control box, dynamics linearization (continuous
@@ -310,7 +312,7 @@ class QPAXPTRSolver(PTRSolver):
 
         # JAX-side scaling diagonals for ``iteration_callback``. The dtype
         # tracks the global ``jax_enable_x64`` setting so the assembled
-        # ``(Q, q, A, b, G, h)`` lands in the dtype ``qpax.solve_qp_primal``
+        # ``(Q, q, A, b, G, h)`` lands in the dtype ``qpax.solve_qp``
         # expects.
         f = jnp.float64 if jax.config.read("jax_enable_x64") else jnp.float32
         self._S_x_diag_j = jnp.asarray(self._S_x_diag, dtype=f)
@@ -866,10 +868,10 @@ class QPAXPTRSolver(PTRSolver):
     def iteration_callback(self):
         """JAX-pure ``(state, SubproblemData) -> SubproblemSolution``.
 
-        Composes :meth:`_assemble_qp_jax` + ``qpax.solve_qp_primal`` +
-        :meth:`_unpack_jax` into a single ``@jax.jit``-decorated closure built
-        once at :meth:`initialize` time. The closure is reusable across SCP
-        iterations — only the ``SubproblemData`` pytree changes between calls.
+        Composes :meth:`_assemble_qp_jax` + ``qpax.solve_qp`` +
+        :meth:`_build_solution_jax` into a single ``@jax.jit``-decorated closure
+        built once at :meth:`initialize` time. The closure is reusable across
+        SCP iterations — only the ``SubproblemData`` pytree changes between calls.
 
         Uses ``qpax.solve_qp``, whose ``converged`` flag is mapped onto the
         returned :class:`SubproblemSolution`'s ``status_code`` so the SCP loop

--- a/openscvx/solvers/qpax_ptr_solver.py
+++ b/openscvx/solvers/qpax_ptr_solver.py
@@ -1351,9 +1351,7 @@ class QPAXPTRSolver(PTRSolver):
         cost = self._reconstruct_cost_jax(z, data)
 
         ok = jnp.logical_and(jnp.asarray(converged, dtype=bool), jnp.all(jnp.isfinite(z)))
-        status_code = jnp.where(
-            ok, jnp.int32(StatusCode.OPTIMAL), jnp.int32(StatusCode.UNKNOWN)
-        )
+        status_code = jnp.where(ok, jnp.int32(StatusCode.OPTIMAL), jnp.int32(StatusCode.UNKNOWN))
 
         return SubproblemSolution(
             x=x,

--- a/openscvx/utils/caching.py
+++ b/openscvx/utils/caching.py
@@ -108,6 +108,13 @@ def load_or_compile_discretization_solver(
 ) -> callable:
     """Load discretization solver from cache or compile and cache it.
 
+    The no-disk path (``save_compiled=False``, the default) returns a plain
+    ``jax.jit`` callable, which has a ``vmap`` batching rule and so composes
+    with ``jax.vmap(problem.solve)`` in the JAX-pure solve work. The disk-cached
+    path (``save_compiled=True``) returns a ``jax.export`` wrapper that
+    serializes to disk but, because ``call_exported`` has no ``vmap`` rule,
+    **cannot** be combined with ``jax.vmap(problem.solve)``.
+
     Args:
         discretization_solver: The solver function to compile
         cache_file: Path to cache file
@@ -115,27 +122,29 @@ def load_or_compile_discretization_solver(
         n_discretization_nodes: Number of discretization nodes
         n_states: Number of state variables
         n_controls: Number of control variables
-        save_compiled: Whether to save/load compiled solvers
+        save_compiled: Whether to save/load compiled solvers to/from disk
+            (``jax.export``); incompatible with ``jax.vmap(problem.solve)``.
         debug: Whether in debug mode (skip compilation)
 
     Returns:
-        Compiled discretization solver
+        Compiled discretization solver — a ``jax.jit`` callable (no-disk) or a
+        ``jax.export`` wrapper (disk-cached).
     """
     if debug:
         return discretization_solver
 
-    if save_compiled:
-        try:
-            with open(cache_file, "rb") as f:
-                serial_dis = f.read()
-            compiled_solver = export.deserialize(serial_dis)
-            print(f"✓ Loaded existing {name} discretization solver")
-            return compiled_solver
-        except FileNotFoundError:
-            print(f"Compiling {name} discretization solver...")
-
-    else:
+    if not save_compiled:
         print(f"Compiling {name} discretization solver (not saving/loading from disk)...")
+        return jax.jit(discretization_solver)
+
+    try:
+        with open(cache_file, "rb") as f:
+            serial_dis = f.read()
+        compiled_solver = export.deserialize(serial_dis)
+        print(f"✓ Loaded existing {name} discretization solver")
+        return compiled_solver
+    except FileNotFoundError:
+        print(f"Compiling {name} discretization solver...")
 
     # Pass parameters as a single dictionary
     compiled_solver = export.export(jax.jit(discretization_solver))(
@@ -144,10 +153,9 @@ def load_or_compile_discretization_solver(
         params,
     )
 
-    if save_compiled:
-        with open(cache_file, "wb") as f:
-            f.write(compiled_solver.serialize())
-        print(f"✓ {name} discretization solver compiled and saved")
+    with open(cache_file, "wb") as f:
+        f.write(compiled_solver.serialize())
+    print(f"✓ {name} discretization solver compiled and saved")
 
     return compiled_solver
 

--- a/tests/algorithms/_iteration_helpers.py
+++ b/tests/algorithms/_iteration_helpers.py
@@ -1,0 +1,27 @@
+"""Shared builder for ``make_scp_iteration`` tests.
+
+Assembles a fused iteration body from an initialized ``Problem`` using
+``jax.jit`` discretization solvers — the production no-disk path. Underscore
+prefix keeps pytest from collecting it as a test module.
+"""
+
+from __future__ import annotations
+
+import jax
+
+from openscvx.algorithms.scvx.iteration import make_scp_iteration
+from openscvx.discretization import get_impulsive_discretization_solver
+
+
+def build_iteration_fn(prob):
+    """Build ``iteration_fn`` from an initialized problem's components."""
+    dis_continuous = jax.jit(prob.discretizer.get_solver(prob.lowered.dynamics, prob.settings))
+    dis_impulsive = jax.jit(get_impulsive_discretization_solver(prob.lowered.dynamics_discrete))
+    return make_scp_iteration(
+        dis_continuous=dis_continuous,
+        dis_impulsive=dis_impulsive,
+        jax_constraints=prob._compiled_constraints,
+        solver_callback=prob.solver.iteration_callback(),
+        autotuner=prob.algorithm.autotuner,
+        settings=prob.settings,
+    )

--- a/tests/algorithms/autotuner/test_update_weights_jit.py
+++ b/tests/algorithms/autotuner/test_update_weights_jit.py
@@ -29,6 +29,7 @@ from openscvx.lowered.jax_constraints import LoweredJaxConstraints
 
 class _DummyState:
     initial = np.array([0.0, 0.0])
+    final = np.array([0.0, 0.0])
     guess = np.array([[0.0, 0.0], [1.0, 1.0], [2.0, 2.0]])
     min = np.array([-10.0, -10.0])
     max = np.array([10.0, 10.0])

--- a/tests/algorithms/test_algorithm_state_pytree.py
+++ b/tests/algorithms/test_algorithm_state_pytree.py
@@ -18,6 +18,7 @@ from openscvx.config import Config, DevConfig, PropagationConfig, SimConfig
 
 class _DummyState:
     initial = np.array([0.0, 0.0])
+    final = np.array([0.0, 0.0])
     guess = np.array([[0.0, 0.0], [1.0, 1.0], [2.0, 2.0]])
     min = np.array([-10.0, -10.0])
     max = np.array([10.0, 10.0])

--- a/tests/algorithms/test_iteration_fn_jit.py
+++ b/tests/algorithms/test_iteration_fn_jit.py
@@ -1,0 +1,45 @@
+"""``jax.jit(iteration_fn)`` must round-trip equivalently to the bare body.
+
+A divergence here would mean the body either retraces unexpectedly or breaks
+pytree structure across the ``jit`` boundary — both fatal for the
+``lax.while_loop``-driven solve in follow-up work.
+"""
+
+import jax
+import numpy as np
+import pytest
+
+pytest.importorskip("qpax")
+
+from openscvx.algorithms import AlgorithmState
+from openscvx.algorithms.scvx.iteration import make_scp_iteration
+from tests.solvers._iteration_callback_helpers import build_brachistochrone
+
+
+def test_jit_matches_bare():
+    prob = build_brachistochrone("qpax", n=4, k_max=1)
+    prob.initialize()
+    state0 = prob.state
+
+    iteration_fn = make_scp_iteration(
+        dynamics=prob.lowered.dynamics,
+        dynamics_discrete=prob.lowered.dynamics_discrete,
+        jax_constraints=prob._compiled_constraints,
+        discretizer=prob.discretizer,
+        solver_callback=prob.solver.iteration_callback(),
+        autotuner=prob.algorithm.autotuner,
+        settings=prob.settings,
+    )
+
+    bare = iteration_fn(state0, prob._parameters)
+    jitted = jax.jit(iteration_fn)(state0, prob._parameters)
+
+    assert isinstance(jitted, AlgorithmState)
+    for field in AlgorithmState._FIELDS:
+        np.testing.assert_allclose(
+            np.asarray(getattr(jitted, field)),
+            np.asarray(getattr(bare, field)),
+            atol=1e-8,
+            rtol=1e-8,
+            equal_nan=True,
+        )

--- a/tests/algorithms/test_iteration_fn_jit.py
+++ b/tests/algorithms/test_iteration_fn_jit.py
@@ -2,7 +2,8 @@
 
 A divergence here would mean the body either retraces unexpectedly or breaks
 pytree structure across the ``jit`` boundary — both fatal for the
-``lax.while_loop``-driven solve in follow-up work.
+``lax.while_loop``-driven solve in follow-up work. Both the next state and the
+diagnostics pytree are checked.
 """
 
 import jax
@@ -12,7 +13,8 @@ import pytest
 pytest.importorskip("qpax")
 
 from openscvx.algorithms import AlgorithmState
-from openscvx.algorithms.scvx.iteration import make_scp_iteration
+from openscvx.algorithms.scvx.iteration import IterationDiagnostics
+from tests.algorithms._iteration_helpers import build_iteration_fn
 from tests.solvers._iteration_callback_helpers import build_brachistochrone
 
 
@@ -21,25 +23,25 @@ def test_jit_matches_bare():
     prob.initialize()
     state0 = prob.state
 
-    iteration_fn = make_scp_iteration(
-        dynamics=prob.lowered.dynamics,
-        dynamics_discrete=prob.lowered.dynamics_discrete,
-        jax_constraints=prob._compiled_constraints,
-        discretizer=prob.discretizer,
-        solver_callback=prob.solver.iteration_callback(),
-        autotuner=prob.algorithm.autotuner,
-        settings=prob.settings,
-    )
+    iteration_fn = build_iteration_fn(prob)
 
-    bare = iteration_fn(state0, prob._parameters)
-    jitted = jax.jit(iteration_fn)(state0, prob._parameters)
+    bare_state, bare_diag = iteration_fn(state0, prob._parameters)
+    jit_state, jit_diag = jax.jit(iteration_fn)(state0, prob._parameters)
 
-    assert isinstance(jitted, AlgorithmState)
+    assert isinstance(jit_state, AlgorithmState)
+    assert isinstance(jit_diag, IterationDiagnostics)
     for field in AlgorithmState._FIELDS:
         np.testing.assert_allclose(
-            np.asarray(getattr(jitted, field)),
-            np.asarray(getattr(bare, field)),
+            np.asarray(getattr(jit_state, field)),
+            np.asarray(getattr(bare_state, field)),
             atol=1e-8,
             rtol=1e-8,
             equal_nan=True,
+        )
+    for field in ("cost", "J_lin", "V", "W", "TR", "VC"):
+        np.testing.assert_allclose(
+            np.asarray(getattr(jit_diag, field)),
+            np.asarray(getattr(bare_diag, field)),
+            atol=1e-8,
+            rtol=1e-8,
         )

--- a/tests/algorithms/test_iteration_fn_parity.py
+++ b/tests/algorithms/test_iteration_fn_parity.py
@@ -1,0 +1,65 @@
+"""Per-iteration parity between ``make_scp_iteration`` and the legacy path.
+
+One call to the fused JAX iteration body must reproduce one
+:meth:`PenalizedTrustRegion.step` — same next-iterate trajectory, same SCP
+convergence metrics — on a fixed brachistochrone. This is the acceptance gate
+for the body before it replaces the Python-side ``_subproblem`` stitching.
+
+QPAX exercises the fully JAX-native solve (``solve_qp_primal`` vs the NumPy
+``solve_qp``, hence the looser primal tolerance); CVXPy exercises the
+``pure_callback`` host solve, which runs the identical QOCO solve as the legacy
+path and so matches tightly.
+"""
+
+import numpy as np
+import pytest
+
+from openscvx.algorithms.scvx.iteration import make_scp_iteration
+from tests.solvers._iteration_callback_helpers import build_brachistochrone
+
+
+def _build_iteration_fn(prob):
+    """Assemble the iteration body from an initialized problem's components."""
+    return make_scp_iteration(
+        dynamics=prob.lowered.dynamics,
+        dynamics_discrete=prob.lowered.dynamics_discrete,
+        jax_constraints=prob._compiled_constraints,
+        discretizer=prob.discretizer,
+        solver_callback=prob.solver.iteration_callback(),
+        autotuner=prob.algorithm.autotuner,
+        settings=prob.settings,
+    )
+
+
+@pytest.mark.parametrize("backend, primal_atol", [("qpax", 1e-6), ("cvxpy", 1e-8)])
+def test_iteration_fn_matches_subproblem(backend, primal_atol):
+    if backend == "qpax":
+        pytest.importorskip("qpax")
+    prob = build_brachistochrone(backend, n=4, k_max=1)
+    prob.initialize()
+
+    # Both paths start from the same fresh initial iterate. ``step`` does not
+    # mutate the (frozen) state it is handed, so we can reuse it.
+    state0 = prob.state
+
+    iteration_fn = _build_iteration_fn(prob)
+    it_next = iteration_fn(state0, prob._parameters)
+
+    legacy_next, _ = prob.algorithm.step(
+        state0, prob.history, prob._parameters, prob.settings
+    )
+
+    np.testing.assert_allclose(
+        np.asarray(it_next.x), np.asarray(legacy_next.x), atol=primal_atol, rtol=primal_atol
+    )
+    np.testing.assert_allclose(
+        np.asarray(it_next.u), np.asarray(legacy_next.u), atol=primal_atol, rtol=primal_atol
+    )
+    np.testing.assert_allclose(
+        np.asarray(it_next.x_prop), np.asarray(legacy_next.x_prop), atol=1e-5, rtol=1e-5
+    )
+    for metric in ("J_tr", "J_vb", "J_vc"):
+        np.testing.assert_allclose(
+            float(getattr(it_next, metric)), float(getattr(legacy_next, metric)), atol=1e-4
+        )
+    assert int(it_next.k) == int(legacy_next.k)

--- a/tests/algorithms/test_iteration_fn_parity.py
+++ b/tests/algorithms/test_iteration_fn_parity.py
@@ -2,8 +2,10 @@
 
 One call to the fused JAX iteration body must reproduce one
 :meth:`PenalizedTrustRegion.step` — same next-iterate trajectory, same SCP
-convergence metrics — on a fixed brachistochrone. This is the acceptance gate
-for the body before it replaces the Python-side ``_subproblem`` stitching.
+convergence metrics, and the same per-iteration diagnostics (raw
+discretization matrix, trust-region / virtual-control matrices) the legacy
+path recorded into history. This is the acceptance gate for the body before it
+replaces the Python-side ``_subproblem`` stitching.
 
 QPAX exercises the fully JAX-native solve (``solve_qp_primal`` vs the NumPy
 ``solve_qp``, hence the looser primal tolerance); CVXPy exercises the
@@ -14,21 +16,8 @@ path and so matches tightly.
 import numpy as np
 import pytest
 
-from openscvx.algorithms.scvx.iteration import make_scp_iteration
+from tests.algorithms._iteration_helpers import build_iteration_fn
 from tests.solvers._iteration_callback_helpers import build_brachistochrone
-
-
-def _build_iteration_fn(prob):
-    """Assemble the iteration body from an initialized problem's components."""
-    return make_scp_iteration(
-        dynamics=prob.lowered.dynamics,
-        dynamics_discrete=prob.lowered.dynamics_discrete,
-        jax_constraints=prob._compiled_constraints,
-        discretizer=prob.discretizer,
-        solver_callback=prob.solver.iteration_callback(),
-        autotuner=prob.algorithm.autotuner,
-        settings=prob.settings,
-    )
 
 
 @pytest.mark.parametrize("backend, primal_atol", [("qpax", 1e-6), ("cvxpy", 1e-8)])
@@ -42,13 +31,12 @@ def test_iteration_fn_matches_subproblem(backend, primal_atol):
     # mutate the (frozen) state it is handed, so we can reuse it.
     state0 = prob.state
 
-    iteration_fn = _build_iteration_fn(prob)
-    it_next = iteration_fn(state0, prob._parameters)
+    iteration_fn = build_iteration_fn(prob)
+    it_next, it_diag = iteration_fn(state0, prob._parameters)
 
-    legacy_next, _ = prob.algorithm.step(
-        state0, prob.history, prob._parameters, prob.settings
-    )
+    legacy_next, _ = prob.algorithm.step(state0, prob.history, prob._parameters, prob.settings)
 
+    # Next-iterate trajectory + metrics.
     np.testing.assert_allclose(
         np.asarray(it_next.x), np.asarray(legacy_next.x), atol=primal_atol, rtol=primal_atol
     )
@@ -63,3 +51,11 @@ def test_iteration_fn_matches_subproblem(backend, primal_atol):
             float(getattr(it_next, metric)), float(getattr(legacy_next, metric)), atol=1e-4
         )
     assert int(it_next.k) == int(legacy_next.k)
+
+    # Diagnostics must match what the legacy step recorded into history
+    # (ConstantProximalWeight always accepts, so TR / VC / V are appended).
+    np.testing.assert_allclose(np.asarray(it_diag.TR), prob.history.TR[-1], atol=1e-5, rtol=1e-5)
+    np.testing.assert_allclose(np.asarray(it_diag.VC), prob.history.VC[-1], atol=1e-5, rtol=1e-5)
+    np.testing.assert_allclose(
+        np.asarray(it_diag.V), prob.history.V_history[-1], atol=1e-6, rtol=1e-6
+    )

--- a/tests/algorithms/test_iteration_fn_parity.py
+++ b/tests/algorithms/test_iteration_fn_parity.py
@@ -1,16 +1,19 @@
-"""Per-iteration parity between ``make_scp_iteration`` and the legacy path.
+"""A factory-built ``make_scp_iteration`` body matches the production ``.step()``.
 
-One call to the fused JAX iteration body must reproduce one
+One call to a standalone ``iteration_fn`` must reproduce one
 :meth:`PenalizedTrustRegion.step` — same next-iterate trajectory, same SCP
 convergence metrics, and the same per-iteration diagnostics (raw
-discretization matrix, trust-region / virtual-control matrices) the legacy
-path recorded into history. This is the acceptance gate for the body before it
-replaces the Python-side ``_subproblem`` stitching.
+discretization matrix, trust-region / virtual-control matrices) the step
+records into history. Since ``.step()`` now drives the same fused body, this is
+a consistency gate between the test-helper build (bare body, no-disk
+``jax.jit`` discretization) and the production wiring (``jax.jit``'d body built
+in :meth:`Problem.initialize`), plus a check that the diagnostics aux-return
+feeds history correctly.
 
-QPAX exercises the fully JAX-native solve (``solve_qp_primal`` vs the NumPy
-``solve_qp``, hence the looser primal tolerance); CVXPy exercises the
-``pure_callback`` host solve, which runs the identical QOCO solve as the legacy
-path and so matches tightly.
+QPAX matches only to ~1e-6 because its iterative ``qpax.solve_qp`` is sensitive
+to the jit-vs-bare floating-point reordering between the two builds; CVXPy
+matches to 1e-8 because its ``pure_callback`` host QOCO solve is bit-identical
+across both.
 """
 
 import numpy as np
@@ -21,7 +24,7 @@ from tests.solvers._iteration_callback_helpers import build_brachistochrone
 
 
 @pytest.mark.parametrize("backend, primal_atol", [("qpax", 1e-6), ("cvxpy", 1e-8)])
-def test_iteration_fn_matches_subproblem(backend, primal_atol):
+def test_iteration_fn_matches_production_step(backend, primal_atol):
     if backend == "qpax":
         pytest.importorskip("qpax")
     prob = build_brachistochrone(backend, n=4, k_max=1)
@@ -34,25 +37,25 @@ def test_iteration_fn_matches_subproblem(backend, primal_atol):
     iteration_fn = build_iteration_fn(prob)
     it_next, it_diag = iteration_fn(state0, prob._parameters)
 
-    legacy_next, _ = prob.algorithm.step(state0, prob.history, prob._parameters, prob.settings)
+    step_next, _ = prob.algorithm.step(state0, prob.history, prob._parameters, prob.settings)
 
     # Next-iterate trajectory + metrics.
     np.testing.assert_allclose(
-        np.asarray(it_next.x), np.asarray(legacy_next.x), atol=primal_atol, rtol=primal_atol
+        np.asarray(it_next.x), np.asarray(step_next.x), atol=primal_atol, rtol=primal_atol
     )
     np.testing.assert_allclose(
-        np.asarray(it_next.u), np.asarray(legacy_next.u), atol=primal_atol, rtol=primal_atol
+        np.asarray(it_next.u), np.asarray(step_next.u), atol=primal_atol, rtol=primal_atol
     )
     np.testing.assert_allclose(
-        np.asarray(it_next.x_prop), np.asarray(legacy_next.x_prop), atol=1e-5, rtol=1e-5
+        np.asarray(it_next.x_prop), np.asarray(step_next.x_prop), atol=1e-5, rtol=1e-5
     )
     for metric in ("J_tr", "J_vb", "J_vc"):
         np.testing.assert_allclose(
-            float(getattr(it_next, metric)), float(getattr(legacy_next, metric)), atol=1e-4
+            float(getattr(it_next, metric)), float(getattr(step_next, metric)), atol=1e-4
         )
-    assert int(it_next.k) == int(legacy_next.k)
+    assert int(it_next.k) == int(step_next.k)
 
-    # Diagnostics must match what the legacy step recorded into history
+    # Diagnostics must match what the step recorded into history
     # (ConstantProximalWeight always accepts, so TR / VC / V are appended).
     np.testing.assert_allclose(np.asarray(it_diag.TR), prob.history.TR[-1], atol=1e-5, rtol=1e-5)
     np.testing.assert_allclose(np.asarray(it_diag.VC), prob.history.VC[-1], atol=1e-5, rtol=1e-5)

--- a/tests/algorithms/test_make_solve_loop.py
+++ b/tests/algorithms/test_make_solve_loop.py
@@ -3,8 +3,9 @@
 The ``lax.while_loop`` wrapper over ``iteration_fn`` should reproduce what the
 Python ``while`` loop in ``Problem.solve()`` produces. ``k_max`` is kept below
 the convergence point (``J_tr`` stays well above ``ep_tr`` throughout), so both
-loops run the identical iteration count and the only divergence is QPAX's
-``solve_qp_primal`` (JAX path) vs ``solve_qp`` (NumPy path).
+loops run the identical iteration count and the only divergence is the
+floating-point reordering between the ``lax.while_loop``-compiled body and the
+per-iteration ``jax.jit``'d body the Python loop drives.
 """
 
 import numpy as np

--- a/tests/algorithms/test_make_solve_loop.py
+++ b/tests/algorithms/test_make_solve_loop.py
@@ -1,0 +1,47 @@
+"""``make_solve_loop`` must match the Python-loop ``.solve()`` trajectory.
+
+The ``lax.while_loop`` wrapper over ``iteration_fn`` should reproduce what the
+Python ``while`` loop in ``Problem.solve()`` produces. ``k_max`` is kept below
+the convergence point (``J_tr`` stays well above ``ep_tr`` throughout), so both
+loops run the identical iteration count and the only divergence is QPAX's
+``solve_qp_primal`` (JAX path) vs ``solve_qp`` (NumPy path).
+"""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("qpax")
+
+from openscvx.algorithms.scvx.iteration import make_scp_iteration, make_solve_loop
+from tests.solvers._iteration_callback_helpers import build_brachistochrone
+
+
+def test_make_solve_loop_matches_python_solve():
+    prob = build_brachistochrone("qpax", n=8, k_max=5)
+    prob.initialize()
+
+    # Reference: the legacy Python-driven solve.
+    prob.solve()
+    solve_x = np.asarray(prob.state.x)
+    solve_u = np.asarray(prob.state.u)
+    solve_k = int(prob.state.k)
+
+    # lax.while_loop over the fused body, from the same fresh initial iterate.
+    prob.reset()
+    state0 = prob.state
+    iteration_fn = make_scp_iteration(
+        dynamics=prob.lowered.dynamics,
+        dynamics_discrete=prob.lowered.dynamics_discrete,
+        jax_constraints=prob._compiled_constraints,
+        discretizer=prob.discretizer,
+        solver_callback=prob.solver.iteration_callback(),
+        autotuner=prob.algorithm.autotuner,
+        settings=prob.settings,
+    )
+    algo = prob.algorithm
+    solve_loop = make_solve_loop(iteration_fn, algo.ep_tr, algo.ep_vb, algo.ep_vc, algo.k_max)
+    loop_state = solve_loop(state0, prob._parameters)
+
+    assert int(loop_state.k) == solve_k
+    np.testing.assert_allclose(np.asarray(loop_state.x), solve_x, atol=1e-5, rtol=1e-5)
+    np.testing.assert_allclose(np.asarray(loop_state.u), solve_u, atol=1e-5, rtol=1e-5)

--- a/tests/algorithms/test_make_solve_loop.py
+++ b/tests/algorithms/test_make_solve_loop.py
@@ -12,7 +12,8 @@ import pytest
 
 pytest.importorskip("qpax")
 
-from openscvx.algorithms.scvx.iteration import make_scp_iteration, make_solve_loop
+from openscvx.algorithms.scvx.iteration import make_solve_loop
+from tests.algorithms._iteration_helpers import build_iteration_fn
 from tests.solvers._iteration_callback_helpers import build_brachistochrone
 
 
@@ -29,15 +30,7 @@ def test_make_solve_loop_matches_python_solve():
     # lax.while_loop over the fused body, from the same fresh initial iterate.
     prob.reset()
     state0 = prob.state
-    iteration_fn = make_scp_iteration(
-        dynamics=prob.lowered.dynamics,
-        dynamics_discrete=prob.lowered.dynamics_discrete,
-        jax_constraints=prob._compiled_constraints,
-        discretizer=prob.discretizer,
-        solver_callback=prob.solver.iteration_callback(),
-        autotuner=prob.algorithm.autotuner,
-        settings=prob.settings,
-    )
+    iteration_fn = build_iteration_fn(prob)
     algo = prob.algorithm
     solve_loop = make_solve_loop(iteration_fn, algo.ep_tr, algo.ep_vb, algo.ep_vc, algo.k_max)
     loop_state = solve_loop(state0, prob._parameters)

--- a/tests/solvers/_iteration_callback_helpers.py
+++ b/tests/solvers/_iteration_callback_helpers.py
@@ -149,9 +149,7 @@ def populate_numpy_stash(prob) -> None:
     slice_imp = settings.sim.u.slice_impulsive
     has_impulsive = bool(slice_imp.stop > slice_imp.start)
 
-    solver.update_boundary_conditions(
-        x_init=settings.sim.x.initial, x_term=settings.sim.x.final
-    )
+    solver.update_boundary_conditions(x_init=settings.sim.x.initial, x_term=settings.sim.x.final)
     solver.update_dynamics_linearization(
         x_bar=x_bar,
         u_bar=u_bar,

--- a/tests/solvers/_iteration_callback_helpers.py
+++ b/tests/solvers/_iteration_callback_helpers.py
@@ -16,10 +16,12 @@ canonical definitions. Per-backend test files import from here.
 
 from __future__ import annotations
 
+import jax
 import jax.numpy as jnp
 import numpy as np
 
 from openscvx import Problem
+from openscvx.discretization import get_impulsive_discretization_solver
 from openscvx.solvers.ptr_solver import SubproblemData
 
 
@@ -113,6 +115,92 @@ def build_brachistochrone(
     )
     prob.settings.dev.printing = False
     return prob
+
+
+def populate_numpy_stash(prob) -> None:
+    """Run one discretize → linearize → ``update_*`` cycle on the initial iterate.
+
+    The SCP loop no longer drives the solver's NumPy ``update_*`` path (it uses
+    the JAX-pure ``iteration_callback``), so ``prob.solve()`` no longer leaves
+    ``solver._dyn`` / ``_cons`` / ``_pen`` populated. Tests that read that stash
+    (or call the legacy ``solver.solve()`` / ``_assemble_qp``) call this after
+    ``initialize()`` to set it up, mirroring what the former
+    ``PenalizedTrustRegion._subproblem`` did for the first iterate.
+    """
+    solver = prob.solver
+    settings = prob.settings
+    params = prob._parameters
+    state = prob.state
+    jc = prob._compiled_constraints
+
+    dis = jax.jit(prob.discretizer.get_solver(prob.lowered.dynamics, settings))
+    dis_imp = jax.jit(get_impulsive_discretization_solver(prob.lowered.dynamics_discrete))
+
+    x_bar = np.asarray(state.x)
+    u_bar = np.asarray(state.u, dtype=float)
+    A_d, B_d, C_d, x_prop, _ = dis(x_bar, u_bar, params)
+
+    init_fixed = np.asarray(settings.sim.x.initial_type) == "Fix"
+    x0_init = np.asarray(settings.sim.x.initial, dtype=float)
+    x0_prior = np.where(init_fixed, x0_init, x_bar[0]).reshape(1, -1)
+    x_nodes_prior = np.vstack((x0_prior, np.asarray(x_prop)))
+    x_prop_plus, D_d, E_d, _ = dis_imp(x_nodes_prior, u_bar, params)
+
+    slice_imp = settings.sim.u.slice_impulsive
+    has_impulsive = bool(slice_imp.stop > slice_imp.start)
+
+    solver.update_boundary_conditions(
+        x_init=settings.sim.x.initial, x_term=settings.sim.x.final
+    )
+    solver.update_dynamics_linearization(
+        x_bar=x_bar,
+        u_bar=u_bar,
+        A_d=np.asarray(A_d),
+        B_d=np.asarray(B_d),
+        C_d=np.asarray(C_d),
+        x_prop=np.asarray(x_prop),
+        x_prop_plus=np.asarray(x_prop_plus) if has_impulsive else None,
+        D_d=np.asarray(D_d) if has_impulsive else None,
+        E_d=np.asarray(E_d) if has_impulsive else None,
+    )
+
+    nodal = []
+    for c in jc.nodal:
+        g = np.squeeze(np.asarray(c.func(x_bar, u_bar, 0, params)))
+        gx = np.asarray(c.grad_g_x(x_bar, u_bar, 0, params))
+        gu = np.asarray(c.grad_g_u(x_bar, u_bar, 0, params))
+        if g.ndim == 0:
+            g = np.broadcast_to(g, (x_bar.shape[0],))
+        elif g.ndim > 1:
+            g = g.reshape(g.shape[0], -1).sum(axis=1)
+        if gx.ndim == 1:
+            gx = np.broadcast_to(gx, (x_bar.shape[0], gx.shape[0]))
+        elif gx.ndim > 2:
+            gx = gx.reshape(gx.shape[0], -1)[:, : x_bar.shape[1]]
+        if gu.ndim == 1:
+            gu = np.broadcast_to(gu, (u_bar.shape[0], gu.shape[0]))
+        elif gu.ndim > 2:
+            gu = gu.reshape(gu.shape[0], -1)[:, : u_bar.shape[1]]
+        nodal.append({"g": g, "grad_g_x": gx, "grad_g_u": gu})
+
+    cross = []
+    for c in jc.cross_node:
+        cross.append(
+            {
+                "g": np.asarray(c.func(x_bar, u_bar, params)),
+                "grad_g_X": np.asarray(c.grad_g_X(x_bar, u_bar, params)),
+                "grad_g_U": np.asarray(c.grad_g_U(x_bar, u_bar, params)),
+            }
+        )
+    solver.update_constraint_linearizations(nodal=nodal or None, cross_node=cross or None)
+    solver.update_penalties(
+        lam_prox=np.asarray(state.lam_prox),
+        lam_cost=np.asarray(state.lam_cost),
+        lam_vc=np.asarray(state.lam_vc),
+        lam_vb_nodal=np.asarray(state.lam_vb_nodal),
+        lam_vb_cross=np.asarray(state.lam_vb_cross),
+    )
+    solver.update_proximal_terms()
 
 
 def subproblem_data_from_numpy_stash(solver) -> SubproblemData:

--- a/tests/solvers/test_iteration_callback_moreau.py
+++ b/tests/solvers/test_iteration_callback_moreau.py
@@ -29,6 +29,7 @@ if _MOREAU_OK:
     from openscvx.solvers.ptr_solver import StatusCode, SubproblemSolution
     from tests.solvers._iteration_callback_helpers import (
         build_brachistochrone,
+        populate_numpy_stash,
         subproblem_data_from_numpy_stash,
     )
 
@@ -50,7 +51,7 @@ def test_assemble_conic_jax_matches_numpy_on_brachistochrone(constraint_style):
     """
     prob = build_brachistochrone("moreau", n=4, k_max=1, constraint_style=constraint_style)
     prob.initialize()
-    prob.solve()
+    populate_numpy_stash(prob)
     solver = prob.solver
 
     P_np, coo_np, q_np, b_np = solver._assemble_conic()
@@ -72,7 +73,7 @@ def test_csr_to_coo_perm_reconstructs_numpy_A_data():
 
     prob = build_brachistochrone("moreau", n=4, k_max=1)
     prob.initialize()
-    prob.solve()
+    populate_numpy_stash(prob)
     solver = prob.solver
 
     _, coo_np, _, _ = solver._assemble_conic()
@@ -102,7 +103,7 @@ def test_iteration_callback_matches_solve_on_brachistochrone():
     """
     prob = build_brachistochrone("moreau", n=4, k_max=1)
     prob.initialize()
-    prob.solve()
+    populate_numpy_stash(prob)
     solver = prob.solver
 
     reference = solver.solve()
@@ -127,7 +128,7 @@ def test_iteration_callback_traces_under_jit():
     trace (no per-call retrace surprises)."""
     prob = build_brachistochrone("moreau", n=4, k_max=1)
     prob.initialize()
-    prob.solve()
+    populate_numpy_stash(prob)
     solver = prob.solver
 
     data = subproblem_data_from_numpy_stash(solver)

--- a/tests/solvers/test_iteration_callback_qpax.py
+++ b/tests/solvers/test_iteration_callback_qpax.py
@@ -24,6 +24,7 @@ pytest.importorskip("qpax")
 from openscvx.solvers.ptr_solver import StatusCode, SubproblemSolution
 from tests.solvers._iteration_callback_helpers import (
     build_brachistochrone,
+    populate_numpy_stash,
     subproblem_data_from_numpy_stash,
 )
 
@@ -45,9 +46,10 @@ def test_assemble_qp_jax_matches_numpy_on_brachistochrone(constraint_style):
     """
     prob = build_brachistochrone("qpax", n=4, k_max=1, constraint_style=constraint_style)
     prob.initialize()
-    # One SCP iteration populates _dyn / _cons / _pen / _x_init / _x_term on
-    # the solver — both assembly paths read from the same iterate after this.
-    prob.solve()
+    # Populate _dyn / _cons / _pen / _x_init / _x_term on the solver so both
+    # assembly paths read from the same iterate. (The SCP loop no longer drives
+    # the NumPy update_* path, so we set up the stash explicitly.)
+    populate_numpy_stash(prob)
 
     solver = prob.solver
     Q_np, q_np, A_np, b_np, G_np, h_np = solver._assemble_qp()
@@ -70,13 +72,12 @@ def test_assemble_qp_jax_matches_numpy_on_brachistochrone(constraint_style):
 
 def test_iteration_callback_matches_solve_on_brachistochrone():
     """``iteration_callback()(state, data)`` must produce the same primal
-    trajectory as ``solver.solve()`` on the same iterate. ``solve_qp_primal``
-    and ``solve_qp`` differ only in what they return (primal-only vs
-    full primal-dual), so on a convergent QP they must produce the same
-    primal up to PDIP tolerance."""
+    trajectory as ``solver.solve()`` on the same iterate. Both now call
+    ``qpax.solve_qp``, so on a convergent QP they produce the same primal up to
+    PDIP tolerance."""
     prob = build_brachistochrone("qpax", n=4, k_max=1)
     prob.initialize()
-    prob.solve()
+    populate_numpy_stash(prob)
     solver = prob.solver
 
     # NumPy reference: re-call _assemble_qp + qpax.solve_qp on the stash.
@@ -100,8 +101,8 @@ def test_iteration_callback_matches_solve_on_brachistochrone():
     # Cost reconstruction is independent of the QP solve — should match the
     # NumPy path's _reconstruct_cost output directly.
     np.testing.assert_allclose(float(solution.cost), reference.cost, atol=1e-8, rtol=1e-8)
-    # solve_qp_primal exposes no convergence diagnostic.
-    assert int(solution.status_code) == int(StatusCode.UNKNOWN)
+    # solve_qp reports convergence on this well-posed QP.
+    assert int(solution.status_code) == int(StatusCode.OPTIMAL)
 
 
 def test_iteration_callback_traces_under_jit():
@@ -110,7 +111,7 @@ def test_iteration_callback_traces_under_jit():
     amortizes across repeated calls (no per-call re-tracing surprises)."""
     prob = build_brachistochrone("qpax", n=4, k_max=1)
     prob.initialize()
-    prob.solve()
+    populate_numpy_stash(prob)
     solver = prob.solver
 
     data = subproblem_data_from_numpy_stash(solver)

--- a/tests/solvers/test_iteration_callback_vmap.py
+++ b/tests/solvers/test_iteration_callback_vmap.py
@@ -25,6 +25,7 @@ from openscvx.solvers.ptr_solver import SubproblemData, SubproblemSolution
 from tests._marks import requires_moreau
 from tests.solvers._iteration_callback_helpers import (
     build_brachistochrone,
+    populate_numpy_stash,
     subproblem_data_from_numpy_stash,
 )
 
@@ -76,7 +77,7 @@ def test_qpax_iteration_callback_composes_with_vmap():
     """
     prob = build_brachistochrone("qpax", n=4, k_max=1)
     prob.initialize()
-    prob.solve()
+    populate_numpy_stash(prob)
     solver = prob.solver
 
     base = subproblem_data_from_numpy_stash(solver)
@@ -123,7 +124,7 @@ def test_moreau_iteration_callback_composes_with_vmap():
     """
     prob = build_brachistochrone("moreau", n=4, k_max=1)
     prob.initialize()
-    prob.solve()
+    populate_numpy_stash(prob)
     solver = prob.solver
 
     base = subproblem_data_from_numpy_stash(solver)

--- a/tests/solvers/test_moreau_ptr_solver.py
+++ b/tests/solvers/test_moreau_ptr_solver.py
@@ -23,6 +23,7 @@ import openscvx as ox
 from openscvx import Problem
 from openscvx.solvers import MoreauPTRSolver, PTRSolver, PTRSolveResult
 from tests._marks import requires_moreau
+from tests.solvers._iteration_callback_helpers import populate_numpy_stash
 
 # Skip the whole module when moreau is absent or unlicensed.
 pytestmark = requires_moreau
@@ -252,7 +253,7 @@ def test_moreau_assembly_shapes_consistent():
     prob = _make_double_integrator_problem(n=6, backend="moreau", k_max=1)
     prob.settings.dev.printing = False
     prob.initialize()
-    prob.solve()
+    populate_numpy_stash(prob)
 
     solver = prob.solver
     assert isinstance(solver, MoreauPTRSolver)
@@ -292,6 +293,7 @@ def test_moreau_solve_returns_PTRSolveResult():
     prob = _make_double_integrator_problem(n=5, backend="moreau", k_max=1)
     prob.settings.dev.printing = False
     prob.initialize()
+    populate_numpy_stash(prob)
     res = prob.solver.solve()
     assert isinstance(res, PTRSolveResult)
     assert res.x.shape[0] == 5

--- a/tests/solvers/test_qpax_ptr_solver.py
+++ b/tests/solvers/test_qpax_ptr_solver.py
@@ -22,6 +22,7 @@ pytest.importorskip("qpax")
 import openscvx as ox
 from openscvx import Problem
 from openscvx.solvers import PTRSolver, PTRSolveResult, QPAXPTRSolver
+from tests.solvers._iteration_callback_helpers import populate_numpy_stash
 
 # ============================================================================
 # Helpers
@@ -279,8 +280,9 @@ def test_qpax_assembly_produces_consistent_shapes():
     prob = _make_double_integrator_problem(n=6, backend="qpax", k_max=1)
     prob.settings.dev.printing = False
     prob.initialize()
-    # Run one iteration to populate _dyn / _cons / _pen / _x_init / _x_term
-    prob.solve()
+    # Populate _dyn / _cons / _pen / _x_init / _x_term for the NumPy assembly
+    # (the SCP loop no longer drives the update_* path).
+    populate_numpy_stash(prob)
 
     solver = prob.solver
     Q, q, A, b, G, h = solver._assemble_qp()
@@ -301,7 +303,8 @@ def test_qpax_solve_returns_PTRSolveResult():
     prob = _make_double_integrator_problem(n=5, backend="qpax", k_max=1)
     prob.settings.dev.printing = False
     prob.initialize()
-    # One direct solver.solve() call after the SCP loop is set up.
+    # One direct solver.solve() call after the NumPy stash is populated.
+    populate_numpy_stash(prob)
     res = prob.solver.solve()
     assert isinstance(res, PTRSolveResult)
     assert res.x.shape[0] == 5
@@ -329,6 +332,9 @@ def test_qpax_solve_raises_on_nonconvergence(monkeypatch):
     prob = _make_double_integrator_problem(n=5, backend="qpax", k_max=1)
     prob.settings.dev.printing = False
     prob.initialize()
+    # Populate the stash so solver.solve() reaches the qpax.solve_qp guard
+    # (rather than the "update_* not called" precondition error).
+    populate_numpy_stash(prob)
 
     n_z = prob.solver.layout.n_z
     nan_z = jnp.full((n_z,), jnp.nan)

--- a/tests/test_autotuning.py
+++ b/tests/test_autotuning.py
@@ -57,6 +57,7 @@ def mock_unified_state():
     """Create a mock UnifiedState object."""
     state = DummyState()
     state.initial = np.array([0.0, 0.0])
+    state.final = np.array([0.0, 0.0])
     state.guess = np.array([[0.0, 0.0], [1.0, 1.0], [2.0, 2.0]])
     state.min = np.array([-10.0, -10.0])
     state.max = np.array([10.0, 10.0])

--- a/tests/test_brachistochrone.py
+++ b/tests/test_brachistochrone.py
@@ -526,12 +526,10 @@ def test_backend_float32_raises():
     if hasattr(problem.settings, "dev"):
         problem.settings.dev.printing = False
 
-    # ``initialize()`` itself triggers a first subproblem solve via
-    # ``PenalizedTrustRegion.initialize`` (penalized_trust_region.py:343),
-    # so the guard fires there before ``solve()`` is even reached. Wrap
-    # both calls in the same context — whichever raises first is the one
-    # we care about.
-    with pytest.raises(RuntimeError, match=r"qpax\.solve_qp failed"):
+    # qpax.solve_qp reports converged=False on this diverged float32 solve;
+    # the QPAX iteration_callback maps that to a non-OPTIMAL status_code, and
+    # ``step()`` raises before the bad iterate becomes a linearization point.
+    with pytest.raises(RuntimeError, match=r"did not solve to optimality"):
         problem.initialize()
         problem.solve()
 
@@ -923,24 +921,15 @@ def test_cross_nodal(test_case):
         problem.settings.dev.printing = False
 
     # Run optimization
-    # For infeasible convex problems, the convex subproblem must not reach
-    # `optimal` — either CVXPy raises SolverError (QOCO 0.3.0; QOCO 0.3.1 on
-    # Linux, where the IPM still triggers QOCO_NUMERICAL_ERROR) or QOCO 0.3.1
-    # on macOS hits QOCO_MAX_ITER and CVXPy returns status='user_limit'.
+    # For an infeasible convex problem the subproblem can't reach `optimal`
+    # (CVXPy raises SolverError, or QOCO returns a user_limit/inaccurate
+    # status). The iteration_callback maps that to a non-OPTIMAL status_code,
+    # and ``step()``'s status gate turns it into a clean RuntimeError.
     # For infeasible non-convex problems, SCP will fail to converge.
     if is_convex and not should_converge:
-        import cvxpy as cp
-
-        try:
+        with pytest.raises(RuntimeError):
             problem.initialize()
-            result = problem.solve()
-        except cp.error.SolverError:
-            pass
-        else:
-            status = problem.solver._problem.status
-            assert status not in ("optimal", "optimal_inaccurate"), (
-                f"Infeasible convex problem unexpectedly solved cleanly: status={status!r}"
-            )
+            problem.solve()
     else:
         # Solvable or non-convex infeasible case
         problem.initialize()


### PR DESCRIPTION
## What this does

Collapses the three-export discretization pipeline plus the Python-side `_subproblem` stitching in `PenalizedTrustRegion` into a single JAX-pure `iteration_fn` (`openscvx/algorithms/scvx/iteration.py`). One call takes `(AlgorithmState, params)` and returns the next state: it discretizes the current iterate (continuous + impulsive), linearizes the nodal/cross-node constraints, packs a `SubproblemData` pytree, hands it to the per-backend solver callback, computes the `J_tr/J_vb/J_vc` convergence metrics, and folds the candidate through the autotuner.

`PenalizedTrustRegion.step()` shrinks from ~80 lines of JIT-warmup/dict-pack scaffolding to a thin wrapper around `iteration_fn`. Also ships `make_solve_loop`, a `lax.while_loop` wrapper over `iteration_fn` (tested; not yet on the `.solve()` path — see Cost).

## How this builds toward a batchable Problem

Foundation slice for `plans/jax-pure-solve.md`. The SCP body is now JAX-pure end-to-end — `state -> state` over a registered pytree — which is the prerequisite for `jax.vmap(problem.solve)` (batch a problem across scenarios) and a `lax.while_loop`-driven `.solve()`. The follow-on plan wraps `iteration_fn` in `make_solve_loop`, registers `OptimizationResults` as a pytree, and adds the batched/grad examples. None of that is in this PR.

To keep the no-disk path vmap-compatible, the discretization compile switches from `jax.export` to plain `jax.jit` (`call_exported` has no vmap batching rule). The disk-cached path (`save_compiled=True`) stays on `jax.export` and is documented as incompatible with `jax.vmap(problem.solve)` until Plan 2 redesigns the cache.

## Cost now / why it isn't breaking

- **No public API change.** `Problem.solve()` signature, return type, dispatch, and behavior are unchanged — same Python `while` loop driving `step()`, same `time_limit`, emitter thread, `continuous` kwarg, return value. Brachistochrone results unchanged within tolerance.
- **Perf gate.** `tests/test_brachistochrone.py` stays within ≤2× baseline on a warm cache (enforced by the per-test timing asserts).
- **`make_solve_loop` is unused in production.** Internal-only primitive (not re-exported), exercised only by `tests/algorithms/test_make_solve_loop.py`. Plan 2 wires it into `.solve()`. Shipping it now lets the `lax.while_loop`-vs-Python-while equivalence be tested in isolation before Plan 2 piles vmap/`OptimizationResults` on top.
- **Error contract shifted (type-preserved).** Solver failures now surface as a `status_code` that `step()` turns into a clean `RuntimeError`, instead of the backend's own guard. The exception *type* is unchanged (`RuntimeError`); the message text and originating layer changed, so two brachistochrone error-path tests were updated to match.

## The CVXPy / QPAX convergence weirdness (worth a look)

Routing the *live* solve through the JAX-pure per-backend callback shook loose two error paths that previously only ran in legacy code:

- **QPAX — `solve_qp` vs `solve_qp_primal`.** qpax exposes two entry points and you can't get both properties at once: `solve_qp_primal` is `custom_vjp`-differentiable but returns *only* the primal (no convergence flag), while `solve_qp` carries a reliable `converged` flag but wraps a `lax.while_loop` that breaks reverse-mode autodiff. This slice needs reliable non-convergence detection (so `step()` can fail loudly), not grad — so it uses `solve_qp` and maps `converged → status_code`. **This reverses the sibling `solver-iteration-callbacks` choice and forfeits differentiability of the QPAX callback** (still `jit`/`vmap`-able). Plan 2 flips the one line back when grad-through-solve is actually on the table. A primal feasibility-residual proxy was tried and rejected — too thin (diverged case violated by only ~5e-5 vs ~1e-16 converged).

- **CVXPy under `pure_callback` — two latent bugs surfaced.** The CVXPy backend hosts its solve via `jax.pure_callback`, and driving the live loop through it exposed that `host_solve` (a) never called `update_proximal_terms()`, so `prox_c` was unset on the first solve of a fresh process — it had only ever been set as a side effect of a prior legacy solve; and (b) let `cvxpy.SolverError` propagate through `pure_callback` as an opaque `ValueError`. Both fixed in `host_solve`: call `update_proximal_terms()` after `update_penalties`, and catch `SolverError → ` non-OPTIMAL `status_code`. Also maps `optimal_inaccurate → OPTIMAL` to preserve the legacy solve tolerance.

One asymmetry worth a reviewer's eye: the two backends now apply *different* leniency before the shared `step()` status gate (CVXPy accepts `optimal_inaccurate`; QPAX maps a hard `converged` bool). Defensible — CVXPy is the only backend with a fuzzy tier — but it's the kind of thing that's easy to trip over later.

## Review notes

Reviewed by a four-lens panel (correctness / minimality / maintainability / API-scope); all must-fixes addressed. Deferred, non-gating should-fixes: a comment naming the QPAX `solve_qp` 6-tuple field order, a note tying the CVXPy `optimal_inaccurate` leniency to the shared status gate, and tightening the `step()` finite-guard target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

Retroactive link: part of the batchable-solve line for #493 and #494.
