### PR TITLE
JAX-pure Problem.solve_jax() alongside Problem.solve()

### DIFF
--- a/docs/UnderTheHood/batching_jit_grad.md
+++ b/docs/UnderTheHood/batching_jit_grad.md
@@ -1,0 +1,136 @@
+# Batching, JIT, and Grad with `Problem.solve_jax()`
+
+`Problem` exposes two solve entry points. `solve()` is the familiar
+Python-loop driver — real-time prints, wall-clock `time_limit`, `continuous`
+mode, populated per-iteration history. `solve_jax()` is its JAX-pure
+sibling: it drives the same fused `iteration_fn` body inside a
+`lax.while_loop` and returns an
+[`OptimizationResults`](../../openscvx/algorithms/optimization_results.py)
+pytree, so it composes with `jax.vmap`, `jax.jit`, and `jax.grad`.
+
+```python
+problem = ox.Problem(..., solver={"backend": "qpax"})
+problem.initialize()
+
+# Familiar interactive solve — unchanged: prints, history, time limit.
+result = problem.solve()
+
+# JAX-pure single solve — silent, no per-iteration history, batchable.
+result = problem.solve_jax()
+
+# Batched — standard jax.vmap, no library-specific API.
+batched = jax.vmap(problem.solve_jax, in_axes=(0, 0, None))(
+    x_initial_stack, x_final_stack, params
+)
+
+# JIT-compile once, solve forever (e.g. MPC inner loop).
+fast_solve = jax.jit(problem.solve_jax)
+```
+
+A worked example lives at
+[`examples/abstract/brachistochrone_batched.py`](../../examples/abstract/brachistochrone_batched.py)
+— four brachistochrone problems with shifted starting x-coordinates,
+solved in parallel via `jax.vmap(problem.solve_jax)`.
+
+## When to choose `solve()` vs. `solve_jax()`
+
+| Use case | Entry point |
+|---|---|
+| Interactive use, real-time prints, plotting per iteration | `solve()` |
+| Wall-clock `time_limit` or `continuous=True` | `solve()` |
+| Per-iteration trajectories / weights / diagnostics | `solve()` |
+| Batched solve over many initial conditions or parameters | `solve_jax()` |
+| JIT-compile once, solve forever (MPC inner loop, scenario sweeps) | `solve_jax()` |
+| `jax.grad` through the solver (best-effort, untested) | `solve_jax()` |
+
+The split exists to make user intent explicit — a single dispatched
+`solve()` would have to infer from arguments which path the caller wants,
+and silent routing failures (like `continuous=True` quietly skipping the
+Python loop) are exactly the failure class the two-method design exists to
+prevent. See `plans/jax-pure-solve.md`'s Decision Log for the longer
+discussion.
+
+## What `solve_jax()` returns
+
+`solve_jax()` returns the same
+[`OptimizationResults`](../../openscvx/algorithms/optimization_results.py)
+type as `solve()`, but built via
+`OptimizationResults.from_final_state(state, problem=...)` instead of
+`from_history(history, final_state, ...)`. The differences:
+
+* **Per-iteration history is empty.** `X = [state.x]` and `U = [state.u]`
+  are single-element lists so `result.x` / `result.u` continue to return
+  the final iterate; every `*_history` field is `[]`. List growth doesn't
+  fit inside `lax.while_loop`. If you need per-iteration trajectories, use
+  `solve()` or wrap `solve_jax()` in `lax.scan` manually.
+* **Post-process fields stay `None`.** `t_full`, `x_full`, `u_full`,
+  `cost`, `ctcs_violation` are populated only by `post_process()`. They're
+  outside the JAX pytree's children surface, so a batched `solve_jax`
+  result doesn't force every consumer to handle `None` leaves. If you want
+  to post-process, call `post_process()` per batch element after the
+  batched solve.
+* **`converged` is a `jnp.bool_`** under the JAX-pure path (a `(B,)` array
+  under vmap), not a Python `bool` like `solve()` returns. Most uses
+  (`if result.converged: ...`) work either way.
+
+## `solve_jax()` arguments
+
+```python
+problem.solve_jax(
+    x_initial=None,      # boundary-condition pin (full unified state vector,
+                         #     ``jnp.nan`` at non-Fix entries — see
+                         #     ``AlgorithmState.from_settings``); falls back
+                         #     to the default from settings
+    x_final=None,        # terminal pin, same conventions
+    parameters=None,     # parameters dict for this solve; falls back to
+                         #     ``self._parameters``
+    *,
+    max_iters=None,      # SCP iteration cap; non-default rebuilds the
+                         #     cached ``lax.while_loop`` closure (one extra
+                         #     trace; subsequent calls at the same cap hit
+                         #     the cache)
+)
+```
+
+Positional kwargs (rather than a single `inputs` pytree) keep
+`jax.vmap(problem.solve_jax, in_axes=(0, 0, None))` ergonomic;
+multi-argument gradient uses `jax.grad(..., argnums=(0, 1))`.
+
+## Caveats
+
+### CVXPy under `vmap` is sequential
+
+The CVXPy backend's
+[`iteration_callback`](../../openscvx/solvers/cvxpy_ptr_solver.py) host-calls
+CVXPy through `jax.pure_callback` with `vmap_method="sequential"`. Host
+CVXPy is not thread-safe, so a `jax.vmap(problem.solve_jax)` over the
+CVXPy backend runs `B` sequential CVXPy solves. The QPAX and Moreau
+backends are pure JAX end-to-end and run in parallel under vmap.
+
+### Moreau warm-start is bypassed
+
+The Moreau backend's `_warm_start` carry is host-side mutable state that
+`lax.while_loop` doesn't thread. Both `solve()` and `solve_jax()` cold-start
+the inner Moreau solve every SCP iteration (see the Moreau module
+docstring and `plans/jax-pure-solve.md`'s Decision Log 2026-05-27).
+Restoring warm-start to the SCP loop requires threading `(x, z, s)`
+through an `AlgorithmState.moreau_carry` field — a Future Extension.
+
+### `jax.grad` is best-effort, untested
+
+The QPAX backend's `solve_qp` is not differentiable (its convergence flag
+costs reverse-mode autodiff). The CVXPy backend's `pure_callback` is
+non-differentiable by default. End-to-end gradient validation through
+`solve_jax` is a follow-up — `jax.grad(loss_fn)(x0)` will run without
+erroring under QPAX (`solve_qp_primal` would be `custom_vjp`, but the
+backend currently uses `solve_qp`), but the gradient's correctness is not
+yet pinned down by a test against finite differences.
+
+### Convergence under `vmap` with mixed-rate elements
+
+`lax.while_loop` continues while *any* batch element still needs
+iterations — converged elements would otherwise keep receiving body calls
+while their peers iterate. `make_solve_loop`'s body selects the unchanged
+state for converged elements (`jax.tree.map(jnp.where, ...)`), so a
+batched solve agrees with the single-problem `solve_jax` on each element.
+The cost is per-iteration work × slowest-element iteration count.

--- a/docs/UnderTheHood/lowering_architecture.md
+++ b/docs/UnderTheHood/lowering_architecture.md
@@ -188,8 +188,13 @@ JAX export, used only by `post_process()` — so a compiled problem holds **one
 `iteration_fn` plus one propagation export**, not three discretization /
 propagation exports stitched together in Python. Because `iteration_fn` is a
 registered pytree in and out, it also composes with `jax.jit`; `make_solve_loop`
-wraps it in `lax.while_loop` as the primitive for a future fully-JAX-driven
-solve.
+wraps it in `lax.while_loop` to drive the **JAX-pure** `Problem.solve_jax()`
+entry point, which composes with `jax.vmap`, `jax.jit`, and `jax.grad` (see
+`docs/UnderTheHood/batching_jit_grad.md`). The familiar
+`Problem.solve()` keeps its Python-loop shape — real-time prints, wall-clock
+`time_limit`, populated per-iteration history — and is the right entry
+point for interactive use. `solve_jax()` is the right entry point for
+batched / JIT'd / differentiable workflows.
 
 Picking a backend at construction time:
 

--- a/examples/abstract/brachistochrone_batched.py
+++ b/examples/abstract/brachistochrone_batched.py
@@ -1,0 +1,128 @@
+"""Batched brachistochrone via ``jax.vmap(problem.solve_jax)``.
+
+Solves four brachistochrone problems in parallel — each with a different
+starting x-coordinate — using the JAX-pure
+:meth:`~openscvx.problem.Problem.solve_jax` entry point. ``solve_jax``
+returns an :class:`~openscvx.algorithms.optimization_results.OptimizationResults`
+pytree, so ``jax.vmap`` over the boundary-condition pins is the standard JAX
+composition pattern; no library-specific batching API is needed.
+
+Run with ``python examples/abstract/brachistochrone_batched.py``.
+
+Notes:
+
+* Under the QPAX backend used here, vmap'd subproblem solves run in
+  parallel (no host callback). The CVXPy backend is single-threaded under
+  vmap because :func:`jax.pure_callback` uses ``vmap_method="sequential"``
+  for thread safety — see :meth:`solve_jax`'s docstring.
+* The Moreau warm-start is bypassed on the JAX-pure path (its carry is
+  host-side state that ``lax.while_loop`` doesn't thread). Use QPAX or
+  CVXPy when you want batched solves.
+"""
+
+import os
+import sys
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+grandparent_dir = os.path.dirname(os.path.dirname(current_dir))
+sys.path.append(grandparent_dir)
+
+import openscvx as ox
+from openscvx import Problem
+
+
+def build_problem(n: int = 8):
+    g = 9.81
+
+    position = ox.State("position", shape=(2,))
+    position.max = np.array([10.0, 10.0])
+    position.min = np.array([0.0, 0.0])
+    position.initial = np.array([0.0, 10.0])
+    position.final = [10.0, 5.0]
+
+    velocity = ox.State("velocity", shape=(1,))
+    velocity.max = np.array([10.0])
+    velocity.min = np.array([0.0])
+    velocity.initial = np.array([0.0])
+    velocity.final = [("free", 10.0)]
+
+    theta = ox.Control("theta", shape=(1,))
+    theta.max = np.array([100.5 * jnp.pi / 180])
+    theta.min = np.array([0.0])
+    theta.guess = np.linspace(5 * jnp.pi / 180, 100.5 * jnp.pi / 180, n).reshape(-1, 1)
+
+    states = [position, velocity]
+    controls = [theta]
+
+    dynamics = {
+        "position": ox.Concat(
+            velocity[0] * ox.Sin(theta[0]),
+            -velocity[0] * ox.Cos(theta[0]),
+        ),
+        "velocity": g * ox.Cos(theta[0]),
+    }
+
+    constraint_exprs = []
+    for state in states:
+        constraint_exprs.extend([ox.ctcs(state <= state.max), ox.ctcs(state.min <= state)])
+
+    time = ox.Time(
+        initial=0.0,
+        final=("minimize", 2.0),
+        min=0.0,
+        max=2.0,
+        uniform_time_grid=True,
+    )
+
+    return Problem(
+        dynamics=dynamics,
+        states=states,
+        controls=controls,
+        time=time,
+        constraints=constraint_exprs,
+        N=n,
+        float_dtype="float64",
+        algorithm={
+            "autotuner": "ConstantProximalWeight",
+            "lam_prox": 1e0,
+            "lam_cost": 6e-1,
+            "ep_tr": 1e-5,
+            "ep_vb": 1e-5,
+            "ep_vc": 1e-9,
+            "k_max": 30,
+        },
+        solver={"backend": "qpax"},
+    )
+
+
+if __name__ == "__main__":
+    problem = build_problem()
+    problem.initialize()
+
+    # The default boundary-condition pin (the full unified state vector with
+    # ``jnp.nan`` at non-Fix entries — see
+    # :meth:`AlgorithmState.from_settings`).
+    default_pin = problem.state.x_init_pin
+
+    # Stack four ICs by varying the starting x-coordinate (component 0 of
+    # the unified state vector is the x-position).
+    shifts = jnp.array([0.0, 0.3, 0.6, 0.9])
+    x_initial_stack = jnp.stack(
+        [default_pin.at[0].set(default_pin[0] + s) for s in shifts]
+    )
+
+    # Bare ``jax.vmap`` — the library exposes no batching wrapper of its own.
+    batched_solve = jax.vmap(problem.solve_jax, in_axes=(0, None, None))
+    results = batched_solve(x_initial_stack, None, None)
+
+    # ``results`` is a batched ``OptimizationResults`` pytree — every child
+    # (``X``, ``U``, ``t_final``, ``converged``, ...) has a leading batch axis.
+    print(f"Batched solve over {x_initial_stack.shape[0]} initial conditions:")
+    print(f"  result.x.shape:   {results.x.shape}")
+    print(f"  result.u.shape:   {results.u.shape}")
+    print(f"  result.t_final:   {np.asarray(results.t_final).reshape(-1)}")
+    print(f"  result.converged: {np.asarray(results.converged)}")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -198,3 +198,4 @@ nav:
     - Under the Hood:
       - 'UnderTheHood/vectorization_and_vmapping.md'
       - 'UnderTheHood/lowering_architecture.md'
+      - 'UnderTheHood/batching_jit_grad.md'

--- a/openscvx/algorithms/optimization_results.py
+++ b/openscvx/algorithms/optimization_results.py
@@ -1,10 +1,17 @@
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
+import jax
+import jax.numpy as jnp
 import numpy as np
 
+if TYPE_CHECKING:
+    from openscvx.algorithms.base import AlgorithmHistory, AlgorithmState
+    from openscvx.problem import Problem
 
+
+@jax.tree_util.register_pytree_node_class
 @dataclass
 class OptimizationResults:
     """
@@ -44,6 +51,30 @@ class OptimizationResults:
             Added by propagate_trajectory_results.
         plotting_data (dict[str, Any]): Flexible storage for plotting and application data.
 
+    !!! note "JAX pytree registration"
+        ``OptimizationResults`` is a registered JAX pytree, so the output of
+        :meth:`~openscvx.problem.Problem.solve_jax` composes with
+        ``jax.vmap`` / ``jax.jit`` / ``jax.grad``. The pytree *children* are
+        ``converged``, ``t_final``, ``nodes``, ``trajectory``, ``X``, ``U``,
+        and every ``*_history`` field — the data the user actually consumes.
+        Post-process fields (``t_full``, ``x_full``, ``u_full``, ``cost``,
+        ``ctcs_violation``), ``plotting_data``, and the internal ``_states`` /
+        ``_controls`` metadata are stashed in the treedef's *aux* instead, so
+        a batched ``solve_jax`` doesn't force callers to handle ``None``
+        leaves and ``post_process()`` outputs stay outside the vmap surface
+        (post-process per element after the batched solve).
+
+        The two construction paths produce different histories:
+
+        * :meth:`from_history` (``solve()``) populates the per-iteration
+          ``X`` / ``U`` / ``*_history`` lists from the Python loop's
+          :class:`~openscvx.algorithms.base.AlgorithmHistory`.
+        * :meth:`from_final_state` (``solve_jax()``) wraps only the final
+          iterate: ``X = [state.x]`` and ``U = [state.u]`` (single-element
+          lists so ``result.x`` / ``result.u`` continue to return the final
+          iterate), and every ``*_history`` field is empty — per-iteration
+          history requires Python-side list growth that can't run inside
+          ``lax.while_loop``.
 
     !!! note "For Developers"
         The ``metadata={"npz": ...}`` parameter on each field below is a built-in feature of
@@ -65,6 +96,30 @@ class OptimizationResults:
     _DICT = "dict"
     _OPT_ARRAY = "optional_array"
     _OPT_SCALAR = "optional_scalar"
+
+    # Pytree children: fields whose contents flow through ``jax.vmap`` /
+    # ``jax.jit`` / ``jax.grad``. Excludes ``_states`` / ``_controls`` (Python
+    # symbolic metadata), ``plotting_data`` (user scratch), and the
+    # post-process fields (``None`` until ``post_process()`` runs and not part
+    # of the ``solve_jax`` vmap surface — see the class docstring).
+    _PYTREE_CHILDREN = (
+        "converged",
+        "t_final",
+        "nodes",
+        "trajectory",
+        "X",
+        "U",
+        "discretization_history",
+        "J_tr_history",
+        "J_vb_history",
+        "J_vc_history",
+        "TR_history",
+        "VC_history",
+        "lam_prox_history",
+        "actual_reduction_history",
+        "pred_reduction_history",
+        "acceptance_ratio_history",
+    )
 
     # Core optimization results
     converged: bool = field(metadata={"npz": "scalar"})
@@ -137,6 +192,183 @@ class OptimizationResults:
     def __post_init__(self):
         """Initialize the results object."""
         pass
+
+    # ------------------------------------------------------------------
+    # JAX pytree registration
+    # ------------------------------------------------------------------
+
+    def tree_flatten(self):
+        """Split into JAX-traceable children and host-side aux.
+
+        See :attr:`_PYTREE_CHILDREN` for the children list. Aux carries the
+        symbolic metadata, scratch dict, and post-process fields verbatim so
+        the round-trip ``tree_unflatten(*tree_flatten(self))`` preserves the
+        instance.
+        """
+        children = tuple(getattr(self, name) for name in self._PYTREE_CHILDREN)
+        aux = (
+            self._states,
+            self._controls,
+            self.t_full,
+            self.x_full,
+            self.u_full,
+            self.cost,
+            self.ctcs_violation,
+            self.plotting_data,
+        )
+        return children, aux
+
+    @classmethod
+    def tree_unflatten(cls, aux, children):
+        kwargs = dict(zip(cls._PYTREE_CHILDREN, children))
+        (
+            _states,
+            _controls,
+            t_full,
+            x_full,
+            u_full,
+            cost,
+            ctcs_violation,
+            plotting_data,
+        ) = aux
+        return cls(
+            **kwargs,
+            _states=_states,
+            _controls=_controls,
+            t_full=t_full,
+            x_full=x_full,
+            u_full=u_full,
+            cost=cost,
+            ctcs_violation=ctcs_violation,
+            plotting_data=plotting_data,
+        )
+
+    # ------------------------------------------------------------------
+    # Constructors
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_final_state(
+        cls,
+        state: "AlgorithmState",
+        *,
+        problem: "Problem",
+    ) -> "OptimizationResults":
+        """JAX-pure construction from the final SCP iterate.
+
+        Used by :meth:`~openscvx.problem.Problem.solve_jax`. Every leaf is a
+        ``jnp.ndarray`` derived from ``state`` via static slicing, so the
+        result composes with ``jax.vmap`` / ``jax.jit`` / ``jax.grad`` over a
+        batched ``state``. ``X = [state.x]`` and ``U = [state.u]`` are
+        single-element lists so ``result.x`` / ``result.u`` continue to
+        return the final iterate; every ``*_history`` field is empty — the
+        Python-loop ``.solve()`` is the path that populates them.
+        """
+        settings = problem.settings
+        symbolic = problem.symbolic
+        algorithm = problem._algorithm
+
+        has_impulsive_controls = any(
+            control.parameterization == "impulsive" for control in symbolic.controls
+        )
+
+        nodes_dict: dict[str, jnp.ndarray] = {}
+        for sym_state in symbolic.states:
+            state_nodes = state.x[..., sym_state._slice]
+            if has_impulsive_controls:
+                bc = jnp.asarray(settings.sim.x.initial[sym_state._slice])
+                state_nodes = state_nodes.at[..., 0, :].set(bc)
+            nodes_dict[sym_state.name] = state_nodes
+
+        for control in symbolic.controls:
+            nodes_dict[control.name] = state.u[..., control._slice]
+
+        # Match the host-path ``t_final`` shape: a 1-vector along the time
+        # slice of the last node (vmap'd to ``(B, 1)``).
+        t_final = state.x[..., -1, :][..., settings.sim.time_slice]
+
+        converged = (
+            (state.J_tr < algorithm.ep_tr)
+            & (state.J_vb < algorithm.ep_vb)
+            & (state.J_vc < algorithm.ep_vc)
+        )
+
+        return cls(
+            converged=converged,
+            t_final=t_final,
+            nodes=nodes_dict,
+            trajectory={},
+            _states=symbolic.states_prop,
+            _controls=symbolic.controls,
+            X=[state.x],
+            U=[state.u],
+            discretization_history=[],
+            J_tr_history=[],
+            J_vb_history=[],
+            J_vc_history=[],
+            TR_history=[],
+            VC_history=[],
+            lam_prox_history=[],
+            actual_reduction_history=[],
+            pred_reduction_history=[],
+            acceptance_ratio_history=[],
+        )
+
+    @classmethod
+    def from_history(
+        cls,
+        history: "AlgorithmHistory",
+        final_state: "AlgorithmState",
+        *,
+        problem: "Problem",
+        converged: bool,
+    ) -> "OptimizationResults":
+        """Host-side construction from the Python-loop iteration history.
+
+        Used by :meth:`~openscvx.problem.Problem.solve` to package the full
+        per-iteration log produced by the Python ``while`` loop. Symmetric
+        with :meth:`from_final_state` — same return type, populated history.
+        """
+        settings = problem.settings
+        symbolic = problem.symbolic
+
+        has_impulsive_controls = any(
+            control.parameterization == "impulsive" for control in symbolic.controls
+        )
+
+        x_arr = np.asarray(final_state.x)
+        u_arr = np.asarray(final_state.u)
+
+        nodes_dict: dict[str, np.ndarray] = {}
+        for sym_state in symbolic.states:
+            state_nodes = x_arr[:, sym_state._slice].copy()
+            if has_impulsive_controls:
+                state_nodes[0] = settings.sim.x.initial[sym_state._slice]
+            nodes_dict[sym_state.name] = state_nodes
+
+        for control in symbolic.controls:
+            nodes_dict[control.name] = u_arr[:, control._slice]
+
+        return cls(
+            converged=converged,
+            t_final=x_arr[:, settings.sim.time_slice][-1],
+            nodes=nodes_dict,
+            trajectory={},
+            _states=symbolic.states_prop,
+            _controls=symbolic.controls,
+            X=history.X,
+            U=history.U,
+            discretization_history=history.V_history,
+            J_tr_history=float(final_state.J_tr),
+            J_vb_history=float(final_state.J_vb),
+            J_vc_history=float(final_state.J_vc),
+            TR_history=history.TR,
+            VC_history=history.VC,
+            lam_prox_history=history.lam_prox.copy(),
+            actual_reduction_history=history.actual_reduction.copy(),
+            pred_reduction_history=history.pred_reduction.copy(),
+            acceptance_ratio_history=history.acceptance_ratio.copy(),
+        )
 
     def update_plotting_data(self, **kwargs: Any) -> None:
         """

--- a/openscvx/algorithms/scvx/iteration.py
+++ b/openscvx/algorithms/scvx/iteration.py
@@ -361,8 +361,25 @@ def make_solve_loop(
             return (state.k <= k_max) & jnp.logical_not(_converged(state, ep_tr, ep_vb, ep_vc))
 
         def body(state: AlgorithmState) -> AlgorithmState:
+            # Under ``jax.vmap`` the ``lax.while_loop`` keeps running until
+            # every batch element has converged; without a freeze, the body
+            # would keep mutating already-converged elements (their iterates
+            # drift through repeated subproblem solves, and the autotuner
+            # would keep advancing ``lam_prox`` / ``lam_cost``). Selecting
+            # ``state`` for converged elements pins them to their first
+            # post-convergence iterate, so a batched solve agrees with the
+            # single-problem ``solve_jax`` on each element.
+            is_converged = _converged(state, ep_tr, ep_vb, ep_vc)
             next_state, _ = iteration_fn(state, params)
-            return next_state
+
+            def freeze(nxt, prev):
+                # ``is_converged`` is scalar (single-problem) or shape ``(B,)``
+                # (vmap'd); reshape with trailing 1-axes so it broadcasts over
+                # each leaf's remaining dims.
+                mask_shape = is_converged.shape + (1,) * (nxt.ndim - is_converged.ndim)
+                return jnp.where(is_converged.reshape(mask_shape), prev, nxt)
+
+            return jax.tree.map(freeze, next_state, state)
 
         return jax.lax.while_loop(cond, body, state)
 

--- a/openscvx/problem.py
+++ b/openscvx/problem.py
@@ -1159,9 +1159,9 @@ class Problem:
     ) -> OptimizationResults:
         """Run the SCP algorithm — JAX-pure.
 
-        Composes with ``jax.vmap``, ``jax.jit``, and ``jax.grad``. Drives
-        the fused ``iteration_fn`` inside a ``lax.while_loop`` rather than
-        the Python ``while`` loop that :meth:`solve` uses. Returns an
+        Composes with ``jax.vmap`` and ``jax.jit``. Drives the fused
+        ``iteration_fn`` inside a ``lax.while_loop`` rather than the Python
+        ``while`` loop that :meth:`solve` uses. Returns an
         :class:`OptimizationResults` pytree built by
         :meth:`OptimizationResults.from_final_state` — per-iteration history
         (``X``/``U`` lists past the final iterate, ``*_history`` fields,
@@ -1170,23 +1170,9 @@ class Problem:
         ``time_limit``, ``continuous`` mode, or populated history, use
         :meth:`solve`.
 
-        Caveats:
-
-        * **CVXPy backend.** :meth:`~openscvx.solvers.cvxpy_ptr_solver.CVXPyPTRSolver.iteration_callback`
-          host-calls CVXPy through :func:`jax.pure_callback` with
-          ``vmap_method="sequential"`` — host CVXPy is not thread-safe, so a
-          ``jax.vmap(problem.solve_jax)`` over the CVXPy backend runs ``B``
-          sequential CVXPy solves. The QPAX and Moreau backends run in
-          parallel under vmap (no host callback).
-        * **Moreau warm-start.** :class:`~openscvx.solvers.moreau_ptr_solver.MoreauPTRSolver`'s
-          ``_warm_start`` carry is host-side mutable state that ``lax.while_loop``
-          can't thread, so the JAX-pure path cold-starts the inner Moreau
-          solve every iteration. :meth:`solve` continues to warm-start.
-        * **``jax.grad`` is best-effort, untested.** The QPAX backend's
-          ``solve_qp`` is not differentiable (its convergence flag costs
-          reverse-mode autodiff); the CVXPy backend's ``pure_callback`` is
-          non-differentiable by default. End-to-end gradient validation is
-          a follow-up.
+        With the CVXPy backend, ``jax.vmap(problem.solve_jax)`` runs ``B``
+        sequential CVXPy solves (host CVXPy is not thread-safe); the QPAX
+        and Moreau backends run in parallel under vmap.
 
         Args:
             x_initial: Initial-state boundary pin, shape ``(n_states,)``.

--- a/openscvx/problem.py
+++ b/openscvx/problem.py
@@ -21,7 +21,6 @@ import time
 from typing import Dict, List, Optional, Union
 
 import jax
-import numpy as np
 
 os.environ["EQX_ON_ERROR"] = "nan"
 
@@ -32,7 +31,9 @@ from openscvx.algorithms import (
     OptimizationResults,
     PenalizedTrustRegionConfig,
 )
-from openscvx.algorithms.scvx.iteration import make_scp_iteration
+import jax.numpy as jnp
+
+from openscvx.algorithms.scvx.iteration import make_scp_iteration, make_solve_loop
 from openscvx.config import (
     Config,
     DevConfig,
@@ -369,6 +370,12 @@ class Problem:
         # Fused JAX-pure SCP iteration body (built in initialize()).
         self._iteration_fn: callable = None
 
+        # Closure cache for the ``lax.while_loop`` wrapper that backs
+        # :meth:`solve_jax`. Keyed on ``k_max`` — rebuilt only when the caller
+        # supplies a non-default ``max_iters``.
+        self._solve_loop_fn: Optional[callable] = None
+        self._solve_loop_k_max: Optional[int] = None
+
         # Set up emitter & queue (thread started in initialize() after columns are known)
         if self.settings.dev.printing:
             self.print_queue = queue.Queue()
@@ -682,50 +689,12 @@ class Problem:
     ) -> OptimizationResults:
         """Format the current iterate + history as :class:`OptimizationResults`.
 
-        Args:
-            state: The final-iterate pytree.
-            history: The CPU-side per-iteration log.
-            converged: Whether the optimization converged.
+        Thin wrapper around :meth:`OptimizationResults.from_history` — kept
+        as a method so ``solve()`` / ``post_process()`` call sites read
+        naturally.
         """
-        # Build nodes dictionary with all states and controls
-        nodes_dict = {}
-        has_impulsive_controls = any(
-            control.parameterization == "impulsive" for control in self.symbolic.controls
-        )
-
-        x_arr = np.asarray(state.x)
-        u_arr = np.asarray(state.u)
-
-        # Add all states (user-defined and augmented)
-        for sym_state in self.symbolic.states:
-            state_nodes = x_arr[:, sym_state._slice].copy()
-            if has_impulsive_controls:
-                state_nodes[0] = self.settings.sim.x.initial[sym_state._slice]
-            nodes_dict[sym_state.name] = state_nodes
-
-        # Add all controls (user-defined and augmented)
-        for control in self.symbolic.controls:
-            nodes_dict[control.name] = u_arr[:, control._slice]
-
-        return OptimizationResults(
-            converged=converged,
-            t_final=x_arr[:, self.settings.sim.time_slice][-1],
-            nodes=nodes_dict,
-            trajectory={},  # Populated by post_process
-            _states=self.symbolic.states_prop,  # Use propagation states for trajectory dict
-            _controls=self.symbolic.controls,
-            X=history.X,
-            U=history.U,
-            discretization_history=history.V_history,
-            J_tr_history=float(state.J_tr),
-            J_vb_history=float(state.J_vb),
-            J_vc_history=float(state.J_vc),
-            TR_history=history.TR,
-            VC_history=history.VC,
-            lam_prox_history=history.lam_prox.copy(),
-            actual_reduction_history=history.actual_reduction.copy(),
-            pred_reduction_history=history.pred_reduction.copy(),
-            acceptance_ratio_history=history.acceptance_ratio.copy(),
+        return OptimizationResults.from_history(
+            history, state, problem=self, converged=converged
         )
 
     def initialize(self):
@@ -884,6 +853,11 @@ class Problem:
         # iteration_callback), and folds the result through the autotuner — one
         # JIT'd call per SCP step in place of the old NumPy↔JAX stitching.
         print("Initializing the SCvx Subproblem Solver...")
+        # Drop any prior ``solve_jax`` closure — it captures the previous
+        # ``iteration_fn`` and would re-use stale traces if ``initialize()``
+        # is invoked twice.
+        self._solve_loop_fn = None
+        self._solve_loop_k_max = None
         self._iteration_fn = jax.jit(
             make_scp_iteration(
                 dis_continuous=discretization_solver,
@@ -907,6 +881,14 @@ class Problem:
         # shapes the first time, same as if no warmup had happened).
         warmup_state = AlgorithmState.from_settings(self.settings, self._algorithm.weights)
         jax.block_until_ready(self._iteration_fn(warmup_state, self._parameters))
+
+        # Build + warm the ``lax.while_loop`` closure that backs
+        # :meth:`solve_jax`. AOT via ``.lower().compile()`` would return an
+        # XLA executable that isn't vmap-traceable; a real-call warmup
+        # populates ``jax.jit``'s standard shape-keyed cache, which vmap
+        # retraces from on first use.
+        solve_loop = self._get_or_build_solve_loop(None)
+        jax.block_until_ready(solve_loop(warmup_state, self._parameters))
         print("✓ SCvx Subproblem Solver initialized")
 
         # Get columns from algorithm (now that autotuner is set) and start print thread
@@ -1038,6 +1020,12 @@ class Problem:
     ) -> OptimizationResults:
         """Run the SCP algorithm until convergence or iteration limit.
 
+        Drives the fused ``iteration_fn`` body from a Python ``while``
+        loop — real-time prints, wall-clock ``time_limit``, ``continuous``
+        mode, and the populated per-iteration history live here. For
+        batched solves, ``jax.jit`` compilation across calls, or
+        ``jax.grad`` through the solver, use :meth:`solve_jax`.
+
         Args:
             max_iters: Maximum iterations (default: algorithm.k_max)
             time_limit: Wall-clock time limit in seconds. Overrides
@@ -1109,6 +1097,124 @@ class Problem:
             self._history,
             int(self._state.k) <= k_max and not timed_out,
         )
+
+    def _resolve_initial_state(
+        self,
+        x_initial: Optional[jnp.ndarray],
+        x_final: Optional[jnp.ndarray],
+    ) -> AlgorithmState:
+        """Build a fresh :class:`AlgorithmState` with user-supplied boundary pins.
+
+        The pins live on the pytree (``x_init_pin`` / ``x_term_pin``) so the
+        fused iteration body assembles the subproblem's initial / terminal
+        rows as a pure function of state. Under ``jax.vmap`` over
+        ``x_initial`` / ``x_final``, the pins batch per element — each batch
+        slot gets its own boundary condition without recompilation.
+
+        ``None`` falls back to the defaults from
+        :meth:`AlgorithmState.from_settings`. A user-supplied vector replaces
+        the corresponding pin in full; pass ``jnp.nan`` at non-pinned
+        entries to match the convention :meth:`from_settings` uses (the
+        subproblem only consumes the pin where the boundary type is
+        ``"Fix"``).
+        """
+        state = AlgorithmState.from_settings(self.settings, self._algorithm.weights)
+        if x_initial is not None:
+            state = state.replace(x_init_pin=jnp.asarray(x_initial, dtype=state.x_init_pin.dtype))
+        if x_final is not None:
+            state = state.replace(x_term_pin=jnp.asarray(x_final, dtype=state.x_term_pin.dtype))
+        return state
+
+    def _get_or_build_solve_loop(self, max_iters: Optional[int]) -> callable:
+        """Return the cached ``jax.jit``'d ``lax.while_loop`` wrapper.
+
+        :func:`make_solve_loop` is hashable on ``k_max`` (the convergence
+        thresholds are problem constants). Cache the closure on
+        ``self._solve_loop_fn`` keyed on ``k_max`` and rebuild only when the
+        caller supplies a non-default ``max_iters``. The closure is wrapped
+        in :func:`jax.jit` so :meth:`solve_jax` shares its compile cache
+        with the warmup call in :meth:`initialize`.
+        """
+        k_max = max_iters if max_iters is not None else self._algorithm.k_max
+        if self._solve_loop_fn is None or self._solve_loop_k_max != k_max:
+            self._solve_loop_fn = jax.jit(
+                make_solve_loop(
+                    self._iteration_fn,
+                    self._algorithm.ep_tr,
+                    self._algorithm.ep_vb,
+                    self._algorithm.ep_vc,
+                    k_max,
+                )
+            )
+            self._solve_loop_k_max = k_max
+        return self._solve_loop_fn
+
+    def solve_jax(
+        self,
+        x_initial: Optional[jnp.ndarray] = None,
+        x_final: Optional[jnp.ndarray] = None,
+        parameters: Optional[dict] = None,
+        *,
+        max_iters: Optional[int] = None,
+    ) -> OptimizationResults:
+        """Run the SCP algorithm — JAX-pure.
+
+        Composes with ``jax.vmap``, ``jax.jit``, and ``jax.grad``. Drives
+        the fused ``iteration_fn`` inside a ``lax.while_loop`` rather than
+        the Python ``while`` loop that :meth:`solve` uses. Returns an
+        :class:`OptimizationResults` pytree built by
+        :meth:`OptimizationResults.from_final_state` — per-iteration history
+        (``X``/``U`` lists past the final iterate, ``*_history`` fields,
+        ``discretization_history``) is empty under this path, because list
+        growth doesn't fit inside ``lax.while_loop``. For prints, wall-clock
+        ``time_limit``, ``continuous`` mode, or populated history, use
+        :meth:`solve`.
+
+        Caveats:
+
+        * **CVXPy backend.** :meth:`~openscvx.solvers.cvxpy_ptr_solver.CVXPyPTRSolver.iteration_callback`
+          host-calls CVXPy through :func:`jax.pure_callback` with
+          ``vmap_method="sequential"`` — host CVXPy is not thread-safe, so a
+          ``jax.vmap(problem.solve_jax)`` over the CVXPy backend runs ``B``
+          sequential CVXPy solves. The QPAX and Moreau backends run in
+          parallel under vmap (no host callback).
+        * **Moreau warm-start.** :class:`~openscvx.solvers.moreau_ptr_solver.MoreauPTRSolver`'s
+          ``_warm_start`` carry is host-side mutable state that ``lax.while_loop``
+          can't thread, so the JAX-pure path cold-starts the inner Moreau
+          solve every iteration. :meth:`solve` continues to warm-start.
+        * **``jax.grad`` is best-effort, untested.** The QPAX backend's
+          ``solve_qp`` is not differentiable (its convergence flag costs
+          reverse-mode autodiff); the CVXPy backend's ``pure_callback`` is
+          non-differentiable by default. End-to-end gradient validation is
+          a follow-up.
+
+        Args:
+            x_initial: Initial-state boundary pin, shape ``(n_states,)``.
+                Replaces ``state.x_init_pin``; pass ``jnp.nan`` at non-Fix
+                entries to match :meth:`AlgorithmState.from_settings`'
+                convention. ``None`` uses the default from settings.
+            x_final: Terminal-state boundary pin, shape ``(n_states,)``.
+                Same conventions as ``x_initial``.
+            parameters: Problem parameters dict for the current solve. Use
+                this rather than mutating ``self.parameters`` if the
+                parameters are traced. ``None`` reuses ``self._parameters``.
+            max_iters: SCP iteration cap. ``None`` uses ``algorithm.k_max``;
+                a different value rebuilds the cached ``lax.while_loop``
+                closure (one extra trace; subsequent calls at the same
+                ``max_iters`` hit the cache).
+
+        Returns:
+            :class:`OptimizationResults` pytree with the final iterate and
+            empty histories.
+        """
+        if self._iteration_fn is None:
+            raise ValueError("Problem has not been initialized. Call initialize() before solve_jax()")
+
+        initial_state = self._resolve_initial_state(x_initial, x_final)
+        params = parameters if parameters is not None else self._parameters
+        solve_fn = self._get_or_build_solve_loop(max_iters)
+        final_state = solve_fn(initial_state, params)
+        return OptimizationResults.from_final_state(final_state, problem=self)
 
     def post_process(self) -> OptimizationResults:
         """Propagate solution through full nonlinear dynamics for high-fidelity trajectory.

--- a/openscvx/solvers/moreau_ptr_solver.py
+++ b/openscvx/solvers/moreau_ptr_solver.py
@@ -274,8 +274,16 @@ class MoreauPTRSolver(PTRSolver):
     :meth:`initialize` and calls it as
     ``(P_data, A_data, q, b) -> (JaxSolution, JaxSolveInfo)`` so the backend
     composes with ``jax.jit`` and ``jax.vmap``. The functional API does not
-    expose a warm-start hook, so the JAX-pure path is cold-start every
-    iteration; the NumPy :meth:`solve` path keeps the OO warm-start.
+    expose a warm-start hook, so every call is a cold start: both
+    :meth:`~openscvx.problem.Problem.solve` and
+    :meth:`~openscvx.problem.Problem.solve_jax` drive
+    ``iteration_callback`` for the SCP body, so neither thread Moreau's
+    ``_warm_start`` carry across SCP iterations. The OO warm-start path
+    still mutates ``_warm_start`` on each :meth:`solve` call (the legacy
+    NumPy entry point, no longer on the SCP hot path); restoring
+    warm-start to the SCP loop requires routing ``(x, z, s)`` through
+    :class:`AlgorithmState` as a real pytree carry — see the
+    Future Extensions in ``plans/jax-pure-solve.md``.
 
     Scope:
         Supported — state/control box, dynamics linearization (continuous
@@ -1255,7 +1263,12 @@ class MoreauPTRSolver(PTRSolver):
         path but does **not** accept a warm-start (see the 2026-05-17 Decision
         Log entry in ``plans/solver-iteration-callbacks.md``). Every call is a
         cold start; ``state`` is accepted only for cross-backend signature
-        uniformity.
+        uniformity. Both :meth:`~openscvx.problem.Problem.solve` and
+        :meth:`~openscvx.problem.Problem.solve_jax` route through this
+        callback for the SCP body, so the warm-start carry isn't threaded
+        on either path — threading it would require an
+        :class:`AlgorithmState.moreau_carry` field (future extension in
+        ``plans/jax-pure-solve.md``).
 
         The returned callable takes ``(state, data)``: ``state`` is the
         :class:`AlgorithmState` pytree, accepted for cross-backend signature

--- a/tests/test_solve_jax_bare_brachistochrone.py
+++ b/tests/test_solve_jax_bare_brachistochrone.py
@@ -1,0 +1,70 @@
+"""``Problem.solve_jax()`` must match ``Problem.solve()`` on brachistochrone.
+
+The Python-loop ``solve()`` and the ``lax.while_loop``-driven ``solve_jax()``
+share the same fused ``iteration_fn`` body — the only divergence is the
+floating-point reordering between Python-loop and ``lax.while_loop``-compiled
+execution, plus any termination-criterion timing differences. Both should
+converge to the same iterate within tolerance on a fixed-seed brachistochrone.
+Parametrized over the two backends that work today (CVXPy / QPAX); Moreau is
+excluded because its warm-start carry is host-side state that neither path
+threads (see ``plans/jax-pure-solve.md`` Decision Log 2026-05-27).
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from tests.solvers._iteration_callback_helpers import build_brachistochrone
+
+
+@pytest.mark.parametrize("backend", ["cvxpy", "qpax"])
+def test_solve_jax_matches_solve(backend):
+    if backend == "qpax":
+        pytest.importorskip("qpax")
+
+    prob = build_brachistochrone(backend, n=8, k_max=20)
+    prob.initialize()
+
+    prob.solve()
+    solve_x = np.asarray(prob.state.x)
+    solve_u = np.asarray(prob.state.u)
+
+    prob.reset()
+    result = prob.solve_jax()
+
+    np.testing.assert_allclose(np.asarray(result.x), solve_x, atol=1e-5, rtol=1e-5)
+    np.testing.assert_allclose(np.asarray(result.u), solve_u, atol=1e-5, rtol=1e-5)
+
+    # ``result.X`` is the single-element wrapper documented in
+    # ``OptimizationResults.from_final_state`` — same final iterate, lists
+    # exist so ``result.x`` continues to return ``X[-1]``.
+    assert len(result.X) == 1
+    assert len(result.U) == 1
+    # History fields are empty on the JAX-pure path.
+    assert result.J_tr_history == []
+    assert result.J_vb_history == []
+    assert result.J_vc_history == []
+    assert result.discretization_history == []
+
+    jax.clear_caches()
+
+
+def test_solve_jax_returns_pytree():
+    """The result registers as a JAX pytree (children flow through transforms)."""
+    pytest.importorskip("qpax")
+
+    prob = build_brachistochrone("qpax", n=4, k_max=2)
+    prob.initialize()
+    result = prob.solve_jax()
+
+    leaves, treedef = jax.tree_util.tree_flatten(result)
+    # Round-trip
+    rebuilt = jax.tree_util.tree_unflatten(treedef, leaves)
+    np.testing.assert_allclose(np.asarray(rebuilt.x), np.asarray(result.x))
+    assert bool(rebuilt.converged) == bool(result.converged)
+
+    # ``result.t_final`` is a jnp 1-vector (matches the host-path shape).
+    assert isinstance(result.t_final, jnp.ndarray)
+
+    jax.clear_caches()

--- a/tests/test_solve_jax_jit_brachistochrone.py
+++ b/tests/test_solve_jax_jit_brachistochrone.py
@@ -1,0 +1,36 @@
+"""``jax.jit(problem.solve_jax)`` matches the bare call.
+
+``solve_jax`` is JIT'd internally via the cached ``make_solve_loop`` closure,
+so wrapping again with ``jax.jit`` is a near no-op — but it's the canonical
+way users write "compile once, solve many times" (the MPC inner-loop shape
+from ``solve_jax``'s docstring), so the round-trip is worth a regression
+test.
+"""
+
+import jax
+import numpy as np
+import pytest
+
+from tests.solvers._iteration_callback_helpers import build_brachistochrone
+
+
+@pytest.mark.parametrize("backend", ["cvxpy", "qpax"])
+def test_jit_solve_jax_matches_bare(backend):
+    if backend == "qpax":
+        pytest.importorskip("qpax")
+
+    prob = build_brachistochrone(backend, n=8, k_max=20)
+    prob.initialize()
+
+    result_bare = prob.solve_jax()
+    fast_solve = jax.jit(prob.solve_jax)
+    result_jit = fast_solve()
+
+    np.testing.assert_allclose(
+        np.asarray(result_jit.x), np.asarray(result_bare.x), atol=1e-5, rtol=1e-5
+    )
+    np.testing.assert_allclose(
+        np.asarray(result_jit.u), np.asarray(result_bare.u), atol=1e-5, rtol=1e-5
+    )
+
+    jax.clear_caches()

--- a/tests/test_solve_jax_vmap_brachistochrone.py
+++ b/tests/test_solve_jax_vmap_brachistochrone.py
@@ -1,0 +1,53 @@
+"""``jax.vmap(problem.solve_jax)`` matches per-element ``solve_jax``.
+
+The batched solve over four stacked initial conditions should produce, for each
+batch element, the same trajectory as if that single problem were solved alone.
+CVXPy's :func:`jax.pure_callback` runs sequentially under vmap (host CVXPy
+isn't thread-safe — see ``solve_jax``'s docstring); QPAX runs in parallel.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from tests.solvers._iteration_callback_helpers import build_brachistochrone
+
+
+@pytest.mark.parametrize("backend", ["cvxpy", "qpax"])
+def test_vmap_solve_jax_matches_per_element(backend):
+    if backend == "qpax":
+        pytest.importorskip("qpax")
+
+    prob = build_brachistochrone(backend, n=8, k_max=20)
+    prob.initialize()
+
+    # Default pin (full unified vector with ``nan`` at non-Fix entries).
+    x_init_default = prob.state.x_init_pin
+
+    # Stack four ICs by varying the x-coordinate of position (component 0).
+    shifts = jnp.array([0.0, 0.3, -0.3, 0.6])
+    stacked = jnp.stack(
+        [x_init_default.at[0].set(x_init_default[0] + s) for s in shifts]
+    )
+
+    # Per-element reference.
+    bare_xs = []
+    bare_us = []
+    for i in range(stacked.shape[0]):
+        res = prob.solve_jax(x_initial=stacked[i])
+        bare_xs.append(np.asarray(res.x))
+        bare_us.append(np.asarray(res.u))
+    bare_xs = np.stack(bare_xs)
+    bare_us = np.stack(bare_us)
+
+    # Batched solve.
+    batched = jax.vmap(prob.solve_jax, in_axes=(0, None, None))(stacked, None, None)
+
+    assert batched.x.shape == bare_xs.shape
+    np.testing.assert_allclose(np.asarray(batched.x), bare_xs, atol=1e-5, rtol=1e-5)
+    np.testing.assert_allclose(np.asarray(batched.u), bare_us, atol=1e-5, rtol=1e-5)
+    # ``converged`` is a per-batch jnp.bool_ under vmap.
+    assert batched.converged.shape == (stacked.shape[0],)
+
+    jax.clear_caches()

--- a/tests/test_solve_jax_vmap_converged_no_drift.py
+++ b/tests/test_solve_jax_vmap_converged_no_drift.py
@@ -1,0 +1,127 @@
+"""Under vmap, an early-converging element's iterate doesn't drift.
+
+``jax.lax.while_loop`` runs until every batch element converges — converged
+elements keep receiving body calls while their peers iterate. Without a
+freeze, those extra iterations would compound subproblem-solver round-off
+into the converged element's state and the autotuner would keep advancing
+``lam_prox``, so the batched result for that element would not match the
+single-problem ``solve_jax``. ``make_solve_loop`` selects the unchanged
+state for converged elements (see Open Question 2 in
+``plans/jax-pure-solve.md``); this test pins that behavior.
+
+The harness uses a loose ``ep_tr`` so the first element converges in a few
+iterations on a near-default initial pin, while the second element starts
+much further off-default and needs more iterations to converge. Under vmap,
+the loop keeps running for both — the freeze pins the first element's
+state at its convergence iteration so it matches the single-problem solve.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+
+def _build_problem(backend: str, n: int = 30, k_max: int = 40):
+    """A converging brachistochrone with a loose-enough ``ep_tr`` for SCP
+    to actually fall below the threshold within ``k_max`` iterations."""
+    import openscvx as ox
+    from openscvx import Problem
+
+    g = 9.81
+
+    position = ox.State("position", shape=(2,))
+    position.max = np.array([10.0, 10.0])
+    position.min = np.array([0.0, 0.0])
+    position.initial = np.array([0.0, 10.0])
+    position.final = [10.0, 5.0]
+
+    velocity = ox.State("velocity", shape=(1,))
+    velocity.max = np.array([10.0])
+    velocity.min = np.array([0.0])
+    velocity.initial = np.array([0.0])
+    velocity.final = [("free", 10.0)]
+
+    theta = ox.Control("theta", shape=(1,))
+    theta.max = np.array([100.5 * jnp.pi / 180])
+    theta.min = np.array([0.0])
+    theta.guess = np.linspace(5 * jnp.pi / 180, 100.5 * jnp.pi / 180, n).reshape(-1, 1)
+
+    states = [position, velocity]
+    controls = [theta]
+
+    dynamics = {
+        "position": ox.Concat(
+            velocity[0] * ox.Sin(theta[0]),
+            -velocity[0] * ox.Cos(theta[0]),
+        ),
+        "velocity": g * ox.Cos(theta[0]),
+    }
+    constraint_exprs = [ox.ctcs(s <= s.max) for s in states] + [
+        ox.ctcs(s.min <= s) for s in states
+    ]
+
+    time = ox.Time(
+        initial=0.0,
+        final=("minimize", 2.0),
+        min=0.0,
+        max=2.0,
+        uniform_time_grid=True,
+    )
+
+    prob = Problem(
+        dynamics=dynamics,
+        states=states,
+        controls=controls,
+        time=time,
+        constraints=constraint_exprs,
+        N=n,
+        float_dtype="float64",
+        algorithm={
+            "autotuner": "ConstantProximalWeight",
+            "lam_prox": 1e0,
+            "lam_cost": 6e-1,
+            "k_max": k_max,
+            "ep_tr": 1e-2,  # loose enough that the loop actually converges
+            "ep_vb": 1e-2,
+            "ep_vc": 1e-2,
+        },
+        solver={"backend": backend},
+    )
+    prob.settings.dev.printing = False
+    return prob
+
+
+@pytest.mark.parametrize("backend", ["cvxpy", "qpax"])
+def test_vmap_no_drift_after_convergence(backend):
+    if backend == "qpax":
+        pytest.importorskip("qpax")
+
+    prob = _build_problem(backend)
+    prob.initialize()
+
+    # Two ICs — element 0 keeps the default x-start (problem converges fast),
+    # element 1 starts off by 1.0 in x (more aggressive shift, needs more
+    # SCP iterations to converge).
+    default_pin = prob.state.x_init_pin
+    shifted_pin = default_pin.at[0].set(default_pin[0] + 1.0)
+    stacked = jnp.stack([default_pin, shifted_pin])
+
+    # Single-problem references.
+    bare_xs = []
+    for i in range(stacked.shape[0]):
+        res = prob.solve_jax(x_initial=stacked[i])
+        bare_xs.append(np.asarray(res.x))
+    bare_xs = np.stack(bare_xs)
+
+    # Batched.
+    batched = jax.vmap(prob.solve_jax, in_axes=(0, None, None))(stacked, None, None)
+    batched_xs = np.asarray(batched.x)
+
+    for i in range(stacked.shape[0]):
+        np.testing.assert_allclose(
+            batched_xs[i], bare_xs[i], atol=1e-5, rtol=1e-5,
+            err_msg=f"batch element {i} drifted after convergence under vmap",
+        )
+
+    jax.clear_caches()


### PR DESCRIPTION
## Summary

- Adds `Problem.solve_jax()` — a JAX-pure entry point composable with `jax.vmap` and `jax.jit` — alongside the unchanged `Problem.solve()`. Two methods, zero dispatch: users pick by name based on whether they need batching/JIT or prints/`time_limit`/history.
- `OptimizationResults` registers as a JAX pytree; new `from_final_state` (JAX path) / `from_history` (Python path) constructors split the empty-history vs full-history asymmetry honestly.
- `make_solve_loop`'s `lax.while_loop` body pins already-converged batch elements to their first post-convergence iterate, so `jax.vmap(problem.solve_jax)` agrees with per-element `solve_jax` (no drift from extra iterations after convergence).
- Moreau cold-start framing corrected: post-Plan-1 it's cold-start on **both** paths today; only the legacy NumPy `solve()` entry point (no longer on the SCP hot path) warm-starts. Docstrings updated to say so honestly.
- Four new tests (bare / vmap / jit / no-drift); new `examples/abstract/brachistochrone_batched.py` and `docs/UnderTheHood/batching_jit_grad.md`.

Not in scope: changes to `Problem.solve()` (kept verbatim), validated `jax.grad` through `solve_jax`, Moreau warm-start under the JAX path, `lax.scan`-based per-iteration history.

## Test plan

- [ ] `pytest -n auto -m 'not integration' tests/algorithms/ tests/test_brachistochrone.py tests/test_optimization_results.py tests/test_solve_jax_*.py` green (locally: 65 passed, 5 skipped).
- [ ] Spot-check `examples/abstract/brachistochrone_batched.py` runs end-to-end and prints batched shapes / `t_final` / `converged` for the four ICs.
- [ ] Confirm `jax.vmap(problem.solve_jax)` on the CVXPy backend runs B sequential CVXPy solves (no host-CVXPy thread-safety violation).

## Follow-ups (not in this PR)

- Inline three single-call-site `Problem` helpers (`_resolve_initial_state`, `_format_result`, `_get_or_build_solve_loop`) per panel review.
- Fix carried-forward `from_history` bug writing `float(...)` into `list[np.ndarray]`-typed `J_*_history` fields.
- Sketch landed at `plans/solve-batched-export.md` for the eventual exportable, disk-cached `solve_batched`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)