### PR TITLE
Problem.solve_batched() — export-friendly batched solve

### DIFF
--- a/docs/UnderTheHood/batching_jit_grad.md
+++ b/docs/UnderTheHood/batching_jit_grad.md
@@ -49,6 +49,81 @@ Python loop) are exactly the failure class the two-method design exists to
 prevent. See `plans/jax-pure-solve.md`'s Decision Log for the longer
 discussion.
 
+## Batched, disk-cached solves with `solve_batched()`
+
+`jax.vmap(solve_jax)` and `solve_batched()` both run `B` SCP solves over
+stacked boundary conditions; they differ in **who owns the batch axis**, and
+that one difference is the whole point.
+
+* `jax.vmap(solve_jax)` — *the caller* owns the axis. Maximally idiomatic,
+  composes with `grad` / `scan`, but **in-process JIT only**: `jax.export` has
+  no outer `vmap` rule (`call_exported` cannot be batched), so an exported
+  artifact can never be re-vmapped, and every fresh process re-traces and
+  re-compiles the entire loop.
+* `solve_batched(x0_stack, xf_stack)` — *the library* owns the axis. The vmap
+  is applied **inside** the method, before any export, so the whole loop lowers
+  to ordinary batched XLA ops and serializes cleanly. Under
+  `save_compiled=True` it is written to the solver cache on the first run and
+  deserialized on later processes — skipping the XLA compile that
+  `jax.vmap(solve_jax)` pays on every launch.
+
+```python
+problem = ox.Problem(..., solver={"backend": "qpax"})
+problem.settings.sim.save_compiled = True
+problem.initialize()
+
+# First process: traces, exports, writes <cache>/compiled_solve_batched_<hash>.jax
+# Later processes: deserialize-and-.call, no compile.
+batched = problem.solve_batched(x0_stack, xf_stack, params)
+# batched.x.shape == (B, N, n_states) — same pytree jax.vmap(solve_jax) returns.
+```
+
+Pick `solve_batched` when **cross-process cold-start dominates** — short-lived
+processes (CI sweeps, notebook restarts, deployed workers) that otherwise pay
+the compile every launch. Pick `jax.vmap(solve_jax)` for everything in-program,
+where you own the transforms and want `grad` / `scan` composition. With
+`save_compiled=False`, `solve_batched` is just an in-process batched wrapper and
+the two produce identical results.
+
+The exported artifact is closed and deployable, not composable: it is the
+`call_exported`-has-no-outer-`vmap`-rule wall again. Use `solve_jax` for
+user-driven `jax.vmap` / `jax.grad`; `solve_batched` for a cached batched solve.
+
+### CVXPy cannot be exported
+
+Export requires every op in the loop — the backend solve included — to lower to
+serializable XLA. CVXPy's `iteration_callback` is a `jax.pure_callback`, and
+`jax.export` cannot serialize host callbacks. So `PTRSolver.exportable` is
+`False` for CVXPy (and `True` for QPAX / Moreau), and
+`solve_batched(save_compiled=True)` on the CVXPy backend **raises a teaching
+error** pointing at QPAX / Moreau rather than silently degrading to an uncached
+in-process solve. With `save_compiled=False`, CVXPy still runs `B` sequential
+in-process solves.
+
+### Cache invalidation is correctness, not just freshness
+
+The exported loop closes over far more than the symbolic problem does. Caching
+on the symbolic hash alone would silently deserialize a **stale artifact** when
+any of that extra state changes — a wrong-answer bug, not a cache miss. So
+`get_solve_batched_cache_path` (`openscvx/utils/caching.py`) extends the
+symbolic hash with everything additionally baked into the loop, each runtime
+object contributing through its own `_hash_into` (the same protocol the symbolic
+layer uses):
+
+* the convex backend class + its `solver_args`,
+* the algorithm + autotuner + convergence thresholds + initial weights,
+* the discretizer scheme (class + hold type + ODE solver),
+* the state/control scaling matrices `inv_S_x` / `inv_S_u`,
+* the fixed batch size `B` (the artifact is exported at one `B`), and
+* the JAX version (exported artifacts are not guaranteed to survive an
+  incompatible jax bump).
+
+Change any of these — backend, a tolerance, `k_max`, a state bound — and you get
+a different cache path, so a stale artifact is never reused.
+
+`examples/abstract/brachistochrone_batched.py` shows both paths side by side;
+re-running it is itself the cross-process demo.
+
 ## What `solve_jax()` returns
 
 `solve_jax()` returns the same `OptimizationResults` type as `solve()`,

--- a/examples/abstract/brachistochrone_batched.py
+++ b/examples/abstract/brachistochrone_batched.py
@@ -1,20 +1,30 @@
-"""Batched brachistochrone via ``jax.vmap(problem.solve_jax)``.
+"""Batched brachistochrone — two ways to solve four problems at once.
 
 Solves four brachistochrone problems in parallel — each with a different
-starting x-coordinate — using the JAX-pure
-:meth:`~openscvx.problem.Problem.solve_jax` entry point. ``solve_jax``
-returns an :class:`~openscvx.algorithms.optimization_results.OptimizationResults`
-pytree, so ``jax.vmap`` over the boundary-condition pins is the standard JAX
-composition pattern; no library-specific batching API is needed.
+starting x-coordinate — and contrasts the two batching entry points:
 
-Run with ``python examples/abstract/brachistochrone_batched.py``.
+* ``jax.vmap(problem.solve_jax)`` — the caller owns the batch axis. Maximally
+  idiomatic, composes with ``grad`` / ``scan``, but in-process JIT only: every
+  fresh process re-traces and re-compiles the whole SCP loop.
+* ``problem.solve_batched(x0_stack, xf_stack)`` — the library owns the batch
+  axis, so the whole vmapped loop is a single function that ``jax.export`` can
+  serialize. Under ``save_compiled=True`` it is written to the solver cache on
+  the first run and deserialized on later runs, skipping that compile. Reach
+  for it when cross-process cold-start dominates (CI sweeps, short-lived
+  workers); reach for ``jax.vmap(solve_jax)`` when you stay inside one program.
+
+Run with ``python examples/abstract/brachistochrone_batched.py``. Re-running is
+itself the cross-process demo: the second invocation deserializes the cached
+``solve_batched`` artifact instead of compiling it.
 
 Notes:
 
 * Under the QPAX backend used here, vmap'd subproblem solves run in
   parallel (no host callback). The CVXPy backend is single-threaded under
   vmap because :func:`jax.pure_callback` uses ``vmap_method="sequential"``
-  for thread safety — see :meth:`solve_jax`'s docstring.
+  for thread safety — see :meth:`solve_jax`'s docstring. That same host
+  callback is why ``solve_batched(save_compiled=True)`` refuses CVXPy: it
+  cannot be exported.
 * The Moreau warm-start is bypassed on the JAX-pure path (its carry is
   host-side state that ``lax.while_loop`` doesn't thread). Use QPAX or
   CVXPy when you want batched solves.
@@ -113,14 +123,33 @@ if __name__ == "__main__":
     shifts = jnp.array([0.0, 0.3, 0.6, 0.9])
     x_initial_stack = jnp.stack([default_pin.at[0].set(default_pin[0] + s) for s in shifts])
 
-    # Bare ``jax.vmap`` — the library exposes no batching wrapper of its own.
+    # --- caller owns the batch axis: jax.vmap(solve_jax) ---------------------
+    # Bare ``jax.vmap`` — composes like any JAX transform, in-process only.
     batched_solve = jax.vmap(problem.solve_jax, in_axes=(0, None, None))
     results = batched_solve(x_initial_stack, None, None)
 
     # ``results`` is a batched ``OptimizationResults`` pytree — every child
     # (``X``, ``U``, ``t_final``, ``converged``, ...) has a leading batch axis.
-    print(f"Batched solve over {x_initial_stack.shape[0]} initial conditions:")
+    print(f"jax.vmap(solve_jax) over {x_initial_stack.shape[0]} initial conditions:")
     print(f"  result.x.shape:   {results.x.shape}")
     print(f"  result.u.shape:   {results.u.shape}")
     print(f"  result.t_final:   {np.asarray(results.t_final).reshape(-1)}")
     print(f"  result.converged: {np.asarray(results.converged)}")
+
+    # --- library owns the batch axis: solve_batched, disk-cached -------------
+    # The same batched solve, but ``solve_batched`` owns the vmap so the whole
+    # loop is one exportable artifact. Under ``save_compiled=True`` it lands in
+    # the solver cache on the first run; re-run this script (a fresh process) to
+    # see it deserialized instead of recompiled. ``xf`` is shared across the
+    # batch, so broadcast the default terminal pin to the same leading axis.
+    export_problem = build_problem()
+    export_problem.settings.sim.save_compiled = True
+    export_problem.initialize()
+
+    x_term_stack = jnp.broadcast_to(export_problem.state.x_term_pin, x_initial_stack.shape)
+    batched = export_problem.solve_batched(x_initial_stack, x_term_stack)
+
+    print(f"\nsolve_batched (save_compiled=True) over {x_initial_stack.shape[0]} ICs:")
+    print(f"  result.x.shape:   {batched.x.shape}")
+    print(f"  result.t_final:   {np.asarray(batched.t_final).reshape(-1)}")
+    print(f"  result.converged: {np.asarray(batched.converged)}")

--- a/examples/drone/2d_obstacle_avoidance_batched_ic.py
+++ b/examples/drone/2d_obstacle_avoidance_batched_ic.py
@@ -1,0 +1,317 @@
+"""Batched 2D obstacle avoidance: solve over B random initial positions.
+
+Same planar double-integrator + CTCS obstacle-avoidance problem as
+``2d_obstacle_avoidance.py``, but ``solve_batched`` runs all B solves in one
+compiled dispatch (Moreau backend).  The initial position is a ``Parameter``
+pinned via ``(position == initial_position).convex().at([0])``.  Passing a ``(B, 2)`` array as ``parameters={"initial_position": ic_batch}``
+pins each IC via the convex equality at node 0.  Per-batch ``x_guess`` stacks
+(a position linspace from each IC to the shared target) seed the SCP iterate
+independently.  ``post_process_batched`` then propagates
+every converged solution through the full nonlinear dynamics.
+
+All B trajectories are visualised together with Plotly — converged runs in
+blue, diverged in orange — on top of the obstacle field.
+"""
+
+import os
+import sys
+import time
+
+import numpy as np
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+grandparent_dir = os.path.dirname(os.path.dirname(current_dir))
+sys.path.append(grandparent_dir)
+
+import openscvx as ox
+from openscvx import Problem
+
+# ── Batch configuration ────────────────────────────────────────────────────────
+N_BATCH = 200    # number of initial conditions to solve simultaneously
+N = 40           # SCP discretisation nodes
+TOTAL_TIME = 120.0
+
+# ── Obstacle field (identical to 2d_obstacle_avoidance.py) ────────────────────
+obstacle_radius_min, obstacle_radius_max = 1.0, 2.5
+
+np.random.seed(42)
+obstacle_centers_list = []
+n_rows, n_cols = 20, 20
+for i in range(n_rows):
+    for j in range(n_cols):
+        x = -6.0 + i * 6.0
+        y = -7.5 + j * 5.0
+        x += np.random.uniform(-1.0, 1.0)
+        y += np.random.uniform(-1.0, 1.0)
+        obstacle_centers_list.append([x, y])
+
+obstacle_centers = np.array(obstacle_centers_list)   # (n_obs, 2)
+obstacle_radii = np.random.uniform(
+    obstacle_radius_min, obstacle_radius_max, size=len(obstacle_centers_list)
+)
+
+# ── States ─────────────────────────────────────────────────────────────────────
+_default_ic = np.array([-10.0, -10.0])   # used for guess; actual IC set by ZeroConeConstraint
+
+position = ox.State("position", shape=(2,))
+position.max = np.array([150.0, 150.0])
+position.min = np.array([-15.0, -15.0])
+position.initial = [ox.Free(-10.0), ox.Free(-10.0)]
+position.final = np.array([100.0, 100.0])
+
+velocity = ox.State("velocity", shape=(2,))
+velocity.max = np.array([10.0, 10.0])
+velocity.min = np.array([-10.0, -10.0])
+velocity.initial = np.array([0.0, 0.0])
+velocity.final = [("free", 0.0), ("free", 0.0)]
+
+# ── Controls ───────────────────────────────────────────────────────────────────
+force = ox.Control("force", shape=(2,))
+a_max = 20.0
+force.max = np.array([a_max, a_max])
+force.min = np.array([-a_max, -a_max])
+
+m = 1.0
+
+# ── Batched parameter: initial position ───────────────────────────────────────
+initial_position = ox.Parameter("initial_position", shape=(2,), value=_default_ic)
+
+# ── Dynamics ───────────────────────────────────────────────────────────────────
+dynamics = {
+    "position": velocity,
+    "velocity": (1.0 / m) * force,
+}
+
+# ── Constraints ────────────────────────────────────────────────────────────────
+states = [position, velocity]
+controls = [force]
+constraints = []
+
+for state in states:
+    constraints.extend([ox.ctcs(state <= state.max), ox.ctcs(state.min <= state)])
+
+constraints.extend([force <= force.max, force.min <= force])
+
+obstacle_avoidance = ox.ctcs(
+    obstacle_radii
+    <= ox.Vmap(
+        lambda obs_center: ox.linalg.Norm(position - obs_center),
+        batch=obstacle_centers,
+    )
+)
+constraints.append(obstacle_avoidance)
+
+# ── Constraints ── initial position pinned via convex equality at node 0 ───────
+constraints.append((position == initial_position).convex().at([0]))
+
+# ── Initial guesses ────────────────────────────────────────────────────────────
+position.guess = np.linspace(_default_ic, position.final, N)
+velocity.guess = np.zeros((N, 2))
+force.guess = np.zeros((N, 2))
+
+# ── Time ───────────────────────────────────────────────────────────────────────
+time_var = ox.Time(
+    initial=0.0,
+    final=("minimize", TOTAL_TIME),
+    min=0.0,
+    max=TOTAL_TIME,
+)
+
+# ── Problem ────────────────────────────────────────────────────────────────────
+# Moreau backend: JAX-native, exportable, required for solve_batched.
+problem = Problem(
+    dynamics=dynamics,
+    states=states,
+    controls=controls,
+    time=time_var,
+    constraints=constraints,
+    N=N,
+    algorithm={
+        "autotuner": ox.RampProximalWeight(ramp_factor=1.1, lam_prox_max=1e3),
+        "lam_cost": 1e-2,
+        "lam_vc": 1e1,
+    },
+    solver=ox.MoreauPTRSolver(),
+    float_dtype="float64",
+)
+
+
+# ── Helper: sample valid initial positions ─────────────────────────────────────
+def sample_initial_positions(
+    B: int,
+    seed: int = 0,
+    x_range: tuple[float, float] = (-14.0, 20.0),
+    y_range: tuple[float, float] = (-14.0, 20.0),
+    safety_margin: float = 0.5,
+) -> np.ndarray:
+    """Sample B positions in [x_range × y_range] that lie outside all obstacles.
+
+    The default range covers the lower-left quadrant of the obstacle field,
+    giving varied starting positions from far-corner approaches to positions
+    already adjacent to the first few rows of obstacles.
+
+    Args:
+        B: Number of positions to sample.
+        seed: RNG seed.
+        x_range: (min, max) for the x coordinate.
+        y_range: (min, max) for the y coordinate.
+        safety_margin: Extra clearance beyond the obstacle radius.
+
+    Returns:
+        Array of shape ``(B, 2)``.
+    """
+    rng = np.random.default_rng(seed)
+    positions: list[np.ndarray] = []
+    while len(positions) < B:
+        p = rng.uniform(
+            [x_range[0], y_range[0]],
+            [x_range[1], y_range[1]],
+        )
+        dists = np.linalg.norm(obstacle_centers - p, axis=1)
+        if np.all(dists > obstacle_radii + safety_margin):
+            positions.append(p)
+    return np.array(positions)
+
+
+def build_batched_x_guess(problem, ic_batch: np.ndarray) -> np.ndarray:
+    """Build per-batch state guesses with position linspace IC → target."""
+    base_x = np.asarray(problem.state.x)  # (N, n_x)
+    pos_sl = position._slice
+    final_pos = np.asarray(position.final)
+    B = ic_batch.shape[0]
+    x_guess_batch = np.broadcast_to(base_x, (B,) + base_x.shape).copy()
+    t = np.linspace(0.0, 1.0, N)
+    x_guess_batch[:, :, pos_sl] = (
+        ic_batch[:, None, :] * (1.0 - t[None, :, None])
+        + final_pos[None, None, :] * t[None, :, None]
+    )
+    return x_guess_batch
+
+
+# ── Visualisation ──────────────────────────────────────────────────────────────
+def plot_batched_2d_trajectories(results, ic_batch: np.ndarray):
+    """Plotly figure overlaying all B propagated trajectories on the obstacle field.
+
+    Args:
+        results: :class:`~openscvx.algorithms.OptimizationResults` returned by
+            :meth:`~openscvx.problem.Problem.post_process_batched`.  Must have
+            ``trajectory["position"]`` of shape ``(B, T, 2)``.
+        ic_batch: ``(B, 2)`` array of initial positions used for the batch.
+    """
+    import plotly.graph_objects as go
+
+    converged = np.asarray(results.converged, dtype=bool).reshape(-1)
+    B = len(converged)
+
+    # Extract propagated positions: (B, T, 2)
+    pos_all = np.asarray(results.trajectory["position"], dtype=np.float64)
+    if pos_all.ndim == 2:
+        # Fallback: single-batch dim was squeezed
+        pos_all = pos_all[np.newaxis]
+
+    fig = go.Figure()
+
+    # ── Background obstacles ──────────────────────────────────────────────────
+    for center, radius in zip(obstacle_centers, obstacle_radii):
+        xc, yc = center
+        fig.add_shape(
+            type="circle",
+            x0=xc - radius, y0=yc - radius,
+            x1=xc + radius, y1=yc + radius,
+            fillcolor="rgba(220, 180, 180, 0.30)",
+            line={"color": "rgba(200, 120, 120, 0.45)", "width": 1},
+            layer="below",
+        )
+
+    # ── Trajectories ──────────────────────────────────────────────────────────
+    # Draw diverged runs first so converged runs render on top.
+    for b in range(B):
+        ok = bool(converged[b])
+        color = "rgba(30, 130, 220, 0.65)" if ok else "rgba(220, 100, 30, 0.50)"
+        pos = pos_all[b]        # (T, 2)
+        fig.add_trace(
+            go.Scatter(
+                x=pos[:, 0], y=pos[:, 1],
+                mode="lines",
+                line={"color": color, "width": 1.5 if ok else 1.0},
+                showlegend=False,
+                hovertemplate=f"run {b}  {'✓' if ok else '✗'}<extra></extra>",
+            )
+        )
+
+    # ── Start markers (one per batch element) ─────────────────────────────────
+    starts_ok  = ic_batch[converged]
+    starts_bad = ic_batch[~converged]
+    if len(starts_ok):
+        fig.add_trace(
+            go.Scatter(
+                x=starts_ok[:, 0], y=starts_ok[:, 1],
+                mode="markers", name="Start (converged)",
+                marker={"color": "rgba(20, 100, 200, 0.9)", "size": 7, "symbol": "circle"},
+            )
+        )
+    if len(starts_bad):
+        fig.add_trace(
+            go.Scatter(
+                x=starts_bad[:, 0], y=starts_bad[:, 1],
+                mode="markers", name="Start (diverged)",
+                marker={"color": "rgba(200, 80, 20, 0.9)", "size": 7, "symbol": "circle-open"},
+            )
+        )
+
+    # ── Target ────────────────────────────────────────────────────────────────
+    tgt = position.final
+    fig.add_trace(
+        go.Scatter(
+            x=[tgt[0]], y=[tgt[1]],
+            mode="markers", name="Target",
+            marker={"color": "black", "size": 12, "symbol": "star"},
+        )
+    )
+
+    # ── Layout ────────────────────────────────────────────────────────────────
+    n_ok = int(converged.sum())
+    fig.update_layout(
+        title=f"Batched 2-D obstacle avoidance  —  {B} ICs  |  {n_ok}/{B} converged",
+        xaxis_title="x  [m]",
+        yaxis_title="y  [m]",
+        yaxis={"scaleanchor": "x", "scaleratio": 1},
+        template="simple_white",
+        paper_bgcolor="white",
+        plot_bgcolor="white",
+        autosize=False,
+        width=720,
+        height=720,
+        margin={"l": 60, "r": 30, "t": 50, "b": 60},
+    )
+    return fig
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+if __name__ == "__main__":
+    print(f"Initializing 2-D obstacle avoidance problem (Moreau, B={N_BATCH}) ...")
+    problem.initialize()
+
+    # Sample B valid initial positions
+    ic_batch = sample_initial_positions(N_BATCH)
+    print(f"Sampled {N_BATCH} initial positions in x∈[-14,20], y∈[-14,20]")
+    print(f"  ic_batch.shape = {ic_batch.shape}")
+
+    # ── Compile + solve ───────────────────────────────────────────────────────
+    # B is inferred from ic_batch.shape[0].  solve_batched vmaps over
+    # initial_position (shape (B, 2)) and the per-batch x_guess stack.
+    x_guess_batch = build_batched_x_guess(problem, ic_batch)
+    print("Compiling and running solve_batched …")
+    results = problem.solve_batched(
+        parameters={"initial_position": ic_batch},
+        x_guess=x_guess_batch,
+    )
+
+    # ── Post-process ──────────────────────────────────────────────────────────
+    print("Post-processing (nonlinear propagation) …")
+    results = problem.post_process_batched(results)
+
+    # ── Plot ──────────────────────────────────────────────────────────────────
+    print("Plotting …")
+    fig = plot_batched_2d_trajectories(results, ic_batch)
+    fig.show()

--- a/examples/drone/2d_obstacle_avoidance_batched_ic.py
+++ b/examples/drone/2d_obstacle_avoidance_batched_ic.py
@@ -3,8 +3,9 @@
 Same planar double-integrator + CTCS obstacle-avoidance problem as
 ``2d_obstacle_avoidance.py``, but ``solve_batched`` runs all B solves in one
 compiled dispatch (Moreau backend).  The initial position is a ``Parameter``
-pinned via ``(position == initial_position).convex().at([0])``.  Passing a ``(B, 2)`` array as ``parameters={"initial_position": ic_batch}``
-pins each IC via the convex equality at node 0.  Per-batch ``x_guess`` stacks
+pinned via ``(position == initial_position).convex().at([0])``.  Pass
+``parameters={"initial_position": ic_batch}`` (shape ``(B, 2)``) to pin each
+IC at node 0.  Per-batch ``x_guess`` stacks
 (a position linspace from each IC to the shared target) seed the SCP iterate
 independently.  ``post_process_batched`` then propagates
 every converged solution through the full nonlinear dynamics.
@@ -15,7 +16,6 @@ blue, diverged in orange — on top of the obstacle field.
 
 import os
 import sys
-import time
 
 import numpy as np
 
@@ -27,8 +27,8 @@ import openscvx as ox
 from openscvx import Problem
 
 # ── Batch configuration ────────────────────────────────────────────────────────
-N_BATCH = 200    # number of initial conditions to solve simultaneously
-N = 40           # SCP discretisation nodes
+N_BATCH = 200  # number of initial conditions to solve simultaneously
+N = 40  # SCP discretisation nodes
 TOTAL_TIME = 120.0
 
 # ── Obstacle field (identical to 2d_obstacle_avoidance.py) ────────────────────
@@ -45,13 +45,13 @@ for i in range(n_rows):
         y += np.random.uniform(-1.0, 1.0)
         obstacle_centers_list.append([x, y])
 
-obstacle_centers = np.array(obstacle_centers_list)   # (n_obs, 2)
+obstacle_centers = np.array(obstacle_centers_list)  # (n_obs, 2)
 obstacle_radii = np.random.uniform(
     obstacle_radius_min, obstacle_radius_max, size=len(obstacle_centers_list)
 )
 
 # ── States ─────────────────────────────────────────────────────────────────────
-_default_ic = np.array([-10.0, -10.0])   # used for guess; actual IC set by ZeroConeConstraint
+_default_ic = np.array([-10.0, -10.0])  # used for guess; actual IC set by ZeroConeConstraint
 
 position = ox.State("position", shape=(2,))
 position.max = np.array([150.0, 150.0])
@@ -216,8 +216,10 @@ def plot_batched_2d_trajectories(results, ic_batch: np.ndarray):
         xc, yc = center
         fig.add_shape(
             type="circle",
-            x0=xc - radius, y0=yc - radius,
-            x1=xc + radius, y1=yc + radius,
+            x0=xc - radius,
+            y0=yc - radius,
+            x1=xc + radius,
+            y1=yc + radius,
             fillcolor="rgba(220, 180, 180, 0.30)",
             line={"color": "rgba(200, 120, 120, 0.45)", "width": 1},
             layer="below",
@@ -228,10 +230,11 @@ def plot_batched_2d_trajectories(results, ic_batch: np.ndarray):
     for b in range(B):
         ok = bool(converged[b])
         color = "rgba(30, 130, 220, 0.65)" if ok else "rgba(220, 100, 30, 0.50)"
-        pos = pos_all[b]        # (T, 2)
+        pos = pos_all[b]  # (T, 2)
         fig.add_trace(
             go.Scatter(
-                x=pos[:, 0], y=pos[:, 1],
+                x=pos[:, 0],
+                y=pos[:, 1],
                 mode="lines",
                 line={"color": color, "width": 1.5 if ok else 1.0},
                 showlegend=False,
@@ -240,21 +243,25 @@ def plot_batched_2d_trajectories(results, ic_batch: np.ndarray):
         )
 
     # ── Start markers (one per batch element) ─────────────────────────────────
-    starts_ok  = ic_batch[converged]
+    starts_ok = ic_batch[converged]
     starts_bad = ic_batch[~converged]
     if len(starts_ok):
         fig.add_trace(
             go.Scatter(
-                x=starts_ok[:, 0], y=starts_ok[:, 1],
-                mode="markers", name="Start (converged)",
+                x=starts_ok[:, 0],
+                y=starts_ok[:, 1],
+                mode="markers",
+                name="Start (converged)",
                 marker={"color": "rgba(20, 100, 200, 0.9)", "size": 7, "symbol": "circle"},
             )
         )
     if len(starts_bad):
         fig.add_trace(
             go.Scatter(
-                x=starts_bad[:, 0], y=starts_bad[:, 1],
-                mode="markers", name="Start (diverged)",
+                x=starts_bad[:, 0],
+                y=starts_bad[:, 1],
+                mode="markers",
+                name="Start (diverged)",
                 marker={"color": "rgba(200, 80, 20, 0.9)", "size": 7, "symbol": "circle-open"},
             )
         )
@@ -263,8 +270,10 @@ def plot_batched_2d_trajectories(results, ic_batch: np.ndarray):
     tgt = position.final
     fig.add_trace(
         go.Scatter(
-            x=[tgt[0]], y=[tgt[1]],
-            mode="markers", name="Target",
+            x=[tgt[0]],
+            y=[tgt[1]],
+            mode="markers",
+            name="Target",
             marker={"color": "black", "size": 12, "symbol": "star"},
         )
     )

--- a/examples/drone/drone_racing_batched_gates.py
+++ b/examples/drone/drone_racing_batched_gates.py
@@ -1,0 +1,421 @@
+"""Batched quadrotor gate racing: solve over B perturbed gate layouts.
+
+Same 6-DOF gate-racing problem as ``drone_racing.py``, but ``solve_batched``
+runs all B solves in one compiled dispatch (Moreau backend).  Each gate
+center is an ``ox.Parameter``; a batch draw adds a small random offset to
+every gate before solving.  Per-batch ``x_guess`` stacks seed the SCP iterate
+with a position linspace through the perturbed gate waypoints.
+All ``B`` trajectories and perturbed gate layouts are visualised together in
+Viser with simultaneous playback.
+
+Run::
+
+    python examples/drone/drone_racing_batched_gates.py
+"""
+
+import os
+import sys
+
+import jax.numpy as jnp
+import numpy as np
+import viser
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+grandparent_dir = os.path.dirname(os.path.dirname(current_dir))
+sys.path.append(grandparent_dir)
+
+import openscvx as ox
+from openscvx import Problem
+from openscvx.plotting.viser import (
+    add_animation_controls,
+    compute_velocity_colors,
+    create_server,
+)
+from openscvx.utils import gen_vertices, rot
+
+# ── Batch configuration ────────────────────────────────────────────────────────
+N_BATCH = 16  # parallel solves (increase if you have GPU headroom)
+N = 22  # SCP discretisation nodes
+TOTAL_TIME = 24.0
+
+# Gaussian perturbation applied to each gate center (metres).
+# Lateral σ ≈ 2 m is ~40 % of the gate width; vertical σ is kept smaller.
+GATE_PERTURB_STD = np.array([5.0, 5.0, 2.0])
+
+# ── States ─────────────────────────────────────────────────────────────────────
+position = ox.State("position", shape=(3,))
+position.max = np.array([200.0, 100.0, 200.0])
+position.min = np.array([-200.0, -100.0, 15.0])
+position.initial = np.array([10.0, 0.0, 20.0])
+position.final = [10.0, 0.0, 20.0]
+
+velocity = ox.State("velocity", shape=(3,))
+velocity.max = np.array([100.0, 100.0, 100.0])
+velocity.min = np.array([-100.0, -100.0, -100.0])
+velocity.initial = np.array([0.0, 0.0, 0.0])
+velocity.final = [("free", 0.0), ("free", 0.0), ("free", 0.0)]
+
+attitude = ox.State("attitude", shape=(4,))
+attitude.max = np.array([1.0, 1.0, 1.0, 1.0])
+attitude.min = np.array([-1.0, -1.0, -1.0, -1.0])
+attitude.initial = [("free", 1.0), ("free", 0.0), ("free", 0.0), ("free", 0.0)]
+attitude.final = [("free", 1.0), ("free", 0.0), ("free", 0.0), ("free", 0.0)]
+
+angular_velocity = ox.State("angular_velocity", shape=(3,))
+angular_velocity.max = np.array([10.0, 10.0, 10.0])
+angular_velocity.min = np.array([-10.0, -10.0, -10.0])
+angular_velocity.initial = [("free", 0.0), ("free", 0.0), ("free", 0.0)]
+angular_velocity.final = [("free", 0.0), ("free", 0.0), ("free", 0.0)]
+
+# ── Controls ───────────────────────────────────────────────────────────────────
+thrust_force = ox.Control("thrust_force", shape=(3,))
+thrust_force.max = np.array([0.0, 0.0, 4.179446268 * 9.81])
+thrust_force.min = np.array([0.0, 0.0, 0.0])
+thrust_force.guess = np.repeat(np.array([[0.0, 0.0, 10.0]]), N, axis=0)
+
+torque = ox.Control("torque", shape=(3,))
+torque.max = np.array([18.665, 18.665, 0.55562])
+torque.min = np.array([-18.665, -18.665, -0.55562])
+torque.guess = np.zeros((N, 3))
+
+m = 1.0
+g_const = -9.18
+J_b = jnp.array([1.0, 1.0, 1.0])
+
+# ── Gate geometry (nominal layout from drone_racing.py) ───────────────────────
+N_GATES = 10
+INITIAL_GATE_CENTERS = [
+    np.array([59.436, 0.000, 20.0000]),
+    np.array([92.964, -23.750, 25.5240]),
+    np.array([92.964, -29.274, 20.0000]),
+    np.array([92.964, -23.750, 20.0000]),
+    np.array([130.150, -23.750, 20.0000]),
+    np.array([152.400, -73.152, 20.0000]),
+    np.array([92.964, -75.080, 20.0000]),
+    np.array([92.964, -68.556, 20.0000]),
+    np.array([59.436, -81.358, 20.0000]),
+    np.array([22.250, -42.672, 20.0000]),
+]
+
+radii = np.array([2.5, 1e-4, 2.5])
+A_gate_const = rot @ np.diag(1 / radii) @ rot.T
+
+# Nominal centres used for parameters, guesses, and static plot overlays.
+modified_centers = []
+for center in INITIAL_GATE_CENTERS:
+    modified_center = center.copy()
+    modified_center[0] = modified_center[0] + 2.5
+    modified_center[2] = modified_center[2] + 2.5
+    modified_centers.append(modified_center)
+modified_centers = np.asarray(modified_centers)
+
+gate_center_params = []
+for i, modified_center in enumerate(modified_centers):
+    gate_center_params.append(
+        ox.Parameter(f"gate_{i}_center", shape=(3,), value=modified_center)
+    )
+
+nodes_per_gate = 2
+gate_nodes = np.arange(nodes_per_gate, N, nodes_per_gate)
+nominal_vertices = [gen_vertices(c, radii) for c in modified_centers]
+
+# ── Dynamics & constraints ─────────────────────────────────────────────────────
+states = [position, velocity, attitude, angular_velocity]
+controls = [thrust_force, torque]
+constraints = []
+
+for state in states:
+    constraints.extend([ox.ctcs(state <= state.max), ox.ctcs(state.min <= state)])
+
+for node, gate_center_param in zip(gate_nodes, gate_center_params):
+    gate_constraint = (
+        (
+            ox.linalg.Norm(A_gate_const @ position - A_gate_const @ gate_center_param, ord="inf")
+            <= 1.0
+        )
+        .convex()
+        .at([node])
+    )
+    constraints.append(gate_constraint)
+
+q_norm = ox.linalg.Norm(attitude)
+attitude_normalized = attitude / q_norm
+J_b_inv = 1.0 / J_b
+J_b_diag = ox.linalg.Diag(J_b)
+
+dynamics = {
+    "position": velocity,
+    "velocity": (1.0 / m) * ox.spatial.QDCM(attitude_normalized) @ thrust_force
+    + ox.Constant(np.array([0.0, 0.0, g_const], dtype=np.float64)),
+    "attitude": 0.5 * ox.spatial.SSMP(angular_velocity) @ attitude_normalized,
+    "angular_velocity": ox.linalg.Diag(J_b_inv)
+    @ (torque - ox.spatial.SSM(angular_velocity) @ J_b_diag @ angular_velocity),
+}
+
+position.guess = ox.init.linspace(
+    keyframes=[position.initial] + list(modified_centers) + [position.final],
+    nodes=[0] + list(gate_nodes) + [N - 1],
+)
+
+time_var = ox.Time(
+    initial=0.0,
+    final=("minimize", TOTAL_TIME),
+    min=0.0,
+    max=TOTAL_TIME,
+)
+
+problem = Problem(
+    dynamics=dynamics,
+    states=states,
+    controls=controls,
+    time=time_var,
+    constraints=constraints,
+    N=N,
+    algorithm={"ep_tr": 1e-3},
+    solver=ox.MoreauPTRSolver(),
+    float_dtype="float64",
+)
+problem.solver.solver_args = {"abstol": 1e-6, "reltol": 1e-9}
+
+
+# ── Batching helpers ───────────────────────────────────────────────────────────
+def sample_gate_centers_batch(
+    base_centers: np.ndarray,
+    B: int,
+    *,
+    std: np.ndarray = GATE_PERTURB_STD,
+    seed: int = 0,
+) -> np.ndarray:
+    """Return shape ``(B, n_gates, 3)`` with small perturbations about *base_centers*."""
+    base = np.asarray(base_centers)
+    rng = np.random.default_rng(seed)
+    noise = rng.normal(0.0, 1.0, size=(B, base.shape[0], 3)) * np.asarray(std)
+    return base[None, :, :] + noise
+
+
+def gate_batch_to_parameters(gate_centers_batch: np.ndarray) -> dict:
+    """Map a ``(B, n_gates, 3)`` stack to the solver parameter dict."""
+    params = {}
+    for i in range(gate_centers_batch.shape[1]):
+        params[f"gate_{i}_center"] = gate_centers_batch[:, i, :]
+    return params
+
+
+def build_batched_x_guess(problem, gate_centers_batch: np.ndarray) -> np.ndarray:
+    """Per-batch state guesses: position linspace through perturbed gate waypoints."""
+    base_x = np.asarray(problem.state.x)
+    pos_sl = position._slice
+    B = gate_centers_batch.shape[0]
+    x_guess_batch = np.broadcast_to(base_x, (B,) + base_x.shape).copy()
+    keyframe_nodes = [0] + list(gate_nodes) + [N - 1]
+    for b in range(B):
+        centers_b = gate_centers_batch[b]
+        keyframes = [position.initial] + list(centers_b) + [position.final]
+        x_guess_batch[b, :, pos_sl] = ox.init.linspace(
+            keyframes=keyframes,
+            nodes=keyframe_nodes,
+        )
+    return x_guess_batch
+
+
+# ── Visualisation ──────────────────────────────────────────────────────────────
+def _batch_palette(B: int) -> list[tuple[int, int, int]]:
+    """Distinct saturated RGB colours — one hue per batch index."""
+    import colorsys
+
+    if B <= 0:
+        return []
+    return [
+        tuple(int(255 * c) for c in colorsys.hsv_to_rgb(i / B, 0.82, 0.95))
+        for i in range(B)
+    ]
+
+
+def _run_color(
+    palette: list[tuple[int, int, int]],
+    b: int,
+    *,
+    converged: bool,
+) -> tuple[int, int, int]:
+    """Return the batch colour, dimmed when the run did not converge."""
+    r, g, bl = palette[b]
+    if converged:
+        return (r, g, bl)
+    return (int(0.45 * r), int(0.45 * g), int(0.45 * bl))
+
+
+def _add_gate_wireframes(
+    server: viser.ViserServer,
+    vertices_list: list,
+    prefix: str,
+    color: tuple[int, int, int],
+    *,
+    line_width: float = 2.0,
+) -> None:
+    """Add planar gate wireframes under a unique scene-path *prefix*."""
+    for i, verts in enumerate(vertices_list):
+        verts = np.asarray(verts, dtype=np.float32)
+        edges = [[0, 1], [1, 2], [2, 3], [3, 0]]
+        points = np.array([[verts[e[0]], verts[e[1]]] for e in edges], dtype=np.float32)
+        server.scene.add_line_segments(
+            f"{prefix}/gate_{i}",
+            points=points,
+            colors=color,
+            line_width=line_width,
+        )
+
+
+def create_racing_batched_viser_server(
+    results,
+    gate_centers_batch: np.ndarray,
+) -> viser.ViserServer:
+    """Build a Viser scene animating all batched gate-racing trajectories.
+
+    All ``B`` propagated trajectories play back simultaneously.  Each batch
+    element shares one hue across its gates, static trace, and position
+    marker (dimmed when diverged).  A faint nominal gate overlay is included
+    for reference.  Animated trails remain velocity-coloured.
+    """
+    pos_all = np.asarray(results.trajectory["position"], dtype=np.float64)
+    vel_all = np.asarray(results.trajectory["velocity"], dtype=np.float64)
+    t_full = np.asarray(results.t_full, dtype=np.float64)
+    converged = np.asarray(results.converged, dtype=bool).reshape(-1)
+
+    if pos_all.ndim == 2:
+        pos_all = pos_all[np.newaxis]
+        vel_all = vel_all[np.newaxis]
+        t_full = t_full[np.newaxis]
+
+    B, T = pos_all.shape[0], pos_all.shape[1]
+    gate_centers_batch = np.asarray(gate_centers_batch, dtype=np.float64)
+    palette = _batch_palette(B)
+
+    server = create_server(pos_all.reshape(-1, 3))
+    server.gui.configure_theme(dark_mode=True)
+
+    # Nominal gate layout (reference).
+    _add_gate_wireframes(
+        server,
+        nominal_vertices,
+        "/gates/nominal",
+        color=(90, 90, 90),
+        line_width=1.5,
+    )
+
+    # Every batch element's perturbed gates (hue keyed to run index).
+    for b in range(B):
+        verts_b = [gen_vertices(c, radii) for c in gate_centers_batch[b]]
+        ok = bool(converged[b])
+        run_rgb = _run_color(palette, b, converged=ok)
+        _add_gate_wireframes(
+            server,
+            verts_b,
+            f"/gates/batch_{b}",
+            run_rgb,
+            line_width=2.5 if ok else 1.5,
+        )
+
+    start = np.asarray(position.initial, dtype=np.float32)
+    server.scene.add_icosphere(
+        "/markers/start_finish",
+        radius=0.35,
+        position=tuple(start),
+        color=(240, 240, 240),
+    )
+
+    # Faint static traces (full trajectory extent), matched to run hue.
+    for b in range(B):
+        ok = bool(converged[b])
+        trace_rgb = _run_color(palette, b, converged=ok)
+        pts = pos_all[b].astype(np.float32)
+        server.scene.add_line_segments(
+            f"/traces/{b}",
+            points=np.stack([pts[:-1], pts[1:]], axis=1),
+            colors=trace_rgb,
+            line_width=1.2 if ok else 0.8,
+        )
+
+    def _make_trail(handle, pts: np.ndarray, cols: np.ndarray):
+        def update(frame_idx: int) -> None:
+            idx = frame_idx + 1
+            handle.points = pts[:idx]
+            handle.colors = cols[:idx]
+
+        return update
+
+    def _make_marker(handle, pts: np.ndarray):
+        def update(frame_idx: int) -> None:
+            handle.position = pts[frame_idx]
+
+        return update
+
+    all_update_cbs = []
+    for b in range(B):
+        pts_b = pos_all[b].astype(np.float32)
+        colors_b = compute_velocity_colors(vel_all[b]).astype(np.uint8)
+        ok = bool(converged[b])
+
+        trail_handle = server.scene.add_point_cloud(
+            f"/animated/{b}/trail",
+            points=pts_b[:1],
+            colors=colors_b[:1],
+            point_size=0.18,
+        )
+        marker_handle = server.scene.add_icosphere(
+            f"/animated/{b}/marker",
+            radius=0.25,
+            color=_run_color(palette, b, converged=ok),
+            position=tuple(pts_b[0]),
+        )
+
+        all_update_cbs.append(_make_trail(trail_handle, pts_b, colors_b))
+        all_update_cbs.append(_make_marker(marker_handle, pts_b))
+
+    n_ok = int(converged.sum())
+    legend_lines = [
+        f"**{B} trajectories animating simultaneously**  ",
+        f"{n_ok}/{B} converged — each run has a unique hue on gates, "
+        "trace, and marker (dimmed if diverged).",
+        "",
+        "**Run colours:**",
+    ]
+    for b in range(B):
+        r, g, bl = palette[b]
+        status = "✓" if converged[b] else "✗"
+        legend_lines.append(
+            f'<span style="color:rgb({r},{g},{bl})">■</span> run {b} {status}'
+        )
+    with server.gui.add_folder("Batch overview"):
+        server.gui.add_markdown("\n".join(legend_lines))
+
+    mean_t_final = float(t_full[:, -1].mean())
+    traj_time = np.linspace(0.0, mean_t_final, T)
+    add_animation_controls(server, traj_time, all_update_cbs, folder_name="Playback")
+
+    return server
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+if __name__ == "__main__":
+    print(f"Initializing gate-racing problem (Moreau, B={N_BATCH}) …")
+    problem.initialize()
+
+    gate_batch = sample_gate_centers_batch(modified_centers, N_BATCH, seed=42)
+    print(f"Sampled {N_BATCH} gate layouts  (σ = {GATE_PERTURB_STD} m)")
+    print(f"  gate_batch.shape = {gate_batch.shape}")
+
+    params = gate_batch_to_parameters(gate_batch)
+    x_guess_batch = build_batched_x_guess(problem, gate_batch)
+
+    print("Compiling and running solve_batched …")
+    results = problem.solve_batched(parameters=params, x_guess=x_guess_batch)
+
+    print("Post-processing (nonlinear propagation) …")
+    results = problem.post_process_batched(results)
+
+    n_ok = int(np.asarray(results.converged, dtype=bool).sum())
+    print(f"Done — {n_ok}/{N_BATCH} converged")
+
+    print("\nLaunching Viser — all trajectories and gate layouts animating …")
+    viser_server = create_racing_batched_viser_server(results, gate_batch)
+    viser_server.sleep_forever()

--- a/examples/drone/drone_racing_batched_gates.py
+++ b/examples/drone/drone_racing_batched_gates.py
@@ -111,9 +111,7 @@ modified_centers = np.asarray(modified_centers)
 
 gate_center_params = []
 for i, modified_center in enumerate(modified_centers):
-    gate_center_params.append(
-        ox.Parameter(f"gate_{i}_center", shape=(3,), value=modified_center)
-    )
+    gate_center_params.append(ox.Parameter(f"gate_{i}_center", shape=(3,), value=modified_center))
 
 nodes_per_gate = 2
 gate_nodes = np.arange(nodes_per_gate, N, nodes_per_gate)
@@ -225,10 +223,7 @@ def _batch_palette(B: int) -> list[tuple[int, int, int]]:
 
     if B <= 0:
         return []
-    return [
-        tuple(int(255 * c) for c in colorsys.hsv_to_rgb(i / B, 0.82, 0.95))
-        for i in range(B)
-    ]
+    return [tuple(int(255 * c) for c in colorsys.hsv_to_rgb(i / B, 0.82, 0.95)) for i in range(B)]
 
 
 def _run_color(
@@ -382,9 +377,7 @@ def create_racing_batched_viser_server(
     for b in range(B):
         r, g, bl = palette[b]
         status = "✓" if converged[b] else "✗"
-        legend_lines.append(
-            f'<span style="color:rgb({r},{g},{bl})">■</span> run {b} {status}'
-        )
+        legend_lines.append(f'<span style="color:rgb({r},{g},{bl})">■</span> run {b} {status}')
     with server.gui.add_folder("Batch overview"):
         server.gui.add_markdown("\n".join(legend_lines))
 

--- a/examples/realtime/6DoF_pdg_batched_ic.py
+++ b/examples/realtime/6DoF_pdg_batched_ic.py
@@ -1,0 +1,488 @@
+"""Batched 6-DoF powered descent guidance — ``solve_batched`` over initial conditions.
+
+Runs ``N_BATCH = 50`` SCP solves in parallel, each starting from a different random
+initial position drawn uniformly within the position bounds.  Demonstrates the
+param-fix-pin mechanism introduced to support
+``(state == parameter).convex().at([0])`` in the JAX-native backends:
+
+* At lowering time :meth:`~openscvx.solvers.moreau_ptr_solver.MoreauPTRSolver` detects
+  ``(position == initial_position).convex().at([0])`` as a param-fix pin and absorbs
+  it into the ``"Fix"`` boundary-condition infrastructure.
+* At call time :meth:`~openscvx.problem.Problem.solve_batched` receives a
+  ``(B, 3)`` batched ``initial_position`` parameter and auto-builds the
+  ``x0_stack`` from it — no manual stack construction required.
+
+The same physics as ``base_problems/6DoF_pdg_realtime_base.py`` but rebuilt
+with a Moreau backend so the whole SCP loop is a single XLA kernel.
+
+After solving, all 50 trajectories are propagated through the full nonlinear
+dynamics via :meth:`~openscvx.problem.Problem.post_process_batched`, and the
+smooth high-fidelity paths are shown in the Viser visualisation.
+
+Run::
+
+    python examples/realtime/6DoF_pdg_batched_ic.py
+
+Requires ``pip install openscvx[moreau]``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+import jax.numpy as jnp
+import numpy as np
+import viser
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+repo_root_dir = os.path.dirname(os.path.dirname(current_dir))
+sys.path.append(repo_root_dir)
+
+import openscvx as ox
+from openscvx import Problem
+from openscvx.plotting.viser import (
+    add_animated_trail,
+    add_animation_controls,
+    add_attitude_frame,
+    add_glideslope_cone,
+    add_position_marker,
+    compute_velocity_colors,
+    create_server,
+)
+
+# ── Problem dimensions ──────────────────────────────────────────────────────
+N = 5          # discretization nodes
+N_BATCH = 50   # number of simultaneous solves
+
+# ── Random initial-condition generator ─────────────────────────────────────
+# Position bounds: [-10, 10]^3.  For physical realism we keep altitude
+# (position[0]) in [3, 9] m and lateral coordinates in [-7, 7] m.
+# All samples trivially satisfy the glide-slope constraint
+# (||pos[1:]|| <= tan(75°) * pos[0]) because tan(75°) ≈ 3.73 and the
+# maximum lateral norm (~9.9) is well below 3.73 * 3 ≈ 11.2.
+def sample_initial_positions(n: int, *, seed: int = 42) -> np.ndarray:
+    """Return shape ``(n, 3)`` array of random initial positions."""
+    rng = np.random.default_rng(seed)
+    altitude = rng.uniform(3.0, 9.0, size=(n,))
+    lateral_y = rng.uniform(-7.0, 7.0, size=(n,))
+    lateral_z = rng.uniform(-7.0, 7.0, size=(n,))
+    return np.stack([altitude, lateral_y, lateral_z], axis=-1)
+
+# ── Runtime parameters ──────────────────────────────────────────────────────
+gI         = ox.Parameter("gI",    value=1.0)
+l_arm      = ox.Parameter("l",     value=0.25)
+J_diag     = ox.Parameter("J_diag", shape=(3,), value=np.array([0.168 * 2e-2, 0.168, 0.168]))
+J_mat      = ox.Diag(J_diag)
+J_inv_mat  = ox.Inv(ox.Diag(J_diag))
+g0         = ox.Parameter("g0",    value=1.0)
+Isp        = ox.Parameter("Isp",   value=30.0)
+m_dry      = ox.Parameter("m_dry", value=1.0)
+v_max      = ox.Parameter("v_max", value=3.0)
+w_max      = ox.Parameter("w_max", value=0.3752)
+del_max    = ox.Parameter("del_max", value=20.0)
+theta_max  = ox.Parameter("theta_max", value=75.0)
+T_min      = ox.Parameter("T_min", value=1.5)
+T_max      = ox.Parameter("T_max", value=6.5)
+gamma      = ox.Parameter("gamma", value=75.0)
+beta       = ox.Parameter("beta",  value=0.01)
+c_ax       = ox.Parameter("c_ax",  value=0.5)
+c_ayz      = ox.Parameter("c_ayz", value=1.0)
+S_a        = ox.Parameter("S_a",   value=0.5)
+rho        = ox.Parameter("rho",   value=1.0)
+l_p        = ox.Parameter("l_p",   value=0.05)
+
+# Boundary-condition parameters (the ones we will batch over)
+initial_position = ox.Parameter("initial_position", shape=(3,), value=np.array([7.5, 4.5, 2.5]))
+final_position   = ox.Parameter("final_position",   shape=(2,), value=np.array([0.0, 0.0]))
+
+CA    = ox.Diag(ox.Concat(c_ax, c_ayz, c_ayz))
+r_arm = ox.Concat(-l_arm, 0.0, 0.0)
+r_cp  = ox.Concat(l_p,    0.0, 0.0)
+
+# ── States ──────────────────────────────────────────────────────────────────
+mass = ox.State("mass", shape=(1,))
+mass.max = [2.0]
+mass.min = [1.0]
+mass.initial = [2.0]
+mass.final   = [ox.Maximize(1.5)]
+
+position = ox.State("position", shape=(3,))
+position.max = [10.0, 10.0, 10.0]
+position.min = [-10.0, -10.0, -10.0]
+position.initial = [
+    ox.Free(float(initial_position.value[0])),
+    ox.Free(float(initial_position.value[1])),
+    ox.Free(float(initial_position.value[2])),
+]
+position.final = [0.0, ox.Free(0.0), ox.Free(0.0)]
+
+velocity = ox.State("velocity", shape=(3,))
+velocity.max = [ v_max.value,  v_max.value,  v_max.value]
+velocity.min = [-v_max.value, -v_max.value, -v_max.value]
+velocity.initial = [-0.5, -2.8, 0.0]
+velocity.final   = [-0.1,  0.0, 0.0]
+
+attitude = ox.State("attitude", shape=(4,))
+attitude.max = [1.0, 1.0, 1.0, 1.0]
+attitude.min = [-1.0, -1.0, -1.0, -1.0]
+attitude.initial = [ox.Free(0.0), ox.Free(0.0), ox.Free(0.0), ox.Free(1.0)]
+attitude.final   = [0.0, 0.0, 0.0, 1.0]
+
+angular_velocity = ox.State("angular_velocity", shape=(3,))
+angular_velocity.max = [ w_max.value,  w_max.value,  w_max.value]
+angular_velocity.min = [-w_max.value, -w_max.value, -w_max.value]
+angular_velocity.initial = [1e-8, 0.0, 0.0]
+angular_velocity.final   = [1e-8, 0.0, 0.0]
+
+# ── Controls ─────────────────────────────────────────────────────────────────
+thrust = ox.Control("thrust", shape=(3,))
+thrust.max = [ T_max.value,  T_max.value,  T_max.value]
+thrust.min = [-T_max.value, -T_max.value, -T_max.value]
+thrust.guess = np.linspace(
+    np.array([gI.value * mass.initial[0], 0, 0]),
+    np.array([gI.value * m_dry.value,     0, 0]),
+    N,
+).reshape(-1, 3)
+
+# ── Quaternion kinematics ────────────────────────────────────────────────────
+q1, q2, q3, q4 = attitude[0], attitude[1], attitude[2], attitude[3]
+
+CBI = ox.Block(
+    [
+        [q4**2 + q1**2 - q2**2 - q3**2, 2*(q1*q2 - q4*q3),              2*(q4*q2 + q1*q3)             ],
+        [2*(q4*q3 + q1*q2),              q4**2 - q1**2 + q2**2 - q3**2,  2*(q2*q3 - q4*q1)             ],
+        [2*(q1*q3 - q4*q2),              2*(q4*q1 + q2*q3),              q4**2 - q1**2 - q2**2 + q3**2],
+    ]
+).T
+
+
+def cross(a, b):
+    return ox.Concat(
+        a[1]*b[2] - a[2]*b[1],
+        a[2]*b[0] - a[0]*b[2],
+        a[0]*b[1] - a[1]*b[0],
+    )
+
+
+w1, w2, w3 = angular_velocity[0], angular_velocity[1], angular_velocity[2]
+attitude_dot = ox.Concat(
+    0.5*(w1*q4 - w2*q3 + w3*q2),
+    0.5*(w1*q3 - w3*q1 + w2*q4),
+    0.5*(w2*q1 - w1*q2 + w3*q4),
+    -0.5*(w1*q1 + w2*q2 + w3*q3),
+)
+
+A_aero = -0.5 * rho * ox.linalg.Norm(velocity) * S_a * CA @ CBI @ velocity
+
+dynamics = {
+    "mass":             -(1 / (Isp * g0)) * ox.linalg.Norm(thrust) - beta,
+    "position":         velocity,
+    "velocity":         CBI.T @ (thrust + A_aero) / mass[0] + ox.Concat(-gI, 0.0, 0.0),
+    "attitude":         attitude_dot,
+    "angular_velocity": J_inv_mat @ (
+        cross(r_arm, thrust)
+        + cross(r_cp, A_aero)
+        - cross(angular_velocity, J_mat @ angular_velocity)
+    ),
+}
+
+# ── Constraints ──────────────────────────────────────────────────────────────
+states   = [mass, position, velocity, attitude, angular_velocity]
+controls = [thrust]
+
+constraint_exprs = []
+for st in states:
+    constraint_exprs.extend([ox.ctcs(st <= st.max), ox.ctcs(st.min <= st)])
+
+# Param-fix boundary constraints — these are the pins we batch over.
+constraint_exprs.append((position       == initial_position).convex().at([0]))
+constraint_exprs.append((position[1:3]  == final_position).convex().at([N - 1]))
+
+constraint_exprs.append(ox.ctcs(1.0 * (mass - m_dry) >= 0))
+constraint_exprs.append(ox.ctcs(
+    0.1 * ox.linalg.Norm(position[1:]) - ox.Tan(gamma * np.pi / 180.0) * position[0] <= 0
+))
+constraint_exprs.append(ox.ctcs(0.1 * ox.linalg.Norm(velocity)**2 - v_max**2 <= 0))
+constraint_exprs.append(ox.ctcs(
+    1.0 * ox.Cos(theta_max * np.pi / 180.0) - 1.0 + 2.0 * (q2**2 + q3**2) <= 0
+))
+constraint_exprs.append(ox.ctcs(1.0 * ox.linalg.Norm(angular_velocity)**2 - w_max**2 <= 0))
+constraint_exprs.append(ox.ctcs(
+    0.1 * ox.linalg.Norm(thrust) - thrust[0] / ox.Cos(del_max * np.pi / 180.0) <= 0
+))
+constraint_exprs.append(ox.ctcs(0.1 * ox.linalg.Norm(thrust)**2 - T_max**2 <= 0))
+constraint_exprs.append(ox.ctcs(0.1 * T_min**2 - ox.linalg.Norm(thrust)**2 <= 0))
+
+# ── Time ─────────────────────────────────────────────────────────────────────
+t_final_guess = 10.0
+time_config = ox.Time(
+    initial=0.0,
+    final=ox.Free(t_final_guess),
+    min=0.0,
+    max=10.0,
+    time_dilation_min=0.2 * t_final_guess,
+    time_dilation_max=2.0 * t_final_guess,
+)
+
+# ── Problem — Moreau backend required for solve_batched ──────────────────────
+problem = Problem(
+    N=N,
+    states=states,
+    controls=controls,
+    dynamics=dynamics,
+    constraints=constraint_exprs,
+    time=time_config,
+    float_dtype="float64",
+    solver={"backend": "moreau", "tol_gap_abs": 1e-7, "tol_feas": 1e-7},
+    algorithm={
+        "autotuner": ox.ConstantProximalWeight(),
+        "lam_cost":  1e-2,
+        "lam_vc":    1e1,
+        "lam_prox":  1e0,
+        "ep_tr":     5e-3,
+        "ep_vc":     1e-6,
+    },
+)
+
+
+# ── Viser coordinate helpers ─────────────────────────────────────────────────
+# The model uses position = [altitude, lat_y, lat_z].
+# Viser convention follows the realtime PDG example: model (a, b, c) → Viser (c, b, a).
+# Altitude (position[0]) therefore maps to the Viser z-axis.
+
+def model_to_viser(pts: np.ndarray) -> np.ndarray:
+    """Remap ``(*, 3)`` model-frame positions to Viser XYZ.
+
+    Model [altitude, lat_y, lat_z] → Viser [lat_z, lat_y, altitude].
+    """
+    pts = np.asarray(pts, dtype=np.float64)
+    return np.stack([pts[..., 2], pts[..., 1], pts[..., 0]], axis=-1)
+
+
+def quat_xyzw_to_wxyz(q: np.ndarray) -> np.ndarray:
+    """Convert ``(*, 4)`` quaternion from [q1,q2,q3,q4=w] to Viser [w,x,y,z]."""
+    q = np.asarray(q, dtype=np.float64)
+    return np.stack([q[..., 3], q[..., 0], q[..., 1], q[..., 2]], axis=-1)
+
+
+def create_pdg_batched_viser_server(
+    results,
+    ic_batch: np.ndarray,
+    *,
+    gamma_deg: float = 75.0,
+) -> viser.ViserServer:
+    """Build a Viser scene showing all batched PDG propagated trajectories.
+
+    Trajectories are drawn from ``results.x_full`` (high-fidelity nonlinear
+    propagation) rather than the coarse SCP nodes, giving smooth continuous
+    paths.  All ``B`` trajectories are shown simultaneously (green = converged,
+    red = diverged).  A slider lets the user pick one run to highlight with an
+    animated trail, position marker, and attitude frame.
+
+    Args:
+        results: :class:`~openscvx.algorithms.OptimizationResults` returned by
+            :meth:`~openscvx.problem.Problem.post_process_batched`.  Must have
+            ``x_full`` (shape ``(B, T, n_x)``) and ``t_full`` (shape
+            ``(B, T)``) populated.
+        ic_batch: ``(B, 3)`` array of initial positions (model frame).
+        gamma_deg: Glide-slope half-angle used in the constraint
+            ``0.1 * ||pos[1:]|| <= tan(gamma) * pos[0]``.  Converted to
+            the visualised cone half-angle internally.
+    """
+    x_full    = np.asarray(results.x_full)          # (B, T, n_x)
+    t_full    = np.asarray(results.t_full)           # (B, T)
+    converged = np.asarray(results.converged, dtype=bool).reshape(-1)
+    B, T = x_full.shape[0], x_full.shape[1]
+
+    # State layout: mass[0], position[1:4], velocity[4:7], attitude[7:11],
+    # angular_velocity[11:14].  Same indices in x_full as in the SCP x array.
+    pos_model = x_full[:, :, 1:4]                   # (B, T, 3)
+    att_xyzw  = x_full[:, :, 7:11]                  # (B, T, 4) — [q1,q2,q3,q4=w]
+    vel_model = x_full[:, :, 4:7]                   # (B, T, 3)
+
+    pos_viser = model_to_viser(pos_model)            # (B, T, 3)  Viser frame
+    att_wxyz  = quat_xyzw_to_wxyz(att_xyzw)         # (B, T, 4)  [w,x,y,z]
+
+    # Create server — frame camera around all trajectory points.
+    server = create_server(pos_viser.reshape(-1, 3))
+    server.gui.configure_theme(dark_mode=True)
+
+    # ── Static scene ─────────────────────────────────────────────────────────
+    server.scene.add_grid(
+        "/grid",
+        width=30.0,
+        height=30.0,
+        position=(0.0, 0.0, 0.0),
+    )
+    server.scene.add_icosphere(
+        "/markers/landing",
+        radius=0.25,
+        position=(0.0, 0.0, 0.0),
+        color=(255, 80, 80),
+    )
+
+    # Glideslope cone.  The constraint is 0.1*||pos[1:]|| <= tan(γ)*pos[0],
+    # i.e. ||pos[1:]|| <= 10·tan(γ)·pos[0], so the effective half-angle is
+    # atan(10·tan(γ)).  In Viser, altitude is the +z axis.
+    effective_half_angle = float(
+        np.degrees(np.arctan(10.0 * np.tan(np.radians(gamma_deg))))
+    )
+    add_glideslope_cone(
+        server,
+        apex=(0.0, 0.0, 0.0),
+        height=12.0,
+        glideslope_angle_deg=effective_half_angle,
+        axis=(0.0, 0.0, 1.0),
+        color=(80, 200, 120),
+        opacity=0.12,
+    )
+
+    # ── All propagated trajectories ───────────────────────────────────────────
+    for b in range(B):
+        color = (80, 210, 100) if converged[b] else (220, 70, 70)
+        pts = pos_viser[b].astype(np.float32)        # (T, 3)
+        segments = np.stack([pts[:-1], pts[1:]], axis=1)
+        server.scene.add_line_segments(
+            f"/runs/{b}/path",
+            points=segments,
+            colors=color,
+            line_width=2.0,
+        )
+        server.scene.add_icosphere(
+            f"/runs/{b}/start",
+            radius=0.12,
+            position=tuple(pts[0]),
+            color=(120, 220, 255) if converged[b] else (255, 160, 80),
+        )
+
+    # ── Highlighted run (animated over propagated time) ───────────────────────
+    ctx: dict = {"run": 0}
+    _pos    = pos_viser[0].copy()      # (T, 3)
+    _att    = att_wxyz[0].copy()       # (T, 4)
+    _vel    = vel_model[0].copy()      # (T, 3)
+    _colors = compute_velocity_colors(_vel)
+
+    _, update_trail    = add_animated_trail(server, _pos, _colors, point_size=0.18)
+    _, update_marker   = add_position_marker(server, _pos, radius=0.25, color=(100, 200, 255))
+    _, update_attitude = add_attitude_frame(server, _pos, _att, axes_length=0.6)
+    highlight_cbs = [cb for cb in (update_trail, update_marker, update_attitude) if cb is not None]
+
+    # traj_time is the real-time axis for run 0 (updated in _load_run).
+    traj_time = t_full[0].copy()       # (T,)
+
+    def _load_run(run_idx: int) -> None:
+        ctx["run"] = run_idx
+        _pos[...]    = pos_viser[run_idx]
+        _att[...]    = att_wxyz[run_idx]
+        _vel[...]    = vel_model[run_idx]
+        _colors[...] = compute_velocity_colors(_vel)
+        traj_time[:] = t_full[run_idx]
+        for cb in highlight_cbs:
+            cb(0)
+
+    # ── GUI ──────────────────────────────────────────────────────────────────
+    n_ok = int(converged.sum())
+    with server.gui.add_folder("Batch overview"):
+        server.gui.add_markdown(
+            f"**{B} initial conditions** — "
+            f"green = converged ({n_ok}), red = diverged ({B - n_ok})."
+        )
+        run_slider = server.gui.add_slider(
+            "Highlight run",
+            min=0,
+            max=B - 1,
+            step=1,
+            initial_value=0,
+        )
+
+        @run_slider.on_update
+        def _(_) -> None:
+            _load_run(int(run_slider.value))
+
+    add_animation_controls(server, traj_time, highlight_cbs, folder_name="Playback")
+
+    return server
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+if __name__ == "__main__":
+    print("Initializing 6-DoF PDG problem (Moreau backend) …")
+    t0 = time.perf_counter()
+    problem.initialize()
+    t_init = time.perf_counter() - t0
+    print(f"  initialize()  {t_init:.2f} s")
+
+    # Sample N_BATCH random initial positions
+    ic_batch = sample_initial_positions(N_BATCH)
+    print(f"\nSampled {N_BATCH} random initial positions (altitude ∈ [3, 9] m, lateral ∈ [-7, 7] m)")
+    print(f"  ic_batch.shape = {ic_batch.shape}")
+
+    # ── First call: compile + solve ───────────────────────────────────────────
+    print(f"\nRunning solve_batched (first call — includes XLA compile) …")
+    t0 = time.perf_counter()
+    results = problem.solve_batched(
+        parameters={"initial_position": ic_batch},
+    )
+    t_first = time.perf_counter() - t0
+    print(f"  solve_batched  {t_first:.2f} s  (incl. compile)")
+
+    # ── Post-process: propagate all B solutions through nonlinear dynamics ────
+    print(f"\nRunning post_process_batched ({N_BATCH} elements, sequential) …")
+    t0 = time.perf_counter()
+    results = problem.post_process_batched(results)
+    t_prop = time.perf_counter() - t0
+    print(f"  post_process_batched  {t_prop:.2f} s")
+    print(f"  propagated shapes: x_full={results.x_full.shape}, t_full={results.t_full.shape}")
+
+    # ── Second call: cached artifact ──────────────────────────────────────────
+    ic_batch2 = sample_initial_positions(N_BATCH, seed=99)
+    print(f"\nRunning solve_batched (second call — compiled artifact cached) …")
+    t0 = time.perf_counter()
+    results2 = problem.solve_batched(
+        parameters={"initial_position": ic_batch2},
+    )
+    t_second = time.perf_counter() - t0
+    print(f"  solve_batched  {t_second:.2f} s")
+
+    # ── Convergence statistics ────────────────────────────────────────────────
+    # results.x has shape (B, N, n_x); results.converged has shape (B,)
+    converged = np.asarray(results.converged)
+    converged2 = np.asarray(results2.converged)
+
+    print(f"\n── First batch results ──────────────────────────────────────────")
+    print(f"  Converged:   {int(converged.sum())} / {N_BATCH}")
+    print(f"  Diverged:    {int((~converged).sum())} / {N_BATCH}")
+
+    if converged.any():
+        x_traj = np.asarray(results.x)          # (B, N, n_x)
+        # Position occupies state indices 1:4 (mass is index 0)
+        pos_traj = x_traj[converged, :, 1:4]    # (n_conv, N, 3)
+        x0_pos   = pos_traj[:, 0, :]            # initial position at node 0
+        xf_pos   = pos_traj[:, -1, :]           # terminal position at node N-1
+
+        print(f"\n  Requested initial altitudes (first 5 converged):")
+        conv_idx = np.where(converged)[0][:5]
+        for i in conv_idx:
+            req  = ic_batch[i]
+            got  = x_traj[i, 0, 1:4]
+            print(f"    sample {i:2d}  requested=[{req[0]:.2f}, {req[1]:.2f}, {req[2]:.2f}]  "
+                  f"got=[{got[0]:.2f}, {got[1]:.2f}, {got[2]:.2f}]")
+
+        print(f"\n  Terminal position errors (||pos_f - [0,0,0]||, first 5 converged):")
+        for i in conv_idx:
+            err = float(np.linalg.norm(xf_pos[i - conv_idx[0]]))
+            print(f"    sample {i:2d}  terminal error = {err:.4f} m")
+
+    print(f"\n── Second batch results ─────────────────────────────────────────")
+    print(f"  Converged:   {int(converged2.sum())} / {N_BATCH}")
+
+    # ── Viser visualisation ───────────────────────────────────────────────────
+    print("\nLaunching Viser — all 50 propagated PDG trajectories + highlight playback …")
+    viser_server = create_pdg_batched_viser_server(results, ic_batch)
+    viser_server.sleep_forever()

--- a/examples/rocket/6DoF_pdg_batched_ic.py
+++ b/examples/rocket/6DoF_pdg_batched_ic.py
@@ -1,12 +1,12 @@
 """Batched 6-DoF powered descent guidance — ``solve_batched`` over initial conditions.
 
-Runs ``N_BATCH = 200`` SCP solves in parallel, each starting from a different random
-initial position drawn uniformly within the position bounds.
-
-The initial position is a ``Parameter`` pinned via
-``(position == initial_position).convex().at([0])``.  Per-batch ``x_guess``
-stacks (position linspace from each sampled IC to the terminal guess) seed the
-SCP iterate independently via :meth:`~openscvx.problem.Problem.solve_batched`.
+Runs ``N_BATCH`` SCP solves in parallel, each starting from a different random
+initial position drawn uniformly within the position bounds.  Each batch element
+gets its own row in ``x0_stack`` (shape ``(B, n_x)``): the default
+``x_init_pin`` from :meth:`~openscvx.problem.Problem.initialize`, with the
+position slice overwritten from the sampled ICs.  Terminal conditions are shared
+via a broadcast ``xf_stack``.  Per-batch ``x_guess`` stacks (position linspace
+from each sampled IC to the terminal guess) seed the SCP iterate independently.
 
 The same physics as ``base_problems/6DoF_pdg_realtime_base.py`` but rebuilt
 with a Moreau backend so the whole SCP loop is a single XLA kernel.
@@ -31,6 +31,7 @@ import jax
 
 jax.config.update("jax_enable_x64", True)
 
+import jax.numpy as jnp
 import numpy as np
 import viser
 
@@ -50,6 +51,9 @@ from openscvx.plotting.viser import (
 # ── Problem dimensions ──────────────────────────────────────────────────────
 N = 5  # discretization nodes
 N_BATCH = 200  # number of simultaneous solves
+
+# Position lives at unified-state indices 1:4 (mass is index 0).
+POSITION_SLICE = slice(1, 4)
 
 
 # ── Random initial-condition generator ─────────────────────────────────────
@@ -205,8 +209,7 @@ constraint_exprs = []
 for st in states:
     constraint_exprs.extend([ox.ctcs(st <= st.max), ox.ctcs(st.min <= st)])
 
-# Initial and terminal position constraints — batched over initial_position.
-constraint_exprs.append((position == initial_position).convex().at([0]))
+# Terminal lateral position; initial position is batched via x0_stack (Fix BC).
 constraint_exprs.append((position[1:3] == final_position).convex().at([N - 1]))
 
 constraint_exprs.append(ox.ctcs(1.0 * (mass - m_dry) >= 0))
@@ -254,6 +257,8 @@ problem = Problem(
         "ep_vc": 1e-6,
     },
 )
+
+problem.settings.prp.dt = 0.02
 
 
 # ── Viser coordinate helpers ─────────────────────────────────────────────────
@@ -424,13 +429,19 @@ if __name__ == "__main__":
     print(f"Sampled {N_BATCH} initial positions  (alt ∈ [3, 9] m, lat ∈ [-7, 7] m)")
 
     # ── Compile + solve ───────────────────────────────────────────────────────
-    # B is inferred from ic_batch.shape[0].  solve_batched vmaps over
-    # initial_position (shape (B, 3)) while broadcasting all other parameters.
-    # Per-batch x_guess seeds each SCP iterate with an IC-consistent trajectory.
+    # Stack boundary pins: default Fix entries plus per-batch position ICs.
+    default_init = np.asarray(problem.state.x_init_pin)
+    x0_stack = np.broadcast_to(default_init, (N_BATCH, default_init.shape[0])).copy()
+    x0_stack[:, POSITION_SLICE] = ic_batch
+    x0_stack = jnp.asarray(x0_stack)
+    xf_pin = np.asarray(problem.state.x_term_pin)
+    xf_stack = jnp.broadcast_to(xf_pin, (N_BATCH, xf_pin.shape[0]))
     x_guess_batch = build_batched_x_guess(problem, ic_batch)
+
     print("Compiling and running solve_batched …")
     results = problem.solve_batched(
-        parameters={"initial_position": ic_batch},
+        x0_stack=x0_stack,
+        xf_stack=xf_stack,
         x_guess=x_guess_batch,
     )
 

--- a/examples/rocket/6DoF_pdg_batched_ic.py
+++ b/examples/rocket/6DoF_pdg_batched_ic.py
@@ -26,13 +26,11 @@ from __future__ import annotations
 
 import os
 import sys
-import time
 
 import jax
 
 jax.config.update("jax_enable_x64", True)
 
-import jax.numpy as jnp
 import numpy as np
 import viser
 
@@ -50,8 +48,9 @@ from openscvx.plotting.viser import (
 )
 
 # ── Problem dimensions ──────────────────────────────────────────────────────
-N = 5          # discretization nodes
-N_BATCH = 200   # number of simultaneous solves
+N = 5  # discretization nodes
+N_BATCH = 200  # number of simultaneous solves
+
 
 # ── Random initial-condition generator ─────────────────────────────────────
 # Position bounds: [-10, 10]^3.  For physical realism we keep altitude
@@ -82,43 +81,44 @@ def build_batched_x_guess(problem, ic_batch: np.ndarray) -> np.ndarray:
     )
     return x_guess_batch
 
+
 # ── Runtime parameters ──────────────────────────────────────────────────────
-gI         = ox.Parameter("gI",    value=1.0)
-l_arm      = ox.Parameter("l",     value=0.25)
-J_diag     = ox.Parameter("J_diag", shape=(3,), value=np.array([0.168 * 2e-2, 0.168, 0.168]))
-J_mat      = ox.Diag(J_diag)
-J_inv_mat  = ox.Inv(ox.Diag(J_diag))
-g0         = ox.Parameter("g0",    value=1.0)
-Isp        = ox.Parameter("Isp",   value=30.0)
-m_dry      = ox.Parameter("m_dry", value=1.0)
-v_max      = ox.Parameter("v_max", value=3.0)
-w_max      = ox.Parameter("w_max", value=0.3752)
-del_max    = ox.Parameter("del_max", value=20.0)
-theta_max  = ox.Parameter("theta_max", value=75.0)
-T_min      = ox.Parameter("T_min", value=1.5)
-T_max      = ox.Parameter("T_max", value=6.5)
-gamma      = ox.Parameter("gamma", value=75.0)
-beta       = ox.Parameter("beta",  value=0.01)
-c_ax       = ox.Parameter("c_ax",  value=0.5)
-c_ayz      = ox.Parameter("c_ayz", value=1.0)
-S_a        = ox.Parameter("S_a",   value=0.5)
-rho        = ox.Parameter("rho",   value=1.0)
-l_p        = ox.Parameter("l_p",   value=0.05)
+gI = ox.Parameter("gI", value=1.0)
+l_arm = ox.Parameter("l", value=0.25)
+J_diag = ox.Parameter("J_diag", shape=(3,), value=np.array([0.168 * 2e-2, 0.168, 0.168]))
+J_mat = ox.Diag(J_diag)
+J_inv_mat = ox.Inv(ox.Diag(J_diag))
+g0 = ox.Parameter("g0", value=1.0)
+Isp = ox.Parameter("Isp", value=30.0)
+m_dry = ox.Parameter("m_dry", value=1.0)
+v_max = ox.Parameter("v_max", value=3.0)
+w_max = ox.Parameter("w_max", value=0.3752)
+del_max = ox.Parameter("del_max", value=20.0)
+theta_max = ox.Parameter("theta_max", value=75.0)
+T_min = ox.Parameter("T_min", value=1.5)
+T_max = ox.Parameter("T_max", value=6.5)
+gamma = ox.Parameter("gamma", value=75.0)
+beta = ox.Parameter("beta", value=0.01)
+c_ax = ox.Parameter("c_ax", value=0.5)
+c_ayz = ox.Parameter("c_ayz", value=1.0)
+S_a = ox.Parameter("S_a", value=0.5)
+rho = ox.Parameter("rho", value=1.0)
+l_p = ox.Parameter("l_p", value=0.05)
 
 # Batched parameter: each solve receives its own initial_position value.
 initial_position = ox.Parameter("initial_position", shape=(3,), value=np.array([7.5, 4.5, 2.5]))
-final_position   = ox.Parameter("final_position",   shape=(2,), value=np.array([0.0, 0.0]))
+final_position = ox.Parameter("final_position", shape=(2,), value=np.array([0.0, 0.0]))
 
-CA    = ox.Diag(ox.Concat(c_ax, c_ayz, c_ayz))
+CA = ox.Diag(ox.Concat(c_ax, c_ayz, c_ayz))
 r_arm = ox.Concat(-l_arm, 0.0, 0.0)
-r_cp  = ox.Concat(l_p,    0.0, 0.0)
+r_cp = ox.Concat(l_p, 0.0, 0.0)
 
 # ── States ──────────────────────────────────────────────────────────────────
 mass = ox.State("mass", shape=(1,))
 mass.max = [2.0]
 mass.min = [1.0]
 mass.initial = [2.0]
-mass.final   = [ox.Maximize(1.5)]
+mass.final = [ox.Maximize(1.5)]
 
 position = ox.State("position", shape=(3,))
 position.max = [10.0, 10.0, 10.0]
@@ -127,30 +127,30 @@ position.initial = [ox.Free(7.5), ox.Free(4.5), ox.Free(2.5)]
 position.final = [0.0, ox.Free(0.0), ox.Free(0.0)]
 
 velocity = ox.State("velocity", shape=(3,))
-velocity.max = [ v_max.value,  v_max.value,  v_max.value]
+velocity.max = [v_max.value, v_max.value, v_max.value]
 velocity.min = [-v_max.value, -v_max.value, -v_max.value]
 velocity.initial = [-0.5, -2.8, 0.0]
-velocity.final   = [-0.1,  0.0, 0.0]
+velocity.final = [-0.1, 0.0, 0.0]
 
 attitude = ox.State("attitude", shape=(4,))
 attitude.max = [1.0, 1.0, 1.0, 1.0]
 attitude.min = [-1.0, -1.0, -1.0, -1.0]
 attitude.initial = [ox.Free(0.0), ox.Free(0.0), ox.Free(0.0), ox.Free(1.0)]
-attitude.final   = [0.0, 0.0, 0.0, 1.0]
+attitude.final = [0.0, 0.0, 0.0, 1.0]
 
 angular_velocity = ox.State("angular_velocity", shape=(3,))
-angular_velocity.max = [ w_max.value,  w_max.value,  w_max.value]
+angular_velocity.max = [w_max.value, w_max.value, w_max.value]
 angular_velocity.min = [-w_max.value, -w_max.value, -w_max.value]
 angular_velocity.initial = [1e-8, 0.0, 0.0]
-angular_velocity.final   = [1e-8, 0.0, 0.0]
+angular_velocity.final = [1e-8, 0.0, 0.0]
 
 # ── Controls ─────────────────────────────────────────────────────────────────
 thrust = ox.Control("thrust", shape=(3,))
-thrust.max = [ T_max.value,  T_max.value,  T_max.value]
+thrust.max = [T_max.value, T_max.value, T_max.value]
 thrust.min = [-T_max.value, -T_max.value, -T_max.value]
 thrust.guess = np.linspace(
     np.array([gI.value * mass.initial[0], 0, 0]),
-    np.array([gI.value * m_dry.value,     0, 0]),
+    np.array([gI.value * m_dry.value, 0, 0]),
     N,
 ).reshape(-1, 3)
 
@@ -159,37 +159,38 @@ q1, q2, q3, q4 = attitude[0], attitude[1], attitude[2], attitude[3]
 
 CBI = ox.Block(
     [
-        [q4**2 + q1**2 - q2**2 - q3**2, 2*(q1*q2 - q4*q3),              2*(q4*q2 + q1*q3)             ],
-        [2*(q4*q3 + q1*q2),              q4**2 - q1**2 + q2**2 - q3**2,  2*(q2*q3 - q4*q1)             ],
-        [2*(q1*q3 - q4*q2),              2*(q4*q1 + q2*q3),              q4**2 - q1**2 - q2**2 + q3**2],
+        [q4**2 + q1**2 - q2**2 - q3**2, 2 * (q1 * q2 - q4 * q3), 2 * (q4 * q2 + q1 * q3)],
+        [2 * (q4 * q3 + q1 * q2), q4**2 - q1**2 + q2**2 - q3**2, 2 * (q2 * q3 - q4 * q1)],
+        [2 * (q1 * q3 - q4 * q2), 2 * (q4 * q1 + q2 * q3), q4**2 - q1**2 - q2**2 + q3**2],
     ]
 ).T
 
 
 def cross(a, b):
     return ox.Concat(
-        a[1]*b[2] - a[2]*b[1],
-        a[2]*b[0] - a[0]*b[2],
-        a[0]*b[1] - a[1]*b[0],
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
     )
 
 
 w1, w2, w3 = angular_velocity[0], angular_velocity[1], angular_velocity[2]
 attitude_dot = ox.Concat(
-    0.5*(w1*q4 - w2*q3 + w3*q2),
-    0.5*(w1*q3 - w3*q1 + w2*q4),
-    0.5*(w2*q1 - w1*q2 + w3*q4),
-    -0.5*(w1*q1 + w2*q2 + w3*q3),
+    0.5 * (w1 * q4 - w2 * q3 + w3 * q2),
+    0.5 * (w1 * q3 - w3 * q1 + w2 * q4),
+    0.5 * (w2 * q1 - w1 * q2 + w3 * q4),
+    -0.5 * (w1 * q1 + w2 * q2 + w3 * q3),
 )
 
 A_aero = -0.5 * rho * ox.linalg.Norm(velocity) * S_a * CA @ CBI @ velocity
 
 dynamics = {
-    "mass":             -(1 / (Isp * g0)) * ox.linalg.Norm(thrust) - beta,
-    "position":         velocity,
-    "velocity":         CBI.T @ (thrust + A_aero) / mass[0] + ox.Concat(-gI, 0.0, 0.0),
-    "attitude":         attitude_dot,
-    "angular_velocity": J_inv_mat @ (
+    "mass": -(1 / (Isp * g0)) * ox.linalg.Norm(thrust) - beta,
+    "position": velocity,
+    "velocity": CBI.T @ (thrust + A_aero) / mass[0] + ox.Concat(-gI, 0.0, 0.0),
+    "attitude": attitude_dot,
+    "angular_velocity": J_inv_mat
+    @ (
         cross(r_arm, thrust)
         + cross(r_cp, A_aero)
         - cross(angular_velocity, J_mat @ angular_velocity)
@@ -197,7 +198,7 @@ dynamics = {
 }
 
 # ── Constraints ──────────────────────────────────────────────────────────────
-states   = [mass, position, velocity, attitude, angular_velocity]
+states = [mass, position, velocity, attitude, angular_velocity]
 controls = [thrust]
 
 constraint_exprs = []
@@ -205,23 +206,23 @@ for st in states:
     constraint_exprs.extend([ox.ctcs(st <= st.max), ox.ctcs(st.min <= st)])
 
 # Initial and terminal position constraints — batched over initial_position.
-constraint_exprs.append((position       == initial_position).convex().at([0]))
-constraint_exprs.append((position[1:3]  == final_position).convex().at([N - 1]))
+constraint_exprs.append((position == initial_position).convex().at([0]))
+constraint_exprs.append((position[1:3] == final_position).convex().at([N - 1]))
 
 constraint_exprs.append(ox.ctcs(1.0 * (mass - m_dry) >= 0))
-constraint_exprs.append(ox.ctcs(
-    0.1 * ox.linalg.Norm(position[1:]) - ox.Tan(gamma * np.pi / 180.0) * position[0] <= 0
-))
-constraint_exprs.append(ox.ctcs(0.1 * ox.linalg.Norm(velocity)**2 - v_max**2 <= 0))
-constraint_exprs.append(ox.ctcs(
-    1.0 * ox.Cos(theta_max * np.pi / 180.0) - 1.0 + 2.0 * (q2**2 + q3**2) <= 0
-))
-constraint_exprs.append(ox.ctcs(1.0 * ox.linalg.Norm(angular_velocity)**2 - w_max**2 <= 0))
-constraint_exprs.append(ox.ctcs(
-    0.1 * ox.linalg.Norm(thrust) - thrust[0] / ox.Cos(del_max * np.pi / 180.0) <= 0
-))
-constraint_exprs.append(ox.ctcs(0.1 * ox.linalg.Norm(thrust)**2 - T_max**2 <= 0))
-constraint_exprs.append(ox.ctcs(0.1 * T_min**2 - ox.linalg.Norm(thrust)**2 <= 0))
+constraint_exprs.append(
+    ox.ctcs(0.1 * ox.linalg.Norm(position[1:]) - ox.Tan(gamma * np.pi / 180.0) * position[0] <= 0)
+)
+constraint_exprs.append(ox.ctcs(0.1 * ox.linalg.Norm(velocity) ** 2 - v_max**2 <= 0))
+constraint_exprs.append(
+    ox.ctcs(1.0 * ox.Cos(theta_max * np.pi / 180.0) - 1.0 + 2.0 * (q2**2 + q3**2) <= 0)
+)
+constraint_exprs.append(ox.ctcs(1.0 * ox.linalg.Norm(angular_velocity) ** 2 - w_max**2 <= 0))
+constraint_exprs.append(
+    ox.ctcs(0.1 * ox.linalg.Norm(thrust) - thrust[0] / ox.Cos(del_max * np.pi / 180.0) <= 0)
+)
+constraint_exprs.append(ox.ctcs(0.1 * ox.linalg.Norm(thrust) ** 2 - T_max**2 <= 0))
+constraint_exprs.append(ox.ctcs(0.1 * T_min**2 - ox.linalg.Norm(thrust) ** 2 <= 0))
 
 # ── Time ─────────────────────────────────────────────────────────────────────
 t_final_guess = 10.0
@@ -246,11 +247,11 @@ problem = Problem(
     solver=ox.MoreauPTRSolver(),
     algorithm={
         "autotuner": ox.ConstantProximalWeight(),
-        "lam_cost":  1e-2,
-        "lam_vc":    1e1,
-        "lam_prox":  1e0,
-        "ep_tr":     5e-3,
-        "ep_vc":     1e-6,
+        "lam_cost": 1e-2,
+        "lam_vc": 1e1,
+        "lam_prox": 1e0,
+        "ep_tr": 5e-3,
+        "ep_vc": 1e-6,
     },
 )
 
@@ -259,6 +260,7 @@ problem = Problem(
 # The model uses position = [altitude, lat_y, lat_z].
 # Viser convention follows the realtime PDG example: model (a, b, c) → Viser (c, b, a).
 # Altitude (position[0]) therefore maps to the Viser z-axis.
+
 
 def model_to_viser(pts: np.ndarray) -> np.ndarray:
     """Remap ``(*, 3)`` model-frame positions to Viser XYZ.
@@ -298,16 +300,16 @@ def create_pdg_batched_viser_server(
             ``0.1 * ||pos[1:]|| <= tan(gamma) * pos[0]``.  Converted to
             the visualised cone half-angle internally.
     """
-    x_full    = np.asarray(results.x_full)          # (B, T, n_x)
-    t_full    = np.asarray(results.t_full)           # (B, T)
+    x_full = np.asarray(results.x_full)  # (B, T, n_x)
+    t_full = np.asarray(results.t_full)  # (B, T)
     converged = np.asarray(results.converged, dtype=bool).reshape(-1)
     B, T = x_full.shape[0], x_full.shape[1]
 
     # State layout: mass[0], position[1:4], velocity[4:7], attitude[7:11].
-    pos_model = x_full[:, :, 1:4]                   # (B, T, 3)
-    vel_model = x_full[:, :, 4:7]                   # (B, T, 3)
+    pos_model = x_full[:, :, 1:4]  # (B, T, 3)
+    vel_model = x_full[:, :, 4:7]  # (B, T, 3)
 
-    pos_viser = model_to_viser(pos_model)            # (B, T, 3)  Viser frame
+    pos_viser = model_to_viser(pos_model)  # (B, T, 3)  Viser frame
 
     # Create server — frame camera around all trajectory points.
     server = create_server(pos_viser.reshape(-1, 3))
@@ -316,16 +318,21 @@ def create_pdg_batched_viser_server(
     # ── Static scene ─────────────────────────────────────────────────────────
     server.scene.add_grid("/grid", width=30.0, height=30.0, position=(0.0, 0.0, 0.0))
     server.scene.add_icosphere(
-        "/markers/landing", radius=0.25, position=(0.0, 0.0, 0.0), color=(255, 80, 80),
+        "/markers/landing",
+        radius=0.25,
+        position=(0.0, 0.0, 0.0),
+        color=(255, 80, 80),
     )
 
-    effective_half_angle = float(
-        np.degrees(np.arctan(10.0 * np.tan(np.radians(gamma_deg))))
-    )
+    effective_half_angle = float(np.degrees(np.arctan(10.0 * np.tan(np.radians(gamma_deg)))))
     add_glideslope_cone(
-        server, apex=(0.0, 0.0, 0.0), height=12.0,
+        server,
+        apex=(0.0, 0.0, 0.0),
+        height=12.0,
         glideslope_angle_deg=effective_half_angle,
-        axis=(0.0, 0.0, 1.0), color=(80, 200, 120), opacity=0.12,
+        axis=(0.0, 0.0, 1.0),
+        color=(80, 200, 120),
+        opacity=0.12,
     )
 
     # ── Faint static traces (full trajectory extent) ──────────────────────────
@@ -351,21 +358,25 @@ def create_pdg_batched_viser_server(
 
     def _make_trail(handle, pts: np.ndarray, cols: np.ndarray):
         """Return a closure that grows the trail up to the given frame."""
+
         def update(frame_idx: int) -> None:
             idx = frame_idx + 1
             handle.points = pts[:idx]
             handle.colors = cols[:idx]
+
         return update
 
     def _make_marker(handle, pts: np.ndarray):
         """Return a closure that moves the marker to the given frame position."""
+
         def update(frame_idx: int) -> None:
             handle.position = pts[frame_idx]
+
         return update
 
     all_update_cbs = []
     for b in range(B):
-        pts_b    = pos_viser[b].astype(np.float32)       # (T, 3)
+        pts_b = pos_viser[b].astype(np.float32)  # (T, 3)
         colors_b = compute_velocity_colors(vel_model[b]).astype(np.uint8)
 
         trail_handle = server.scene.add_point_cloud(

--- a/examples/rocket/6DoF_pdg_batched_ic.py
+++ b/examples/rocket/6DoF_pdg_batched_ic.py
@@ -47,18 +47,15 @@ sys.path.append(repo_root_dir)
 import openscvx as ox
 from openscvx import Problem
 from openscvx.plotting.viser import (
-    add_animated_trail,
     add_animation_controls,
-    add_attitude_frame,
     add_glideslope_cone,
-    add_position_marker,
     compute_velocity_colors,
     create_server,
 )
 
 # ── Problem dimensions ──────────────────────────────────────────────────────
 N = 5          # discretization nodes
-N_BATCH = 50   # number of simultaneous solves
+N_BATCH = 200   # number of simultaneous solves
 
 # ── Random initial-condition generator ─────────────────────────────────────
 # Position bounds: [-10, 10]^3.  For physical realism we keep altitude
@@ -239,7 +236,7 @@ problem = Problem(
     constraints=constraint_exprs,
     time=time_config,
     float_dtype="float64",
-    solver={"backend": "moreau", "tol_gap_abs": 1e-7, "tol_feas": 1e-7},
+    solver=ox.MoreauPTRSolver(),
     algorithm={
         "autotuner": ox.ConstantProximalWeight(),
         "lam_cost":  1e-2,
@@ -277,13 +274,12 @@ def create_pdg_batched_viser_server(
     *,
     gamma_deg: float = 75.0,
 ) -> viser.ViserServer:
-    """Build a Viser scene showing all batched PDG propagated trajectories.
+    """Build a Viser scene animating all batched PDG trajectories simultaneously.
 
-    Trajectories are drawn from ``results.x_full`` (high-fidelity nonlinear
-    propagation) rather than the coarse SCP nodes, giving smooth continuous
-    paths.  All ``B`` trajectories are shown simultaneously (green = converged,
-    red = diverged).  A slider lets the user pick one run to highlight with an
-    animated trail, position marker, and attitude frame.
+    All ``B`` propagated trajectories play back at the same time.  Each run
+    gets its own growing trail (coloured by velocity magnitude) and a position
+    marker that slides along the path.  Static faint traces show the full
+    extent of each trajectory as context.
 
     Args:
         results: :class:`~openscvx.algorithms.OptimizationResults` returned by
@@ -300,112 +296,102 @@ def create_pdg_batched_viser_server(
     converged = np.asarray(results.converged, dtype=bool).reshape(-1)
     B, T = x_full.shape[0], x_full.shape[1]
 
-    # State layout: mass[0], position[1:4], velocity[4:7], attitude[7:11],
-    # angular_velocity[11:14].  Same indices in x_full as in the SCP x array.
+    # State layout: mass[0], position[1:4], velocity[4:7], attitude[7:11].
     pos_model = x_full[:, :, 1:4]                   # (B, T, 3)
-    att_xyzw  = x_full[:, :, 7:11]                  # (B, T, 4) — [q1,q2,q3,q4=w]
     vel_model = x_full[:, :, 4:7]                   # (B, T, 3)
 
     pos_viser = model_to_viser(pos_model)            # (B, T, 3)  Viser frame
-    att_wxyz  = quat_xyzw_to_wxyz(att_xyzw)         # (B, T, 4)  [w,x,y,z]
 
     # Create server — frame camera around all trajectory points.
     server = create_server(pos_viser.reshape(-1, 3))
     server.gui.configure_theme(dark_mode=True)
 
     # ── Static scene ─────────────────────────────────────────────────────────
-    server.scene.add_grid(
-        "/grid",
-        width=30.0,
-        height=30.0,
-        position=(0.0, 0.0, 0.0),
-    )
+    server.scene.add_grid("/grid", width=30.0, height=30.0, position=(0.0, 0.0, 0.0))
     server.scene.add_icosphere(
-        "/markers/landing",
-        radius=0.25,
-        position=(0.0, 0.0, 0.0),
-        color=(255, 80, 80),
+        "/markers/landing", radius=0.25, position=(0.0, 0.0, 0.0), color=(255, 80, 80),
     )
 
-    # Glideslope cone.  The constraint is 0.1*||pos[1:]|| <= tan(γ)*pos[0],
-    # i.e. ||pos[1:]|| <= 10·tan(γ)·pos[0], so the effective half-angle is
-    # atan(10·tan(γ)).  In Viser, altitude is the +z axis.
     effective_half_angle = float(
         np.degrees(np.arctan(10.0 * np.tan(np.radians(gamma_deg))))
     )
     add_glideslope_cone(
-        server,
-        apex=(0.0, 0.0, 0.0),
-        height=12.0,
+        server, apex=(0.0, 0.0, 0.0), height=12.0,
         glideslope_angle_deg=effective_half_angle,
-        axis=(0.0, 0.0, 1.0),
-        color=(80, 200, 120),
-        opacity=0.12,
+        axis=(0.0, 0.0, 1.0), color=(80, 200, 120), opacity=0.12,
     )
 
-    # ── All propagated trajectories ───────────────────────────────────────────
+    # ── Faint static traces (full trajectory extent) ──────────────────────────
     for b in range(B):
-        color = (80, 210, 100) if converged[b] else (220, 70, 70)
-        pts = pos_viser[b].astype(np.float32)        # (T, 3)
-        segments = np.stack([pts[:-1], pts[1:]], axis=1)
+        color = (40, 120, 55) if converged[b] else (110, 40, 40)
+        pts = pos_viser[b].astype(np.float32)
         server.scene.add_line_segments(
-            f"/runs/{b}/path",
-            points=segments,
+            f"/traces/{b}",
+            points=np.stack([pts[:-1], pts[1:]], axis=1),
             colors=color,
-            line_width=2.0,
+            line_width=1.0,
         )
         server.scene.add_icosphere(
-            f"/runs/{b}/start",
-            radius=0.12,
+            f"/traces/{b}/start",
+            radius=0.10,
             position=tuple(pts[0]),
-            color=(120, 220, 255) if converged[b] else (255, 160, 80),
+            color=(80, 160, 200) if converged[b] else (200, 120, 60),
         )
 
-    # ── Highlighted run (animated over propagated time) ───────────────────────
-    ctx: dict = {"run": 0}
-    _pos    = pos_viser[0].copy()      # (T, 3)
-    _att    = att_wxyz[0].copy()       # (T, 4)
-    _vel    = vel_model[0].copy()      # (T, 3)
-    _colors = compute_velocity_colors(_vel)
+    # ── Per-element animated trails and position markers ──────────────────────
+    # The helpers (add_animated_trail / add_position_marker) hardcode scene
+    # paths, so we inline the equivalent logic with unique per-element paths.
 
-    _, update_trail    = add_animated_trail(server, _pos, _colors, point_size=0.18)
-    _, update_marker   = add_position_marker(server, _pos, radius=0.25, color=(100, 200, 255))
-    _, update_attitude = add_attitude_frame(server, _pos, _att, axes_length=0.6)
-    highlight_cbs = [cb for cb in (update_trail, update_marker, update_attitude) if cb is not None]
+    def _make_trail(handle, pts: np.ndarray, cols: np.ndarray):
+        """Return a closure that grows the trail up to the given frame."""
+        def update(frame_idx: int) -> None:
+            idx = frame_idx + 1
+            handle.points = pts[:idx]
+            handle.colors = cols[:idx]
+        return update
 
-    # traj_time is the real-time axis for run 0 (updated in _load_run).
-    traj_time = t_full[0].copy()       # (T,)
+    def _make_marker(handle, pts: np.ndarray):
+        """Return a closure that moves the marker to the given frame position."""
+        def update(frame_idx: int) -> None:
+            handle.position = pts[frame_idx]
+        return update
 
-    def _load_run(run_idx: int) -> None:
-        ctx["run"] = run_idx
-        _pos[...]    = pos_viser[run_idx]
-        _att[...]    = att_wxyz[run_idx]
-        _vel[...]    = vel_model[run_idx]
-        _colors[...] = compute_velocity_colors(_vel)
-        traj_time[:] = t_full[run_idx]
-        for cb in highlight_cbs:
-            cb(0)
+    all_update_cbs = []
+    for b in range(B):
+        pts_b    = pos_viser[b].astype(np.float32)       # (T, 3)
+        colors_b = compute_velocity_colors(vel_model[b]).astype(np.uint8)
+
+        trail_handle = server.scene.add_point_cloud(
+            f"/animated/{b}/trail",
+            points=pts_b[:1],
+            colors=colors_b[:1],
+            point_size=0.13,
+        )
+        marker_color = (80, 210, 100) if converged[b] else (220, 70, 70)
+        marker_handle = server.scene.add_icosphere(
+            f"/animated/{b}/marker",
+            radius=0.20,
+            color=marker_color,
+            position=tuple(pts_b[0]),
+        )
+
+        all_update_cbs.append(_make_trail(trail_handle, pts_b, colors_b))
+        all_update_cbs.append(_make_marker(marker_handle, pts_b))
 
     # ── GUI ──────────────────────────────────────────────────────────────────
     n_ok = int(converged.sum())
     with server.gui.add_folder("Batch overview"):
         server.gui.add_markdown(
-            f"**{B} initial conditions** — "
+            f"**{B} trajectories animating simultaneously**  \n"
             f"green = converged ({n_ok}), red = diverged ({B - n_ok})."
         )
-        run_slider = server.gui.add_slider(
-            "Highlight run",
-            min=0,
-            max=B - 1,
-            step=1,
-            initial_value=0,
-        )
 
-        @run_slider.on_update
-        def _(_) -> None:
-            _load_run(int(run_slider.value))
+    # Use the mean terminal time as the representative playback axis so the
+    # slider labels reflect a typical trajectory duration.
+    mean_t_final = float(t_full[:, -1].mean())
+    traj_time = np.linspace(0.0, mean_t_final, T)
 
-    add_animation_controls(server, traj_time, highlight_cbs, folder_name="Playback")
+    add_animation_controls(server, traj_time, all_update_cbs, folder_name="Playback")
 
     return server
 
@@ -413,76 +399,23 @@ def create_pdg_batched_viser_server(
 # ── Main ──────────────────────────────────────────────────────────────────────
 if __name__ == "__main__":
     print("Initializing 6-DoF PDG problem (Moreau backend) …")
-    t0 = time.perf_counter()
     problem.initialize()
-    t_init = time.perf_counter() - t0
-    print(f"  initialize()  {t_init:.2f} s")
 
     # Sample N_BATCH random initial positions
     ic_batch = sample_initial_positions(N_BATCH)
-    print(f"\nSampled {N_BATCH} random initial positions (altitude ∈ [3, 9] m, lateral ∈ [-7, 7] m)")
-    print(f"  ic_batch.shape = {ic_batch.shape}")
+    print(f"Sampled {N_BATCH} initial positions  (alt ∈ [3, 9] m, lat ∈ [-7, 7] m)")
 
-    # ── First call: compile + solve ───────────────────────────────────────────
-    print(f"\nRunning solve_batched (first call — includes XLA compile) …")
-    t0 = time.perf_counter()
-    results = problem.solve_batched(
-        parameters={"initial_position": ic_batch},
-    )
-    t_first = time.perf_counter() - t0
-    print(f"  solve_batched  {t_first:.2f} s  (incl. compile)")
+    # ── Compile + solve ───────────────────────────────────────────────────────
+    # AOT compilation happens inside solve_batched and is timed separately;
+    # timing_solve reflects pure SCP execution only.
+    print("Compiling and running solve_batched …")
+    results = problem.solve_batched(parameters={"initial_position": ic_batch})
 
     # ── Post-process: propagate all B solutions through nonlinear dynamics ────
-    print(f"\nRunning post_process_batched ({N_BATCH} elements, sequential) …")
-    t0 = time.perf_counter()
+    print("Post-processing (nonlinear propagation) …")
     results = problem.post_process_batched(results)
-    t_prop = time.perf_counter() - t0
-    print(f"  post_process_batched  {t_prop:.2f} s")
-    print(f"  propagated shapes: x_full={results.x_full.shape}, t_full={results.t_full.shape}")
-
-    # ── Second call: cached artifact ──────────────────────────────────────────
-    ic_batch2 = sample_initial_positions(N_BATCH, seed=99)
-    print(f"\nRunning solve_batched (second call — compiled artifact cached) …")
-    t0 = time.perf_counter()
-    results2 = problem.solve_batched(
-        parameters={"initial_position": ic_batch2},
-    )
-    t_second = time.perf_counter() - t0
-    print(f"  solve_batched  {t_second:.2f} s")
-
-    # ── Convergence statistics ────────────────────────────────────────────────
-    # results.x has shape (B, N, n_x); results.converged has shape (B,)
-    converged = np.asarray(results.converged)
-    converged2 = np.asarray(results2.converged)
-
-    print(f"\n── First batch results ──────────────────────────────────────────")
-    print(f"  Converged:   {int(converged.sum())} / {N_BATCH}")
-    print(f"  Diverged:    {int((~converged).sum())} / {N_BATCH}")
-
-    if converged.any():
-        x_traj = np.asarray(results.x)          # (B, N, n_x)
-        # Position occupies state indices 1:4 (mass is index 0)
-        pos_traj = x_traj[converged, :, 1:4]    # (n_conv, N, 3)
-        x0_pos   = pos_traj[:, 0, :]            # initial position at node 0
-        xf_pos   = pos_traj[:, -1, :]           # terminal position at node N-1
-
-        print(f"\n  Requested initial altitudes (first 5 converged):")
-        conv_idx = np.where(converged)[0][:5]
-        for i in conv_idx:
-            req  = ic_batch[i]
-            got  = x_traj[i, 0, 1:4]
-            print(f"    sample {i:2d}  requested=[{req[0]:.2f}, {req[1]:.2f}, {req[2]:.2f}]  "
-                  f"got=[{got[0]:.2f}, {got[1]:.2f}, {got[2]:.2f}]")
-
-        print(f"\n  Terminal position errors (||pos_f - [0,0,0]||, first 5 converged):")
-        for i in conv_idx:
-            err = float(np.linalg.norm(xf_pos[i - conv_idx[0]]))
-            print(f"    sample {i:2d}  terminal error = {err:.4f} m")
-
-    print(f"\n── Second batch results ─────────────────────────────────────────")
-    print(f"  Converged:   {int(converged2.sum())} / {N_BATCH}")
 
     # ── Viser visualisation ───────────────────────────────────────────────────
-    print("\nLaunching Viser — all 50 propagated PDG trajectories + highlight playback …")
+    print("\nLaunching Viser — all trajectories animating simultaneously …")
     viser_server = create_pdg_batched_viser_server(results, ic_batch)
     viser_server.sleep_forever()

--- a/examples/rocket/6DoF_pdg_batched_ic.py
+++ b/examples/rocket/6DoF_pdg_batched_ic.py
@@ -1,27 +1,23 @@
 """Batched 6-DoF powered descent guidance — ``solve_batched`` over initial conditions.
 
-Runs ``N_BATCH = 50`` SCP solves in parallel, each starting from a different random
-initial position drawn uniformly within the position bounds.  Demonstrates the
-param-fix-pin mechanism introduced to support
-``(state == parameter).convex().at([0])`` in the JAX-native backends:
+Runs ``N_BATCH = 200`` SCP solves in parallel, each starting from a different random
+initial position drawn uniformly within the position bounds.
 
-* At lowering time :meth:`~openscvx.solvers.moreau_ptr_solver.MoreauPTRSolver` detects
-  ``(position == initial_position).convex().at([0])`` as a param-fix pin and absorbs
-  it into the ``"Fix"`` boundary-condition infrastructure.
-* At call time :meth:`~openscvx.problem.Problem.solve_batched` receives a
-  ``(B, 3)`` batched ``initial_position`` parameter and auto-builds the
-  ``x0_stack`` from it — no manual stack construction required.
+The initial position is a ``Parameter`` pinned via
+``(position == initial_position).convex().at([0])``.  Per-batch ``x_guess``
+stacks (position linspace from each sampled IC to the terminal guess) seed the
+SCP iterate independently via :meth:`~openscvx.problem.Problem.solve_batched`.
 
 The same physics as ``base_problems/6DoF_pdg_realtime_base.py`` but rebuilt
 with a Moreau backend so the whole SCP loop is a single XLA kernel.
 
-After solving, all 50 trajectories are propagated through the full nonlinear
+After solving, all trajectories are propagated through the full nonlinear
 dynamics via :meth:`~openscvx.problem.Problem.post_process_batched`, and the
 smooth high-fidelity paths are shown in the Viser visualisation.
 
 Run::
 
-    python examples/realtime/6DoF_pdg_batched_ic.py
+    python examples/rocket/6DoF_pdg_batched_ic.py
 
 Requires ``pip install openscvx[moreau]``.
 """
@@ -71,6 +67,21 @@ def sample_initial_positions(n: int, *, seed: int = 42) -> np.ndarray:
     lateral_z = rng.uniform(-7.0, 7.0, size=(n,))
     return np.stack([altitude, lateral_y, lateral_z], axis=-1)
 
+
+def build_batched_x_guess(problem, ic_batch: np.ndarray) -> np.ndarray:
+    """Build per-batch state guesses with position linspace IC → terminal."""
+    base_x = np.asarray(problem.state.x)  # (N, n_x)
+    pos_sl = position._slice
+    final_pos = base_x[-1, pos_sl]
+    B = ic_batch.shape[0]
+    x_guess_batch = np.broadcast_to(base_x, (B,) + base_x.shape).copy()
+    t = np.linspace(0.0, 1.0, N)
+    x_guess_batch[:, :, pos_sl] = (
+        ic_batch[:, None, :] * (1.0 - t[None, :, None])
+        + final_pos[None, None, :] * t[None, :, None]
+    )
+    return x_guess_batch
+
 # ── Runtime parameters ──────────────────────────────────────────────────────
 gI         = ox.Parameter("gI",    value=1.0)
 l_arm      = ox.Parameter("l",     value=0.25)
@@ -94,7 +105,7 @@ S_a        = ox.Parameter("S_a",   value=0.5)
 rho        = ox.Parameter("rho",   value=1.0)
 l_p        = ox.Parameter("l_p",   value=0.05)
 
-# Boundary-condition parameters (the ones we will batch over)
+# Batched parameter: each solve receives its own initial_position value.
 initial_position = ox.Parameter("initial_position", shape=(3,), value=np.array([7.5, 4.5, 2.5]))
 final_position   = ox.Parameter("final_position",   shape=(2,), value=np.array([0.0, 0.0]))
 
@@ -112,11 +123,7 @@ mass.final   = [ox.Maximize(1.5)]
 position = ox.State("position", shape=(3,))
 position.max = [10.0, 10.0, 10.0]
 position.min = [-10.0, -10.0, -10.0]
-position.initial = [
-    ox.Free(float(initial_position.value[0])),
-    ox.Free(float(initial_position.value[1])),
-    ox.Free(float(initial_position.value[2])),
-]
+position.initial = [ox.Free(7.5), ox.Free(4.5), ox.Free(2.5)]
 position.final = [0.0, ox.Free(0.0), ox.Free(0.0)]
 
 velocity = ox.State("velocity", shape=(3,))
@@ -197,7 +204,7 @@ constraint_exprs = []
 for st in states:
     constraint_exprs.extend([ox.ctcs(st <= st.max), ox.ctcs(st.min <= st)])
 
-# Param-fix boundary constraints — these are the pins we batch over.
+# Initial and terminal position constraints — batched over initial_position.
 constraint_exprs.append((position       == initial_position).convex().at([0]))
 constraint_exprs.append((position[1:3]  == final_position).convex().at([N - 1]))
 
@@ -406,10 +413,15 @@ if __name__ == "__main__":
     print(f"Sampled {N_BATCH} initial positions  (alt ∈ [3, 9] m, lat ∈ [-7, 7] m)")
 
     # ── Compile + solve ───────────────────────────────────────────────────────
-    # AOT compilation happens inside solve_batched and is timed separately;
-    # timing_solve reflects pure SCP execution only.
+    # B is inferred from ic_batch.shape[0].  solve_batched vmaps over
+    # initial_position (shape (B, 3)) while broadcasting all other parameters.
+    # Per-batch x_guess seeds each SCP iterate with an IC-consistent trajectory.
+    x_guess_batch = build_batched_x_guess(problem, ic_batch)
     print("Compiling and running solve_batched …")
-    results = problem.solve_batched(parameters={"initial_position": ic_batch})
+    results = problem.solve_batched(
+        parameters={"initial_position": ic_batch},
+        x_guess=x_guess_batch,
+    )
 
     # ── Post-process: propagate all B solutions through nonlinear dynamics ────
     print("Post-processing (nonlinear propagation) …")

--- a/examples/rocket/6DoF_pdg_batched_ic.py
+++ b/examples/rocket/6DoF_pdg_batched_ic.py
@@ -1,12 +1,12 @@
 """Batched 6-DoF powered descent guidance — ``solve_batched`` over initial conditions.
 
 Runs ``N_BATCH`` SCP solves in parallel, each starting from a different random
-initial position drawn uniformly within the position bounds.  Each batch element
-gets its own row in ``x0_stack`` (shape ``(B, n_x)``): the default
-``x_init_pin`` from :meth:`~openscvx.problem.Problem.initialize`, with the
-position slice overwritten from the sampled ICs.  Terminal conditions are shared
-via a broadcast ``xf_stack``.  Per-batch ``x_guess`` stacks (position linspace
-from each sampled IC to the terminal guess) seed the SCP iterate independently.
+initial position drawn uniformly within the position bounds.  Per-batch ICs are
+passed through ``x0_stack``: position is declared ``Fix`` at the symbolic level
+(so the solver consumes ``x_init_pin``), then each batch row overwrites the
+position slice with the sampled values.  This avoids the per-iteration
+``(position == parameter).convex()`` constraint while still enforcing the full
+uniform IC cloud.
 
 The same physics as ``base_problems/6DoF_pdg_realtime_base.py`` but rebuilt
 with a Moreau backend so the whole SCP loop is a single XLA kernel.
@@ -71,21 +71,6 @@ def sample_initial_positions(n: int, *, seed: int = 42) -> np.ndarray:
     return np.stack([altitude, lateral_y, lateral_z], axis=-1)
 
 
-def build_batched_x_guess(problem, ic_batch: np.ndarray) -> np.ndarray:
-    """Build per-batch state guesses with position linspace IC → terminal."""
-    base_x = np.asarray(problem.state.x)  # (N, n_x)
-    pos_sl = position._slice
-    final_pos = base_x[-1, pos_sl]
-    B = ic_batch.shape[0]
-    x_guess_batch = np.broadcast_to(base_x, (B,) + base_x.shape).copy()
-    t = np.linspace(0.0, 1.0, N)
-    x_guess_batch[:, :, pos_sl] = (
-        ic_batch[:, None, :] * (1.0 - t[None, :, None])
-        + final_pos[None, None, :] * t[None, :, None]
-    )
-    return x_guess_batch
-
-
 # ── Runtime parameters ──────────────────────────────────────────────────────
 gI = ox.Parameter("gI", value=1.0)
 l_arm = ox.Parameter("l", value=0.25)
@@ -109,8 +94,6 @@ S_a = ox.Parameter("S_a", value=0.5)
 rho = ox.Parameter("rho", value=1.0)
 l_p = ox.Parameter("l_p", value=0.05)
 
-# Batched parameter: each solve receives its own initial_position value.
-initial_position = ox.Parameter("initial_position", shape=(3,), value=np.array([7.5, 4.5, 2.5]))
 final_position = ox.Parameter("final_position", shape=(2,), value=np.array([0.0, 0.0]))
 
 CA = ox.Diag(ox.Concat(c_ax, c_ayz, c_ayz))
@@ -127,7 +110,8 @@ mass.final = [ox.Maximize(1.5)]
 position = ox.State("position", shape=(3,))
 position.max = [10.0, 10.0, 10.0]
 position.min = [-10.0, -10.0, -10.0]
-position.initial = [ox.Free(7.5), ox.Free(4.5), ox.Free(2.5)]
+# Fix so x0_stack pins are consumed; per-batch values overwrite these defaults.
+position.initial = [7.5, 4.5, 2.5]
 position.final = [0.0, ox.Free(0.0), ox.Free(0.0)]
 
 velocity = ox.State("velocity", shape=(3,))
@@ -209,7 +193,7 @@ constraint_exprs = []
 for st in states:
     constraint_exprs.extend([ox.ctcs(st <= st.max), ox.ctcs(st.min <= st)])
 
-# Terminal lateral position; initial position is batched via x0_stack (Fix BC).
+# Initial position via x0_stack (Fix BC); terminal lateral via convex constraint.
 constraint_exprs.append((position[1:3] == final_position).convex().at([N - 1]))
 
 constraint_exprs.append(ox.ctcs(1.0 * (mass - m_dry) >= 0))
@@ -350,10 +334,11 @@ def create_pdg_batched_viser_server(
             colors=color,
             line_width=1.0,
         )
+        ic_viser = model_to_viser(ic_batch[b : b + 1])[0]
         server.scene.add_icosphere(
             f"/traces/{b}/start",
             radius=0.10,
-            position=tuple(pts[0]),
+            position=tuple(ic_viser.astype(np.float64)),
             color=(80, 160, 200) if converged[b] else (200, 120, 60),
         )
 
@@ -429,21 +414,15 @@ if __name__ == "__main__":
     print(f"Sampled {N_BATCH} initial positions  (alt ∈ [3, 9] m, lat ∈ [-7, 7] m)")
 
     # ── Compile + solve ───────────────────────────────────────────────────────
-    # Stack boundary pins: default Fix entries plus per-batch position ICs.
     default_init = np.asarray(problem.state.x_init_pin)
     x0_stack = np.broadcast_to(default_init, (N_BATCH, default_init.shape[0])).copy()
     x0_stack[:, POSITION_SLICE] = ic_batch
     x0_stack = jnp.asarray(x0_stack)
     xf_pin = np.asarray(problem.state.x_term_pin)
     xf_stack = jnp.broadcast_to(xf_pin, (N_BATCH, xf_pin.shape[0]))
-    x_guess_batch = build_batched_x_guess(problem, ic_batch)
 
     print("Compiling and running solve_batched …")
-    results = problem.solve_batched(
-        x0_stack=x0_stack,
-        xf_stack=xf_stack,
-        x_guess=x_guess_batch,
-    )
+    results = problem.solve_batched(x0_stack=x0_stack, xf_stack=xf_stack)
 
     # ── Post-process: propagate all B solutions through nonlinear dynamics ────
     print("Post-processing (nonlinear propagation) …")

--- a/openscvx/algorithms/base.py
+++ b/openscvx/algorithms/base.py
@@ -213,8 +213,16 @@ class AutotuningBase(ABC):
         parameter that steers it (penalty ramps, acceptance thresholds, weight
         clips). The default hashes the concrete class plus all instance
         attributes — sufficient because autotuner parameters are plain scalars.
-        Folded in by :meth:`Algorithm._hash_into`; mirrors the symbolic
-        ``_hash_into`` protocol.
+        Folded in by the algorithm's ``_hash_into`` (e.g.
+        :meth:`~openscvx.algorithms.scvx.penalized_trust_region.PenalizedTrustRegion._hash_into`);
+        mirrors the symbolic ``_hash_into`` protocol.
+
+        Caveat: the ``vars(self)`` sweep hashes *every* instance attribute, so a
+        subclass that stashes an iteration-count- or ``k_max``-derived field
+        would silently re-introduce the double-count that the algorithm's own
+        ``_hash_into`` deliberately avoids (the loop bound is keyed once, on the
+        assembler's resolved ``k_max``). Keep such fields out of the autotuner,
+        or override this method to exclude them.
         """
         from openscvx.utils.caching import hash_value_into
 

--- a/openscvx/algorithms/base.py
+++ b/openscvx/algorithms/base.py
@@ -28,6 +28,8 @@ from jax import export
 from openscvx.utils.printing import Column
 
 if TYPE_CHECKING:
+    import hashlib
+
     from openscvx.config import Config
     from openscvx.lowered.jax_constraints import LoweredJaxConstraints
 

--- a/openscvx/algorithms/base.py
+++ b/openscvx/algorithms/base.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING, Callable, List, Optional, Tuple, Union
 import jax
 import jax.numpy as jnp
 import numpy as np
+from jax import export
 
 from openscvx.utils.printing import Column
 
@@ -204,6 +205,23 @@ class AutotuningBase(ABC):
     # ``update_weights`` is one node in the outer compiled graph and the inner
     # JIT boundary disappears — the flag becomes a silent no-op on that path.
     JIT_UPDATE_WEIGHTS: bool = True
+
+    def _hash_into(self, hasher: "hashlib._Hash") -> None:
+        """Contribute the autotuner's update rule to the ``solve_batched`` cache key.
+
+        The exported batched loop bakes in ``update_weights`` and every numeric
+        parameter that steers it (penalty ramps, acceptance thresholds, weight
+        clips). The default hashes the concrete class plus all instance
+        attributes — sufficient because autotuner parameters are plain scalars.
+        Folded in by :meth:`Algorithm._hash_into`; mirrors the symbolic
+        ``_hash_into`` protocol.
+        """
+        from openscvx.utils.caching import hash_value_into
+
+        hasher.update(type(self).__name__.encode())
+        for name in sorted(vars(self)):
+            hasher.update(name.encode())
+            hash_value_into(hasher, getattr(self, name))
 
     @staticmethod
     def calculate_cost_from_state(
@@ -522,6 +540,20 @@ class AlgorithmState:
             x_init_pin=put(jnp.asarray(x_init_pin, dtype=f)),
             x_term_pin=put(jnp.asarray(x_term_pin, dtype=f)),
         )
+
+
+# ``AlgorithmState`` is the in/out pytree of the exported ``solve_batched``
+# artifact, so ``jax.export`` must know how to (de)serialize its treedef on top
+# of the runtime pytree registration above — a separate registry. The auxdata is
+# ``None`` (see ``tree_flatten``), so serialization is empty bytes and rebuild
+# falls back to the registered ``tree_unflatten``. Registered at import so any
+# process that deserializes the artifact has it.
+export.register_pytree_node_serialization(
+    AlgorithmState,
+    serialized_name="openscvx.algorithms.base.AlgorithmState",
+    serialize_auxdata=lambda aux: b"",
+    deserialize_auxdata=lambda data: None,
+)
 
 
 # ---------------------------------------------------------------------------

--- a/openscvx/algorithms/scvx/iteration.py
+++ b/openscvx/algorithms/scvx/iteration.py
@@ -270,6 +270,7 @@ def make_scp_iteration(
             lam_vb_cross=state.lam_vb_cross,
             x_init=state.x_init_pin,
             x_term=state.x_term_pin,
+            params=params,
         )
 
         # 5. Solve the convex subproblem.

--- a/openscvx/algorithms/scvx/penalized_trust_region.py
+++ b/openscvx/algorithms/scvx/penalized_trust_region.py
@@ -170,6 +170,33 @@ class PenalizedTrustRegion(Algorithm):
     def lam_vb(self, value: float) -> None:
         self.weights.lam_vb = float(value)
 
+    def _hash_into(self, hasher: "hashlib._Hash") -> None:
+        """Contribute this algorithm's identity to the ``solve_batched`` cache key.
+
+        The exported batched loop bakes in the convergence thresholds, the
+        iteration cap, the initial penalty weights, and the autotuner's update
+        rule — none of which the symbolic problem hash covers. Each piece is
+        folded in next to where it lives (weights via their fields, the
+        autotuner via its own ``_hash_into``), mirroring the symbolic
+        ``_hash_into`` protocol so a new field is hashed where it is added.
+        """
+        from openscvx.utils.caching import hash_value_into
+
+        hasher.update(type(self).__name__.encode())
+        for value in (self.ep_tr, self.ep_vb, self.ep_vc, self.k_max):
+            hash_value_into(hasher, value)
+        w = self.weights
+        for value in (
+            w.lam_prox,
+            w.lam_vc,
+            w.lam_cost,
+            w.lam_vb,
+            w.lam_vb_nodal,
+            w.lam_vb_cross,
+        ):
+            hash_value_into(hasher, value)
+        self.autotuner._hash_into(hasher)
+
     def get_columns(self, verbosity: int = Verbosity.STANDARD) -> List[Column]:
         """Get the columns to display for iteration output."""
         all_columns = self.BASE_COLUMNS + self.autotuner.COLUMNS + self.TAIL_COLUMNS

--- a/openscvx/algorithms/scvx/penalized_trust_region.py
+++ b/openscvx/algorithms/scvx/penalized_trust_region.py
@@ -35,6 +35,8 @@ from ..base import (
 from ..weights import Weights
 
 if TYPE_CHECKING:
+    import hashlib
+
     from openscvx.lowered import LoweredJaxConstraints
     from openscvx.symbolic.expr.control import Control
     from openscvx.symbolic.expr.state import State

--- a/openscvx/algorithms/scvx/penalized_trust_region.py
+++ b/openscvx/algorithms/scvx/penalized_trust_region.py
@@ -174,16 +174,22 @@ class PenalizedTrustRegion(Algorithm):
         """Contribute this algorithm's identity to the ``solve_batched`` cache key.
 
         The exported batched loop bakes in the convergence thresholds, the
-        iteration cap, the initial penalty weights, and the autotuner's update
-        rule — none of which the symbolic problem hash covers. Each piece is
-        folded in next to where it lives (weights via their fields, the
-        autotuner via its own ``_hash_into``), mirroring the symbolic
-        ``_hash_into`` protocol so a new field is hashed where it is added.
+        initial penalty weights, and the autotuner's update rule — none of which
+        the symbolic problem hash covers. Each piece is folded in next to where
+        it lives (weights via their fields, the autotuner via its own
+        ``_hash_into``), mirroring the symbolic ``_hash_into`` protocol so a new
+        field is hashed where it is added.
+
+        The iteration cap ``k_max`` is deliberately *not* folded in here: the
+        loop is built at a *resolved* bound (a ``solve_batched(max_iters=...)``
+        override supersedes ``self.k_max``), so the assembler stamps that
+        resolved value to avoid both a stale read and spurious invalidation when
+        ``self.k_max`` changes but the caller always overrides it.
         """
         from openscvx.utils.caching import hash_value_into
 
         hasher.update(type(self).__name__.encode())
-        for value in (self.ep_tr, self.ep_vb, self.ep_vc, self.k_max):
+        for value in (self.ep_tr, self.ep_vb, self.ep_vc):
             hash_value_into(hasher, value)
         w = self.weights
         for value in (

--- a/openscvx/discretization/base.py
+++ b/openscvx/discretization/base.py
@@ -25,6 +25,8 @@ import numpy as np
 from pydantic import BaseModel, ConfigDict
 
 if TYPE_CHECKING:
+    import hashlib
+
     from openscvx.config import Config
     from openscvx.lowered.dynamics import Dynamics
 

--- a/openscvx/discretization/base.py
+++ b/openscvx/discretization/base.py
@@ -154,6 +154,20 @@ class Discretizer(ABC):
     #: must set this in ``__init__``.
     ode_solver: str
 
+    def _hash_into(self, hasher: "hashlib._Hash") -> None:
+        """Contribute the discretizer's scheme to the ``solve_batched`` cache key.
+
+        The exported batched loop bakes in the discrete-time Jacobians the
+        discretizer produces, so the scheme that produced them — the concrete
+        class, the control hold type, and the ODE solver — must invalidate the
+        artifact when it changes. Mirrors the symbolic ``_hash_into`` protocol.
+        """
+        from openscvx.utils.caching import hash_value_into
+
+        hasher.update(type(self).__name__.encode())
+        hash_value_into(hasher, self.dis_type)
+        hash_value_into(hasher, self.ode_solver)
+
     @abstractmethod
     def get_solver(self, dynamics: "Dynamics", settings: "Config") -> callable:
         """Create a discretization solver callable.

--- a/openscvx/problem.py
+++ b/openscvx/problem.py
@@ -1584,20 +1584,26 @@ class Problem:
         n_u = self.settings.sim.n_controls
         _default = AlgorithmState.from_settings(self.settings, self._algorithm.weights)
         if x0_stack is None:
-            x0_stack = jnp.asarray(np.broadcast_to(np.asarray(_default.x_init_pin), (B, n_x)).copy())
+            x0_stack = jnp.asarray(
+                np.broadcast_to(np.asarray(_default.x_init_pin), (B, n_x)).copy()
+            )
         else:
             x0_stack = jnp.asarray(x0_stack)
             if x0_stack.shape != (B, n_x):
                 raise ValueError(
-                    f"solve_batched: x0_stack must have shape (B, n_x)=({B}, {n_x}), got {x0_stack.shape}."
+                    f"solve_batched: x0_stack must have shape (B, n_x)=({B}, {n_x}), "
+                    f"got {x0_stack.shape}."
                 )
         if xf_stack is None:
-            xf_stack = jnp.asarray(np.broadcast_to(np.asarray(_default.x_term_pin), (B, n_x)).copy())
+            xf_stack = jnp.asarray(
+                np.broadcast_to(np.asarray(_default.x_term_pin), (B, n_x)).copy()
+            )
         else:
             xf_stack = jnp.asarray(xf_stack)
             if xf_stack.shape != (B, n_x):
                 raise ValueError(
-                    f"solve_batched: xf_stack must have shape (B, n_x)=({B}, {n_x}), got {xf_stack.shape}."
+                    f"solve_batched: xf_stack must have shape (B, n_x)=({B}, {n_x}), "
+                    f"got {xf_stack.shape}."
                 )
         x_guess_stack = _expand_batched_trajectory_guess(
             x_guess, B=B, N=N, n=n_x, name="x_guess", default=_default.x

--- a/openscvx/problem.py
+++ b/openscvx/problem.py
@@ -81,43 +81,73 @@ from openscvx.utils.caching import (
 
 
 def _infer_batch_size(
-    x0_stack,
-    xf_stack,
-    params: dict,
-    pins: list,
+    user_params: Optional[dict],
+    *,
+    x_guess=None,
+    u_guess=None,
 ) -> int:
     """Infer the batch size B for :meth:`Problem.solve_batched`.
 
-    Tries (in order):
-
-    1. Leading axis of *x0_stack* (if not None).
-    2. Leading axis of *xf_stack* (if not None).
-    3. Leading axis of a batched parameter value that matches a param-fix pin:
-       for a pin with *n_elem* pinned state components, a value with shape
-       ``(B, n_elem)`` signals batch size *B*. For a scalar pin (*n_elem* == 1)
-       a value with shape ``(B,)`` also works.
-
-    Raises ``ValueError`` when none of the above resolves.
+    Returns the leading axis of the first batched entry among *x_guess*,
+    *u_guess* (shape ``(B, N, n)``), or a non-scalar value in *user_params*.
+    Raises ``ValueError`` when no batched entry is found.
     """
-    if x0_stack is not None:
-        return int(jnp.asarray(x0_stack).shape[0])
-    if xf_stack is not None:
-        return int(jnp.asarray(xf_stack).shape[0])
-    for pin in pins:
-        val = params.get(pin.param_name)
-        if val is None:
-            continue
-        arr = np.asarray(val)
-        n_elem = pin.state_slice.stop - pin.state_slice.start
-        if arr.ndim == 2 and arr.shape[1] == n_elem:
-            return int(arr.shape[0])
-        if arr.ndim == 1 and n_elem == 1:
-            return int(arr.shape[0])
+    for value in (x_guess, u_guess):
+        if value is not None:
+            arr = jnp.asarray(value)
+            if arr.ndim >= 3:
+                return int(arr.shape[0])
+    if user_params:
+        for value in user_params.values():
+            arr = jnp.asarray(value)
+            if arr.ndim > 0:
+                return int(arr.shape[0])
     raise ValueError(
         "solve_batched: cannot infer batch size B. "
-        "Either pass x0_stack / xf_stack explicitly, or ensure that at least "
-        "one batched parameter corresponds to a param-fix pin "
-        "(e.g. parameters={'initial_position': array_of_shape_B_x_3})."
+        "Pass at least one batched entry in parameters "
+        "(e.g. parameters={'initial_position': array_of_shape_B_x_n}), "
+        "or batched x_guess/u_guess arrays of shape (B, N, n)."
+    )
+
+
+def _expand_batched_trajectory_guess(
+    arr,
+    *,
+    B: int,
+    N: int,
+    n: int,
+    name: str,
+    default: jnp.ndarray,
+) -> jnp.ndarray:
+    """Broadcast or validate a trajectory guess for :meth:`Problem.solve_batched`.
+
+    Accepts ``None`` (use *default*), a shared ``(N, n)`` array, or a
+    per-batch ``(B, N, n)`` stack.
+    """
+    if arr is None:
+        return jnp.asarray(np.broadcast_to(np.asarray(default), (B, N, n)).copy())
+    arr = jnp.asarray(arr)
+    if arr.ndim == 2:
+        if tuple(arr.shape) != (N, n):
+            raise ValueError(
+                f"solve_batched: shared {name} must have shape (N, n)=({N}, {n}), "
+                f"got {arr.shape}."
+            )
+        return jnp.asarray(np.broadcast_to(np.asarray(arr), (B, N, n)).copy())
+    if arr.ndim == 3:
+        if int(arr.shape[0]) != B:
+            raise ValueError(
+                f"solve_batched: batched {name} leading axis must equal B={B}, "
+                f"got shape {arr.shape}."
+            )
+        if tuple(arr.shape[1:]) != (N, n):
+            raise ValueError(
+                f"solve_batched: batched {name} must have shape (B, N, n)=({B}, {N}, {n}), "
+                f"got {arr.shape}."
+            )
+        return arr
+    raise ValueError(
+        f"solve_batched: {name} must be None, shape (N, n), or (B, N, n); got {arr.shape}."
     )
 
 
@@ -148,30 +178,27 @@ def _make_single_result(
     )
 
 
-def _solve_batched_param_in_axes(params: dict, B: int) -> Optional[int]:
-    """Leading vmap axis for the parameters pytree, if any.
+def _solve_batched_param_in_axes(params: dict, B: int):
+    """Per-parameter vmap ``in_axes`` spec for the parameters pytree.
 
-    Returns ``0`` when every parameter array carries a batch axis of size ``B``,
-    ``None`` when none do (shared across the batch), and raises if the dict is
-    mixed.
+    Returns ``0`` when every parameter carries a leading batch axis of size ``B``,
+    ``None`` when none do (all shared), or a per-key ``dict`` when the dict is
+    mixed — JAX ``vmap`` accepts any pytree-shaped ``in_axes`` value, so a dict
+    of ``{key: 0 | None}`` correctly batches only the parameters that carry the
+    batch dimension while broadcasting the rest.
     """
     if not params:
         return None
-    axes: List[Optional[int]] = []
-    for value in params.values():
-        arr = jnp.asarray(value)
-        if arr.ndim > 0 and int(arr.shape[0]) == B:
-            axes.append(0)
-        else:
-            axes.append(None)
-    if all(ax == 0 for ax in axes):
+    axes = {
+        key: (0 if (jnp.asarray(v).ndim > 0 and int(jnp.asarray(v).shape[0]) == B) else None)
+        for key, v in params.items()
+    }
+    vals = list(axes.values())
+    if all(ax == 0 for ax in vals):
         return 0
-    if all(ax is None for ax in axes):
+    if all(ax is None for ax in vals):
         return None
-    raise ValueError(
-        f"solve_batched parameters must either all carry a leading batch axis of "
-        f"size {B} or none must — got a mix of batched and shared entries."
-    )
+    return axes  # mixed: return per-key spec; JAX vmap handles it
 
 
 class Problem:
@@ -648,32 +675,6 @@ class Problem:
                 self._lowered.x_prop_unified.final[state._slice] = state.final
                 self._lowered.x_prop_unified.final_type[state._slice] = state.final_type
 
-        # Sync param-fix-pin values from the current parameters dict into
-        # x_unified so that AlgorithmState.from_settings and the solver
-        # assembler see up-to-date values.
-        pins = getattr(self._solver, "_param_fix_pins", [])
-        if pins:
-            for pin in pins:
-                value = np.asarray(self._parameters[pin.param_name], dtype=float).ravel()
-                if pin.node_type == "init":
-                    self._lowered.x_unified.initial[pin.state_slice] = value
-                else:
-                    self._lowered.x_unified.final[pin.state_slice] = value
-            # Also patch the in-flight AlgorithmState so that solve() (Python
-            # while-loop path) picks up the new value without requiring reset().
-            if self._state is not None:
-                init_pin_arr = np.array(self._state.x_init_pin)
-                term_pin_arr = np.array(self._state.x_term_pin)
-                for pin in pins:
-                    value = np.asarray(self._parameters[pin.param_name], dtype=float).ravel()
-                    if pin.node_type == "init":
-                        init_pin_arr[pin.state_slice] = value
-                    else:
-                        term_pin_arr[pin.state_slice] = value
-                self._state = self._state.replace(
-                    x_init_pin=jnp.asarray(init_pin_arr),
-                    x_term_pin=jnp.asarray(term_pin_arr),
-                )
 
         # Push to the solver — both backends short-circuit on a pre-initialize
         # call, so this is safe to invoke from any lifecycle point.
@@ -1268,27 +1269,35 @@ class Problem:
         self,
         x_initial: Optional[jnp.ndarray],
         x_final: Optional[jnp.ndarray],
+        x_guess: Optional[jnp.ndarray] = None,
+        u_guess: Optional[jnp.ndarray] = None,
     ) -> AlgorithmState:
         """Build a fresh :class:`AlgorithmState` with user-supplied boundary pins.
 
         The pins live on the pytree (``x_init_pin`` / ``x_term_pin``) so the
         fused iteration body assembles the subproblem's initial / terminal
         rows as a pure function of state. Under ``jax.vmap`` over
-        ``x_initial`` / ``x_final``, the pins batch per element — each batch
-        slot gets its own boundary condition without recompilation.
+        ``x_initial`` / ``x_final`` / ``x_guess`` / ``u_guess``, each batch
+        slot gets its own boundary condition and SCP seed iterate without
+        recompilation.
 
         ``None`` falls back to the defaults from
         :meth:`AlgorithmState.from_settings`. A user-supplied vector replaces
         the corresponding pin in full; pass ``jnp.nan`` at non-pinned
         entries to match the convention :meth:`from_settings` uses (the
         subproblem only consumes the pin where the boundary type is
-        ``"Fix"``).
+        ``"Fix"``).  Optional ``x_guess`` / ``u_guess`` replace
+        ``state.x`` / ``state.u`` (the trajectory warm-start).
         """
         state = AlgorithmState.from_settings(self.settings, self._algorithm.weights)
         if x_initial is not None:
             state = state.replace(x_init_pin=jnp.asarray(x_initial, dtype=state.x_init_pin.dtype))
         if x_final is not None:
             state = state.replace(x_term_pin=jnp.asarray(x_final, dtype=state.x_term_pin.dtype))
+        if x_guess is not None:
+            state = state.replace(x=jnp.asarray(x_guess, dtype=state.x.dtype))
+        if u_guess is not None:
+            state = state.replace(u=jnp.asarray(u_guess, dtype=state.u.dtype))
         return state
 
     def _get_or_build_solve_loop(self, max_iters: Optional[int]) -> callable:
@@ -1407,6 +1416,8 @@ class Problem:
         x_final: Optional[jnp.ndarray] = None,
         parameters: Optional[dict] = None,
         *,
+        x_guess: Optional[jnp.ndarray] = None,
+        u_guess: Optional[jnp.ndarray] = None,
         max_iters: Optional[int] = None,
     ) -> OptimizationResults:
         """Run the SCP algorithm — JAX-pure.
@@ -1436,6 +1447,11 @@ class Problem:
             parameters: Problem parameters dict for the current solve. Use
                 this rather than mutating ``self.parameters`` if the
                 parameters are traced. ``None`` reuses ``self._parameters``.
+            x_guess: Initial state trajectory guess, shape ``(N, n_states)``.
+                Replaces ``state.x``; ``None`` uses the default from
+                settings (``State.guess`` at ``initialize()``).
+            u_guess: Initial control trajectory guess, shape ``(N, n_controls)``.
+                Replaces ``state.u``; ``None`` uses the default from settings.
             max_iters: SCP iteration cap. ``None`` uses ``algorithm.k_max``;
                 a different value rebuilds the cached ``lax.while_loop``
                 closure (one extra trace; subsequent calls at the same
@@ -1452,182 +1468,118 @@ class Problem:
 
         params = parameters if parameters is not None else self._parameters
 
-        # Auto-populate x_initial / x_final from param-fix pins when the
-        # caller did not supply explicit boundary pins.  This lets
-        # solve_jax(parameters={"initial_position": ic}) work without
-        # requiring the caller to also build x_initial by hand.
-        pins = getattr(self._solver, "_param_fix_pins", [])
-        init_pins = [p for p in pins if p.node_type == "init"]
-        term_pins = [p for p in pins if p.node_type == "term"]
-        if (x_initial is None and init_pins) or (x_final is None and term_pins):
-            _default = AlgorithmState.from_settings(self.settings, self._algorithm.weights)
-            if x_initial is None and init_pins:
-                x_init_arr = np.array(_default.x_init_pin)
-                for pin in init_pins:
-                    x_init_arr[pin.state_slice] = np.asarray(
-                        params[pin.param_name], dtype=float
-                    ).ravel()
-                x_initial = jnp.asarray(x_init_arr, dtype=_default.x_init_pin.dtype)
-            if x_final is None and term_pins:
-                x_term_arr = np.array(_default.x_term_pin)
-                for pin in term_pins:
-                    x_term_arr[pin.state_slice] = np.asarray(
-                        params[pin.param_name], dtype=float
-                    ).ravel()
-                x_final = jnp.asarray(x_term_arr, dtype=_default.x_term_pin.dtype)
-
-        initial_state = self._resolve_initial_state(x_initial, x_final)
+        initial_state = self._resolve_initial_state(
+            x_initial, x_final, x_guess=x_guess, u_guess=u_guess
+        )
         solve_fn = self._get_or_build_solve_loop(max_iters)
         final_state = solve_fn(initial_state, params)
         return OptimizationResults.from_final_state(final_state, problem=self)
 
     def solve_batched(
         self,
-        x0_stack: Optional[jnp.ndarray] = None,
-        xf_stack: Optional[jnp.ndarray] = None,
         parameters: Optional[dict] = None,
         *,
-        x_guess_stack: Optional[jnp.ndarray] = None,
+        x_guess: Optional[jnp.ndarray] = None,
+        u_guess: Optional[jnp.ndarray] = None,
         max_iters: Optional[int] = None,
     ) -> OptimizationResults:
-        """Run ``B`` SCP solves over stacked boundary conditions — batch baked in.
+        """Run ``B`` SCP solves in parallel, batching over parameters.
 
-        Applies ``jax.vmap`` *internally* over ``x0_stack`` / ``xf_stack`` (the
-        parameters are shared unless every parameter array carries the same
-        leading batch axis) and drives the same fused
-        ``iteration_fn`` core as :meth:`solve_jax` inside one ``lax.while_loop``.
-        The result is a batched :class:`OptimizationResults` pytree: every array
-        leaf carries the leading batch axis ``B`` (``result.x.shape ==
-        (B, N, n_x)``), exactly as ``jax.vmap(solve_jax)`` produces. Per-iteration
-        history is empty, the same asymmetry :meth:`solve_jax` carries — list
-        growth doesn't fit inside ``lax.while_loop``; use :meth:`solve` for
-        populated history.
+        Applies ``jax.vmap`` *internally* and drives the same fused
+        ``iteration_fn`` core as :meth:`solve_jax` inside one
+        ``lax.while_loop``.  The result is a batched
+        :class:`OptimizationResults` pytree: every array leaf carries the
+        leading batch axis ``B`` (e.g. ``result.x.shape == (B, N, n_x)``).
 
-        Why this exists alongside ``jax.vmap(solve_jax)``: because the batch axis
-        is owned here rather than by the caller, the whole vmapped loop is a
-        single function that ``jax.export`` can serialize. Under
-        ``save_compiled=True`` the artifact is written to the solver cache on the
-        first call and deserialized on later processes — skipping the XLA compile
-        that ``jax.vmap(solve_jax)`` pays on every fresh launch. ``jax.vmap(
-        solve_jax)`` is the right tool for in-program batching that composes with
-        ``grad``/``scan``; ``solve_batched`` is for when cross-process cold-start
-        dominates. With ``save_compiled=False`` the two produce identical results
-        in-process.
+        **Batching over parameters**: declare any state or constraint whose
+        value changes across solves as an ``ox.Parameter``, then pass an
+        ``(B, ...)``-shaped array for it in *parameters*::
+
+            ic_param = ox.Parameter("ic", shape=(3,), value=default_ic)
+            constraints += [(state == ic_param).convex().at([0])]
+            ...
+            results = problem.solve_batched(parameters={"ic": ic_batch})
+
+        Parameters whose leading axis equals ``B`` are vmapped over; all others
+        are broadcast across the batch.  ``B`` is inferred from the first
+        batched entry in *parameters*, *x_guess*, or *u_guess*.
+
+        **Trajectory guesses**: pass ``x_guess`` / ``u_guess`` as shared
+        ``(N, n)`` arrays (broadcast to every batch element) or per-batch
+        ``(B, N, n)`` stacks to seed each solve's SCP iterate independently::
+
+            results = problem.solve_batched(
+                parameters={"initial_position": ic_batch},
+                x_guess=x_guess_batch,
+                u_guess=u_guess_batch,
+            )
+
+        Why this exists alongside ``jax.vmap(solve_jax)``: because the batch
+        axis is owned here the whole vmapped loop is a single function that
+        ``jax.export`` can serialize.  Under ``save_compiled=True`` the artifact
+        is written to the solver cache on the first call and deserialized on
+        later processes — skipping the XLA compile that ``jax.vmap(solve_jax)``
+        pays on every fresh launch.  ``jax.vmap(solve_jax)`` is the right tool
+        for in-program batching that composes with ``grad``/``scan``;
+        ``solve_batched`` is for when cross-process cold-start dominates.
 
         Export requires a pure-JAX backend: under ``save_compiled=True`` the
-        CVXPy backend raises (its solve is a ``jax.pure_callback``, which
-        ``jax.export`` cannot serialize), pointing at QPAX / Moreau. The cache
-        key invalidates on any change that alters the exported loop — backend +
-        ``solver_args``, algorithm + autotuner + thresholds + weights,
-        discretizer, scaling, ``B``, and the JAX version — so a stale artifact is
-        never silently reused.
+        CVXPy backend raises.  The cache key invalidates on any change that
+        alters the exported loop — backend, algorithm, discretizer, scaling,
+        ``B``, and the JAX version — so a stale artifact is never silently
+        reused.
 
         Args:
-            x0_stack: Stacked initial-state boundary pins, shape
-                ``(B, n_states)``. Each row follows the :meth:`solve_jax`
-                ``x_initial`` convention (``jnp.nan`` at non-Fix entries).
-                ``None`` auto-builds the stack from the default
-                ``x_init_pin`` with param-fix-pin slots overwritten from
-                *parameters* (requires at least one param-fix-pin and
-                a batched parameter value, or that *xf_stack* provides B).
-            xf_stack: Stacked terminal-state boundary pins, shape
-                ``(B, n_states)``. Same per-row convention as ``x0_stack``.
-                ``None`` auto-builds similarly from the default
-                ``x_term_pin``.
-            parameters: Problem parameters dict. ``None`` reuses
-                ``self._parameters``. When every value has a leading axis of
-                size ``B`` (matching ``x0_stack.shape[0]``), each batch element
-                receives its own parameter slice; otherwise parameters are
-                shared across the batch. Values flow as runtime inputs to the
-                exported artifact; its pytree structure is fixed at the first
-                ``solve_batched`` call that builds the artifact.
-            x_guess_stack: Per-element initial guess for the state trajectory,
-                shape ``(B, N, n_states)``.  When provided, replaces the
-                shared ``AlgorithmState.x`` after the vmapped boundary pins
-                are built but before the SCP iterations start.  Each batch
-                element therefore starts from its own warm starting point
-                rather than the global problem-level guess stored in
-                ``problem.settings.sim.x.guess``.  ``None`` falls back to the
-                shared guess (broadcast from the single problem-level guess).
-                The AOT-compiled artifact is unaffected because shapes and
-                dtypes are identical to the default; only the concrete values
-                differ at runtime.
-            max_iters: SCP iteration cap. ``None`` uses ``algorithm.k_max``; a
-                different value (or a different ``B``) rebuilds the cached
-                batched closure *and* keys a distinct exported artifact, so an
-                override never reuses an artifact compiled at another bound.
+            parameters: Problem parameters dict.  ``None`` reuses
+                ``self._parameters``.  Parameters whose leading axis equals
+                ``B`` are vmapped over (each batch element receives its own
+                slice); parameters with a different shape are broadcast.
+                ``B`` is inferred from the first batched entry supplied here,
+                in *x_guess*, or in *u_guess* (raises if none is found).
+            x_guess: State trajectory guess, shape ``(N, n_states)`` shared
+                across the batch or ``(B, N, n_states)`` per element.
+                ``None`` uses the default from settings.
+            u_guess: Control trajectory guess, shape ``(N, n_controls)`` or
+                ``(B, N, n_controls)``.  ``None`` uses the default from
+                settings.
+            max_iters: SCP iteration cap.  ``None`` uses
+                ``algorithm.k_max``; a different value (or a different ``B``)
+                rebuilds the cached batched closure.
 
         Returns:
             :class:`OptimizationResults` pytree with a leading ``B`` axis on
-            every leaf and empty histories.
+            every leaf and empty per-iteration histories.
         """
         if self._iteration_fn_jit_inner is None:
             raise ValueError(
                 "Problem has not been initialized. Call initialize() before solve_batched()"
             )
 
-        pins = getattr(self._solver, "_param_fix_pins", [])
-        pin_names = {pin.param_name for pin in pins}
+        params_for_solve = dict(self._parameters, **(parameters or {}))
 
-        # Determine which user-supplied parameters are intended only as boundary-
-        # condition overrides (param-fix pins) vs. parameters that should be
-        # forwarded into the SCP loop (dynamics / constraints).  Pin parameters
-        # are consumed here to build x0_stack / xf_stack; they are excluded from
-        # params_for_solve so the vmap never sees a partial / mixed-batch dict.
-        params_for_bc = parameters or {}
-        if parameters is None:
-            params_for_solve = self._parameters
-        else:
-            # Merge: start from current self._parameters, then apply any user
-            # overrides that are NOT pin parameters (those are boundary-only).
-            params_for_solve = dict(self._parameters)
-            for k, v in parameters.items():
-                if k not in pin_names:
-                    params_for_solve[k] = v
-
-        # Auto-build x0_stack / xf_stack when not supplied by the caller.
-        # This allows the compact call:
-        #   problem.solve_batched(parameters={"initial_position": ic_batch})
-        # without the user manually constructing the boundary-pin stacks.
-        if x0_stack is None or xf_stack is None:
-            B = _infer_batch_size(x0_stack, xf_stack, params_for_bc, pins)
-            n_x = self.settings.sim.n_states
-            _default = AlgorithmState.from_settings(self.settings, self._algorithm.weights)
-            if x0_stack is None:
-                x0_np = np.broadcast_to(np.asarray(_default.x_init_pin), (B, n_x)).copy()
-                for pin in pins:
-                    if pin.node_type == "init" and pin.param_name in params_for_bc:
-                        x0_np[:, pin.state_slice] = np.asarray(
-                            params_for_bc[pin.param_name], dtype=float
-                        ).reshape(B, -1)
-                x0_stack = jnp.asarray(x0_np)
-            if xf_stack is None:
-                xf_np = np.broadcast_to(np.asarray(_default.x_term_pin), (B, n_x)).copy()
-                for pin in pins:
-                    if pin.node_type == "term" and pin.param_name in params_for_bc:
-                        xf_np[:, pin.state_slice] = np.asarray(
-                            params_for_bc[pin.param_name], dtype=float
-                        ).reshape(B, -1)
-                xf_stack = jnp.asarray(xf_np)
-
-        states = jax.vmap(self._resolve_initial_state)(x0_stack, xf_stack)
-        # _get_or_build_solve_batched triggers AOT compilation on the first call
-        # and stores self.timing_compile.  Subsequent calls return the cached
-        # compiled artifact immediately, so t_0_solve captures execution only.
-        batched_solve = self._get_or_build_solve_batched(
-            x0_stack.shape[0], max_iters, params_for_solve
+        B = _infer_batch_size(parameters, x_guess=x_guess, u_guess=u_guess)
+        N = self.settings.sim.n
+        n_x = self.settings.sim.n_states
+        n_u = self.settings.sim.n_controls
+        _default = AlgorithmState.from_settings(self.settings, self._algorithm.weights)
+        x0_stack = jnp.asarray(
+            np.broadcast_to(np.asarray(_default.x_init_pin), (B, n_x)).copy()
         )
-        # Inject per-element initial guesses after compilation (shapes/dtypes
-        # match the compiled artifact) but before execution.
-        if x_guess_stack is not None:
-            states = states.replace(
-                x=jnp.asarray(x_guess_stack, dtype=states.x.dtype)
-            )
+        xf_stack = jnp.asarray(
+            np.broadcast_to(np.asarray(_default.x_term_pin), (B, n_x)).copy()
+        )
+        x_guess_stack = _expand_batched_trajectory_guess(
+            x_guess, B=B, N=N, n=n_x, name="x_guess", default=_default.x
+        )
+        u_guess_stack = _expand_batched_trajectory_guess(
+            u_guess, B=B, N=N, n=n_u, name="u_guess", default=_default.u
+        )
+
+        states = jax.vmap(self._resolve_initial_state)(
+            x0_stack, xf_stack, x_guess_stack, u_guess_stack
+        )
+        batched_solve = self._get_or_build_solve_batched(B, max_iters, params_for_solve)
         t_0_solve = time.time()
-        # jax.export.Exported wrappers (save_compiled path) are invoked via
-        # .call(); jax.stages.Compiled (AOT path) is a plain callable.
-        # We track which case we have via self._solve_batched_is_exported rather
-        # than hasattr() since Compiled also happens to have a .call attribute.
         if getattr(self, "_solve_batched_is_exported", False):
             final_states = batched_solve.call(states, params_for_solve)
         else:

--- a/openscvx/problem.py
+++ b/openscvx/problem.py
@@ -130,8 +130,7 @@ def _expand_batched_trajectory_guess(
     if arr.ndim == 2:
         if tuple(arr.shape) != (N, n):
             raise ValueError(
-                f"solve_batched: shared {name} must have shape (N, n)=({N}, {n}), "
-                f"got {arr.shape}."
+                f"solve_batched: shared {name} must have shape (N, n)=({N}, {n}), got {arr.shape}."
             )
         return jnp.asarray(np.broadcast_to(np.asarray(arr), (B, N, n)).copy())
     if arr.ndim == 3:
@@ -165,8 +164,8 @@ def _make_single_result(
     ``converged``, ``t_final``, ``_states``, ``_controls``.  History fields
     are left empty (they are not needed for post-processing).
     """
-    x_b = np.asarray(results.X[-1])[b]   # (N, n_x)
-    u_b = np.asarray(results.U[-1])[b]   # (N, n_u)
+    x_b = np.asarray(results.X[-1])[b]  # (N, n_x)
+    u_b = np.asarray(results.U[-1])[b]  # (N, n_u)
     t_final_b = float(np.asarray(results.t_final[b]).reshape(-1)[0])
     return OptimizationResults(
         converged=bool(np.asarray(results.converged).reshape(-1)[b]),
@@ -674,7 +673,6 @@ class Problem:
             if state.final is not None:
                 self._lowered.x_prop_unified.final[state._slice] = state.final
                 self._lowered.x_prop_unified.final_type[state._slice] = state.final_type
-
 
         # Push to the solver — both backends short-circuit on a pre-initialize
         # call, so this is safe to invoke from any lifecycle point.
@@ -1562,12 +1560,8 @@ class Problem:
         n_x = self.settings.sim.n_states
         n_u = self.settings.sim.n_controls
         _default = AlgorithmState.from_settings(self.settings, self._algorithm.weights)
-        x0_stack = jnp.asarray(
-            np.broadcast_to(np.asarray(_default.x_init_pin), (B, n_x)).copy()
-        )
-        xf_stack = jnp.asarray(
-            np.broadcast_to(np.asarray(_default.x_term_pin), (B, n_x)).copy()
-        )
+        x0_stack = jnp.asarray(np.broadcast_to(np.asarray(_default.x_init_pin), (B, n_x)).copy())
+        xf_stack = jnp.asarray(np.broadcast_to(np.asarray(_default.x_term_pin), (B, n_x)).copy())
         x_guess_stack = _expand_batched_trajectory_guess(
             x_guess, B=B, N=N, n=n_x, name="x_guess", default=_default.x
         )
@@ -1680,11 +1674,11 @@ class Problem:
         if self._lowered is None:
             raise ValueError("Problem not initialized. Call initialize() first.")
 
-        x_batch = np.asarray(results.X[-1])   # (B, N, n_x)
+        x_batch = np.asarray(results.X[-1])  # (B, N, n_x)
         B = x_batch.shape[0]
 
         if n_times is None:
-            t_finals = np.asarray(results.t_final).reshape(-1)   # (B,)
+            t_finals = np.asarray(results.t_final).reshape(-1)  # (B,)
             T_max = float(t_finals.max())
             n_times = max(int(np.ceil(T_max / self.settings.prp.dt)) + 1, 2)
 
@@ -1717,14 +1711,13 @@ class Problem:
 
         self.timing_post = time.time() - t_0_post
 
-        results.t_full = np.stack(t_fulls)        # (B, n_times)
-        results.x_full = np.stack(x_fulls)        # (B, n_times, n_prop_states)
-        results.u_full = np.stack(u_fulls)        # (B, n_times, n_controls)
+        results.t_full = np.stack(t_fulls)  # (B, n_times)
+        results.x_full = np.stack(x_fulls)  # (B, n_times, n_prop_states)
+        results.u_full = np.stack(u_fulls)  # (B, n_times, n_controls)
         results.trajectory = {
-            k: np.stack([traj[k] for traj in trajectories])
-            for k in trajectories[0]
+            k: np.stack([traj[k] for traj in trajectories]) for k in trajectories[0]
         }
-        results.cost = np.array(costs)            # (B,)
+        results.cost = np.array(costs)  # (B,)
         if ctcs_violations[0] is not None:
             results.ctcs_violation = np.stack(ctcs_violations)
 

--- a/openscvx/problem.py
+++ b/openscvx/problem.py
@@ -5,12 +5,17 @@ and solving trajectory optimization problems using Sequential Convex Programming
 
 Example:
     The prototypical flow is to define a problem, then initialize, solve, and post-process the
-    results
+    results::
 
         problem = Problem(dynamics, constraints, states, controls, N, time)
         problem.initialize()
         result = problem.solve()
         result = problem.post_process()
+
+    For batched solves over many initial conditions::
+
+        results = problem.solve_batched(parameters={"initial_position": ic_batch})
+        results = problem.post_process_batched(results)
 """
 
 import copy
@@ -21,6 +26,7 @@ import time
 from typing import Dict, List, Optional, Tuple, Union
 
 import jax
+import numpy as np
 
 os.environ["EQX_ON_ERROR"] = "nan"
 
@@ -72,6 +78,100 @@ from openscvx.utils.caching import (
     load_or_export_solve_batched,
     prime_propagation_solver,
 )
+
+
+def _infer_batch_size(
+    x0_stack,
+    xf_stack,
+    params: dict,
+    pins: list,
+) -> int:
+    """Infer the batch size B for :meth:`Problem.solve_batched`.
+
+    Tries (in order):
+
+    1. Leading axis of *x0_stack* (if not None).
+    2. Leading axis of *xf_stack* (if not None).
+    3. Leading axis of a batched parameter value that matches a param-fix pin:
+       for a pin with *n_elem* pinned state components, a value with shape
+       ``(B, n_elem)`` signals batch size *B*. For a scalar pin (*n_elem* == 1)
+       a value with shape ``(B,)`` also works.
+
+    Raises ``ValueError`` when none of the above resolves.
+    """
+    if x0_stack is not None:
+        return int(jnp.asarray(x0_stack).shape[0])
+    if xf_stack is not None:
+        return int(jnp.asarray(xf_stack).shape[0])
+    for pin in pins:
+        val = params.get(pin.param_name)
+        if val is None:
+            continue
+        arr = np.asarray(val)
+        n_elem = pin.state_slice.stop - pin.state_slice.start
+        if arr.ndim == 2 and arr.shape[1] == n_elem:
+            return int(arr.shape[0])
+        if arr.ndim == 1 and n_elem == 1:
+            return int(arr.shape[0])
+    raise ValueError(
+        "solve_batched: cannot infer batch size B. "
+        "Either pass x0_stack / xf_stack explicitly, or ensure that at least "
+        "one batched parameter corresponds to a param-fix pin "
+        "(e.g. parameters={'initial_position': array_of_shape_B_x_3})."
+    )
+
+
+def _make_single_result(
+    results: "OptimizationResults",
+    b: int,
+) -> "OptimizationResults":
+    """Slice a single element ``b`` from a batched ``OptimizationResults``.
+
+    Returns a minimal :class:`~openscvx.algorithms.OptimizationResults` with
+    the trajectory arrays for element ``b`` at normal (non-batched) shape — ready
+    to be passed to :func:`~openscvx.propagation.propagate_trajectory_results`.
+
+    Only the fields consumed by propagation are populated: ``X``, ``U``,
+    ``converged``, ``t_final``, ``_states``, ``_controls``.  History fields
+    are left empty (they are not needed for post-processing).
+    """
+    x_b = np.asarray(results.X[-1])[b]   # (N, n_x)
+    u_b = np.asarray(results.U[-1])[b]   # (N, n_u)
+    t_final_b = float(np.asarray(results.t_final[b]).reshape(-1)[0])
+    return OptimizationResults(
+        converged=bool(np.asarray(results.converged).reshape(-1)[b]),
+        t_final=t_final_b,
+        X=[x_b],
+        U=[u_b],
+        _states=results._states,
+        _controls=results._controls,
+    )
+
+
+def _solve_batched_param_in_axes(params: dict, B: int) -> Optional[int]:
+    """Leading vmap axis for the parameters pytree, if any.
+
+    Returns ``0`` when every parameter array carries a batch axis of size ``B``,
+    ``None`` when none do (shared across the batch), and raises if the dict is
+    mixed.
+    """
+    if not params:
+        return None
+    axes: List[Optional[int]] = []
+    for value in params.values():
+        arr = jnp.asarray(value)
+        if arr.ndim > 0 and int(arr.shape[0]) == B:
+            axes.append(0)
+        else:
+            axes.append(None)
+    if all(ax == 0 for ax in axes):
+        return 0
+    if all(ax is None for ax in axes):
+        return None
+    raise ValueError(
+        f"solve_batched parameters must either all carry a leading batch axis of "
+        f"size {B} or none must — got a mix of batched and shared entries."
+    )
 
 
 class Problem:
@@ -546,6 +646,33 @@ class Problem:
             if state.final is not None:
                 self._lowered.x_prop_unified.final[state._slice] = state.final
                 self._lowered.x_prop_unified.final_type[state._slice] = state.final_type
+
+        # Sync param-fix-pin values from the current parameters dict into
+        # x_unified so that AlgorithmState.from_settings and the solver
+        # assembler see up-to-date values.
+        pins = getattr(self._solver, "_param_fix_pins", [])
+        if pins:
+            for pin in pins:
+                value = np.asarray(self._parameters[pin.param_name], dtype=float).ravel()
+                if pin.node_type == "init":
+                    self._lowered.x_unified.initial[pin.state_slice] = value
+                else:
+                    self._lowered.x_unified.final[pin.state_slice] = value
+            # Also patch the in-flight AlgorithmState so that solve() (Python
+            # while-loop path) picks up the new value without requiring reset().
+            if self._state is not None:
+                init_pin_arr = np.array(self._state.x_init_pin)
+                term_pin_arr = np.array(self._state.x_term_pin)
+                for pin in pins:
+                    value = np.asarray(self._parameters[pin.param_name], dtype=float).ravel()
+                    if pin.node_type == "init":
+                        init_pin_arr[pin.state_slice] = value
+                    else:
+                        term_pin_arr[pin.state_slice] = value
+                self._state = self._state.replace(
+                    x_init_pin=jnp.asarray(init_pin_arr),
+                    x_term_pin=jnp.asarray(term_pin_arr),
+                )
 
         # Push to the solver — both backends short-circuit on a pre-initialize
         # call, so this is safe to invoke from any lifecycle point.
@@ -1199,8 +1326,10 @@ class Problem:
         """Return the cached ``jax.jit``'d batched ``lax.while_loop`` wrapper.
 
         Mirrors :meth:`_get_or_build_solve_loop` but the loop body is
-        ``jax.vmap``'d over the leading batch axis of the ``AlgorithmState``
-        (parameters shared), so a single XLA program runs all ``B`` SCP solves.
+        ``jax.vmap``'d over the leading batch axis of the ``AlgorithmState`` and,
+        when every parameter array carries that same axis, over parameters too;
+        otherwise parameters are shared across the batch. A single XLA program
+        runs all ``B`` SCP solves.
         It is built over :attr:`_iteration_fn_jit_inner` — the body whose inner
         discretization solvers are plain ``jax.jit``, hence ``vmap``-safe — not
         :attr:`_iteration_fn`, which under ``save_compiled`` wraps
@@ -1225,7 +1354,8 @@ class Problem:
                 self._algorithm.ep_vc,
                 k_max,
             )
-            batched = jax.vmap(loop, in_axes=(0, None))
+            param_axes = _solve_batched_param_in_axes(params, B)
+            batched = jax.vmap(loop, in_axes=(0, param_axes))
             if self.settings.sim.save_compiled and not self.settings.dev.debug:
                 if not self._solver.exportable:
                     raise ValueError(
@@ -1307,16 +1437,41 @@ class Problem:
                 "Problem has not been initialized. Call initialize() before solve_jax()"
             )
 
-        initial_state = self._resolve_initial_state(x_initial, x_final)
         params = parameters if parameters is not None else self._parameters
+
+        # Auto-populate x_initial / x_final from param-fix pins when the
+        # caller did not supply explicit boundary pins.  This lets
+        # solve_jax(parameters={"initial_position": ic}) work without
+        # requiring the caller to also build x_initial by hand.
+        pins = getattr(self._solver, "_param_fix_pins", [])
+        init_pins = [p for p in pins if p.node_type == "init"]
+        term_pins = [p for p in pins if p.node_type == "term"]
+        if (x_initial is None and init_pins) or (x_final is None and term_pins):
+            _default = AlgorithmState.from_settings(self.settings, self._algorithm.weights)
+            if x_initial is None and init_pins:
+                x_init_arr = np.array(_default.x_init_pin)
+                for pin in init_pins:
+                    x_init_arr[pin.state_slice] = np.asarray(
+                        params[pin.param_name], dtype=float
+                    ).ravel()
+                x_initial = jnp.asarray(x_init_arr, dtype=_default.x_init_pin.dtype)
+            if x_final is None and term_pins:
+                x_term_arr = np.array(_default.x_term_pin)
+                for pin in term_pins:
+                    x_term_arr[pin.state_slice] = np.asarray(
+                        params[pin.param_name], dtype=float
+                    ).ravel()
+                x_final = jnp.asarray(x_term_arr, dtype=_default.x_term_pin.dtype)
+
+        initial_state = self._resolve_initial_state(x_initial, x_final)
         solve_fn = self._get_or_build_solve_loop(max_iters)
         final_state = solve_fn(initial_state, params)
         return OptimizationResults.from_final_state(final_state, problem=self)
 
     def solve_batched(
         self,
-        x0_stack: jnp.ndarray,
-        xf_stack: jnp.ndarray,
+        x0_stack: Optional[jnp.ndarray] = None,
+        xf_stack: Optional[jnp.ndarray] = None,
         parameters: Optional[dict] = None,
         *,
         max_iters: Optional[int] = None,
@@ -1324,7 +1479,8 @@ class Problem:
         """Run ``B`` SCP solves over stacked boundary conditions — batch baked in.
 
         Applies ``jax.vmap`` *internally* over ``x0_stack`` / ``xf_stack`` (the
-        parameters are shared across the batch) and drives the same fused
+        parameters are shared unless every parameter array carries the same
+        leading batch axis) and drives the same fused
         ``iteration_fn`` core as :meth:`solve_jax` inside one ``lax.while_loop``.
         The result is a batched :class:`OptimizationResults` pytree: every array
         leaf carries the leading batch axis ``B`` (``result.x.shape ==
@@ -1356,12 +1512,21 @@ class Problem:
             x0_stack: Stacked initial-state boundary pins, shape
                 ``(B, n_states)``. Each row follows the :meth:`solve_jax`
                 ``x_initial`` convention (``jnp.nan`` at non-Fix entries).
+                ``None`` auto-builds the stack from the default
+                ``x_init_pin`` with param-fix-pin slots overwritten from
+                *parameters* (requires at least one param-fix-pin and
+                a batched parameter value, or that *xf_stack* provides B).
             xf_stack: Stacked terminal-state boundary pins, shape
                 ``(B, n_states)``. Same per-row convention as ``x0_stack``.
-            parameters: Problem parameters dict shared across the batch.
-                ``None`` reuses ``self._parameters``. Values flow as runtime
-                inputs to the exported artifact; its pytree structure is fixed
-                at the first ``solve_batched`` call that builds the artifact.
+                ``None`` auto-builds similarly from the default
+                ``x_term_pin``.
+            parameters: Problem parameters dict. ``None`` reuses
+                ``self._parameters``. When every value has a leading axis of
+                size ``B`` (matching ``x0_stack.shape[0]``), each batch element
+                receives its own parameter slice; otherwise parameters are
+                shared across the batch. Values flow as runtime inputs to the
+                exported artifact; its pytree structure is fixed at the first
+                ``solve_batched`` call that builds the artifact.
             max_iters: SCP iteration cap. ``None`` uses ``algorithm.k_max``; a
                 different value (or a different ``B``) rebuilds the cached
                 batched closure *and* keys a distinct exported artifact, so an
@@ -1376,15 +1541,60 @@ class Problem:
                 "Problem has not been initialized. Call initialize() before solve_batched()"
             )
 
+        pins = getattr(self._solver, "_param_fix_pins", [])
+        pin_names = {pin.param_name for pin in pins}
+
+        # Determine which user-supplied parameters are intended only as boundary-
+        # condition overrides (param-fix pins) vs. parameters that should be
+        # forwarded into the SCP loop (dynamics / constraints).  Pin parameters
+        # are consumed here to build x0_stack / xf_stack; they are excluded from
+        # params_for_solve so the vmap never sees a partial / mixed-batch dict.
+        params_for_bc = parameters or {}
+        if parameters is None:
+            params_for_solve = self._parameters
+        else:
+            # Merge: start from current self._parameters, then apply any user
+            # overrides that are NOT pin parameters (those are boundary-only).
+            params_for_solve = dict(self._parameters)
+            for k, v in parameters.items():
+                if k not in pin_names:
+                    params_for_solve[k] = v
+
+        # Auto-build x0_stack / xf_stack when not supplied by the caller.
+        # This allows the compact call:
+        #   problem.solve_batched(parameters={"initial_position": ic_batch})
+        # without the user manually constructing the boundary-pin stacks.
+        if x0_stack is None or xf_stack is None:
+            B = _infer_batch_size(x0_stack, xf_stack, params_for_bc, pins)
+            n_x = self.settings.sim.n_states
+            _default = AlgorithmState.from_settings(self.settings, self._algorithm.weights)
+            if x0_stack is None:
+                x0_np = np.broadcast_to(np.asarray(_default.x_init_pin), (B, n_x)).copy()
+                for pin in pins:
+                    if pin.node_type == "init" and pin.param_name in params_for_bc:
+                        x0_np[:, pin.state_slice] = np.asarray(
+                            params_for_bc[pin.param_name], dtype=float
+                        ).reshape(B, -1)
+                x0_stack = jnp.asarray(x0_np)
+            if xf_stack is None:
+                xf_np = np.broadcast_to(np.asarray(_default.x_term_pin), (B, n_x)).copy()
+                for pin in pins:
+                    if pin.node_type == "term" and pin.param_name in params_for_bc:
+                        xf_np[:, pin.state_slice] = np.asarray(
+                            params_for_bc[pin.param_name], dtype=float
+                        ).reshape(B, -1)
+                xf_stack = jnp.asarray(xf_np)
+
         states = jax.vmap(self._resolve_initial_state)(x0_stack, xf_stack)
-        params = parameters if parameters is not None else self._parameters
-        batched_solve = self._get_or_build_solve_batched(x0_stack.shape[0], max_iters, params)
+        batched_solve = self._get_or_build_solve_batched(
+            x0_stack.shape[0], max_iters, params_for_solve
+        )
         # The exported (``save_compiled``) artifact is a ``jax.export`` wrapper
         # dispatched via ``.call``; the in-process artifact is a plain callable.
         final_states = (
-            batched_solve.call(states, params)
+            batched_solve.call(states, params_for_solve)
             if hasattr(batched_solve, "call")
-            else batched_solve(states, params)
+            else batched_solve(states, params_for_solve)
         )
         return OptimizationResults.from_final_state(final_states, problem=self)
 
@@ -1434,6 +1644,97 @@ class Problem:
 
         profiling.profiling_end(pr, "postprocess")
         return result
+
+    def post_process_batched(
+        self,
+        results: OptimizationResults,
+        *,
+        n_times: Optional[int] = None,
+    ) -> OptimizationResults:
+        """Propagate all batch elements through the nonlinear dynamics.
+
+        Applies the same high-fidelity propagation as :meth:`post_process` to
+        every element of a batched :class:`~openscvx.algorithms.OptimizationResults`
+        returned by :meth:`solve_batched`.  Results are stacked so that the
+        post-process fields carry a leading batch axis ``B``:
+
+        - ``results.t_full``  — ``(B, n_times)``
+        - ``results.x_full``  — ``(B, n_times, n_prop_states)``
+        - ``results.u_full``  — ``(B, n_times, n_controls)``
+        - ``results.trajectory`` — ``{name: (B, n_times, ...)}``
+        - ``results.cost``    — ``(B,)``
+        - ``results.ctcs_violation`` — ``(B, ...)`` or ``None``
+
+        Propagation runs sequentially over the batch in a Python loop;
+        all elements share ``self._parameters`` for any parameter values not
+        embedded in the trajectory state vector.
+
+        Args:
+            results: Batched :class:`~openscvx.algorithms.OptimizationResults`
+                from :meth:`solve_batched`.  ``results.X[-1]`` must have shape
+                ``(B, N, n_x)``.
+            n_times: Number of interpolation points for the dense time grid.
+                When ``None`` (default), uses
+                ``ceil(T_max / settings.prp.dt) + 1`` where ``T_max`` is the
+                longest terminal time across the batch.  All ``B`` elements are
+                interpolated to the **same** ``n_times`` so the output arrays
+                have uniform shape.
+
+        Returns:
+            The same ``results`` object with ``t_full``, ``x_full``, ``u_full``,
+            ``trajectory``, ``cost``, and ``ctcs_violation`` populated.
+
+        Raises:
+            ValueError: If the problem has not been initialized yet.
+        """
+        if self._lowered is None:
+            raise ValueError("Problem not initialized. Call initialize() first.")
+
+        x_batch = np.asarray(results.X[-1])   # (B, N, n_x)
+        B = x_batch.shape[0]
+
+        if n_times is None:
+            t_finals = np.asarray(results.t_final).reshape(-1)   # (B,)
+            T_max = float(t_finals.max())
+            n_times = max(int(np.ceil(T_max / self.settings.prp.dt)) + 1, 2)
+
+        t_fulls: List[np.ndarray] = []
+        x_fulls: List[np.ndarray] = []
+        u_fulls: List[np.ndarray] = []
+        trajectories: List[Dict] = []
+        costs: List[float] = []
+        ctcs_violations = []
+
+        for b in range(B):
+            single = _make_single_result(results, b)
+            prop = propagate_trajectory_results(
+                self._parameters,
+                self.settings,
+                single,
+                self._propagation_solver,
+                dynamics_discrete=self._lowered.dynamics_discrete.f,
+                algebraic_prop=self._lowered.algebraic_prop,
+                discretizer=self._discretizer,
+                n_times=n_times,
+            )
+            t_fulls.append(prop.t_full)
+            x_fulls.append(prop.x_full)
+            u_fulls.append(prop.u_full)
+            trajectories.append(prop.trajectory)
+            costs.append(prop.cost)
+            ctcs_violations.append(prop.ctcs_violation)
+
+        results.t_full = np.stack(t_fulls)        # (B, n_times)
+        results.x_full = np.stack(x_fulls)        # (B, n_times, n_prop_states)
+        results.u_full = np.stack(u_fulls)        # (B, n_times, n_controls)
+        results.trajectory = {
+            k: np.stack([traj[k] for traj in trajectories])
+            for k in trajectories[0]
+        }
+        results.cost = np.array(costs)            # (B,)
+        if ctcs_violations[0] is not None:
+            results.ctcs_violation = np.stack(ctcs_violations)
+        return results
 
     def citation(self) -> str:
         """Return BibTeX citations for all components used in this problem.

--- a/openscvx/problem.py
+++ b/openscvx/problem.py
@@ -83,15 +83,22 @@ from openscvx.utils.caching import (
 def _infer_batch_size(
     user_params: Optional[dict],
     *,
+    x0_stack=None,
+    xf_stack=None,
     x_guess=None,
     u_guess=None,
 ) -> int:
     """Infer the batch size B for :meth:`Problem.solve_batched`.
 
-    Returns the leading axis of the first batched entry among *x_guess*,
-    *u_guess* (shape ``(B, N, n)``), or a non-scalar value in *user_params*.
+    Returns the leading axis of the first batched entry among *x0_stack*,
+    *xf_stack*, *x_guess*, *u_guess*, or a non-scalar value in *user_params*.
     Raises ``ValueError`` when no batched entry is found.
     """
+    for value in (x0_stack, xf_stack):
+        if value is not None:
+            arr = jnp.asarray(value)
+            if arr.ndim >= 2:
+                return int(arr.shape[0])
     for value in (x_guess, u_guess):
         if value is not None:
             arr = jnp.asarray(value)
@@ -1477,6 +1484,8 @@ class Problem:
         self,
         parameters: Optional[dict] = None,
         *,
+        x0_stack: Optional[jnp.ndarray] = None,
+        xf_stack: Optional[jnp.ndarray] = None,
         x_guess: Optional[jnp.ndarray] = None,
         u_guess: Optional[jnp.ndarray] = None,
         max_iters: Optional[int] = None,
@@ -1502,14 +1511,21 @@ class Problem:
         are broadcast across the batch.  ``B`` is inferred from the first
         batched entry in *parameters*, *x_guess*, or *u_guess*.
 
+        **Boundary pins**: pass ``x0_stack`` / ``xf_stack`` as ``(B, n_x)``
+        arrays to batch initial and terminal Fix boundary conditions without
+        declaring a runtime ``.convex()`` constraint (cheaper than parameter
+        pins evaluated every SCP iteration)::
+
+            results = problem.solve_batched(x0_stack=x0_stack, xf_stack=xf_stack)
+
         **Trajectory guesses**: pass ``x_guess`` / ``u_guess`` as shared
         ``(N, n)`` arrays (broadcast to every batch element) or per-batch
         ``(B, N, n)`` stacks to seed each solve's SCP iterate independently::
 
             results = problem.solve_batched(
-                parameters={"initial_position": ic_batch},
+                x0_stack=x0_stack,
+                xf_stack=xf_stack,
                 x_guess=x_guess_batch,
-                u_guess=u_guess_batch,
             )
 
         Why this exists alongside ``jax.vmap(solve_jax)``: because the batch
@@ -1533,7 +1549,12 @@ class Problem:
                 ``B`` are vmapped over (each batch element receives its own
                 slice); parameters with a different shape are broadcast.
                 ``B`` is inferred from the first batched entry supplied here,
-                in *x_guess*, or in *u_guess* (raises if none is found).
+                in *x0_stack*, *xf_stack*, *x_guess*, or *u_guess* (raises
+                if none is found).
+            x0_stack: Initial boundary pins, shape ``(B, n_states)``.  ``None``
+                broadcasts the default ``x_init_pin`` from settings.
+            xf_stack: Terminal boundary pins, shape ``(B, n_states)``.  ``None``
+                broadcasts the default ``x_term_pin`` from settings.
             x_guess: State trajectory guess, shape ``(N, n_states)`` shared
                 across the batch or ``(B, N, n_states)`` per element.
                 ``None`` uses the default from settings.
@@ -1555,13 +1576,29 @@ class Problem:
 
         params_for_solve = dict(self._parameters, **(parameters or {}))
 
-        B = _infer_batch_size(parameters, x_guess=x_guess, u_guess=u_guess)
+        B = _infer_batch_size(
+            parameters, x0_stack=x0_stack, xf_stack=xf_stack, x_guess=x_guess, u_guess=u_guess
+        )
         N = self.settings.sim.n
         n_x = self.settings.sim.n_states
         n_u = self.settings.sim.n_controls
         _default = AlgorithmState.from_settings(self.settings, self._algorithm.weights)
-        x0_stack = jnp.asarray(np.broadcast_to(np.asarray(_default.x_init_pin), (B, n_x)).copy())
-        xf_stack = jnp.asarray(np.broadcast_to(np.asarray(_default.x_term_pin), (B, n_x)).copy())
+        if x0_stack is None:
+            x0_stack = jnp.asarray(np.broadcast_to(np.asarray(_default.x_init_pin), (B, n_x)).copy())
+        else:
+            x0_stack = jnp.asarray(x0_stack)
+            if x0_stack.shape != (B, n_x):
+                raise ValueError(
+                    f"solve_batched: x0_stack must have shape (B, n_x)=({B}, {n_x}), got {x0_stack.shape}."
+                )
+        if xf_stack is None:
+            xf_stack = jnp.asarray(np.broadcast_to(np.asarray(_default.x_term_pin), (B, n_x)).copy())
+        else:
+            xf_stack = jnp.asarray(xf_stack)
+            if xf_stack.shape != (B, n_x):
+                raise ValueError(
+                    f"solve_batched: xf_stack must have shape (B, n_x)=({B}, {n_x}), got {xf_stack.shape}."
+                )
         x_guess_stack = _expand_batched_trajectory_guess(
             x_guess, B=B, N=N, n=n_x, name="x_guess", default=_default.x
         )
@@ -1681,6 +1718,12 @@ class Problem:
             t_finals = np.asarray(results.t_final).reshape(-1)  # (B,)
             T_max = float(t_finals.max())
             n_times = max(int(np.ceil(T_max / self.settings.prp.dt)) + 1, 2)
+
+        # The propagation solver is compiled with a per-segment tau capacity of
+        # ``max_tau_len``.  A uniform ``linspace`` grid sized from the batch
+        # ``T_max`` can place more output times into one normalized segment than
+        # that capacity when shorter trajectories are padded to the same count.
+        n_times = min(n_times, self.settings.prp.max_tau_len)
 
         t_fulls: List[np.ndarray] = []
         x_fulls: List[np.ndarray] = []

--- a/openscvx/problem.py
+++ b/openscvx/problem.py
@@ -65,9 +65,11 @@ from openscvx.symbolic.lower import lower_symbolic_problem
 from openscvx.symbolic.problem import SymbolicProblem
 from openscvx.utils import printing, profiling
 from openscvx.utils.caching import (
+    get_solve_batched_cache_path,
     get_solver_cache_paths,
     load_or_compile_discretization_solver,
     load_or_compile_propagation_solver,
+    load_or_export_solve_batched,
     prime_propagation_solver,
 )
 
@@ -1203,6 +1205,13 @@ class Problem:
         ``call_exported`` solvers that have no ``vmap`` rule (§3). The closure
         is cached on ``(B, k_max)``: the batch size is baked into the program,
         so a different ``B`` retraces.
+
+        Under ``save_compiled`` the whole vmapped loop is exported once to the
+        solver cache and deserialized on later processes (the single artifact
+        that makes ``solve_batched`` worth having); the returned object is then
+        a ``jax.export`` wrapper called via ``.call``. Export requires an
+        exportable backend — CVXPy raises a teaching error here rather than
+        silently degrading to an in-process solve.
         """
         k_max = max_iters if max_iters is not None else self._algorithm.k_max
         key = (B, k_max)
@@ -1215,7 +1224,33 @@ class Problem:
                 k_max,
             )
             batched = jax.vmap(loop, in_axes=(0, None))
-            self._solve_batched_fn = jax.jit(batched)
+            if self.settings.sim.save_compiled and not self.settings.dev.debug:
+                if not self._solver.exportable:
+                    raise ValueError(
+                        f"solve_batched(save_compiled=True) cannot export the "
+                        f"{type(self._solver).__name__} backend: its solve runs through a "
+                        f"jax.pure_callback, which jax.export cannot serialize. Use an "
+                        f"exportable backend (QPAXPTRSolver or MoreauPTRSolver), or set "
+                        f"save_compiled=False to run B sequential in-process solves."
+                    )
+                cache_file = get_solve_batched_cache_path(
+                    self.symbolic,
+                    self.settings,
+                    self._algorithm,
+                    self._solver,
+                    self._discretizer,
+                    B,
+                )
+                sample_state = jax.tree_util.tree_map(
+                    lambda a: jnp.broadcast_to(a, (B,) + jnp.shape(a)),
+                    AlgorithmState.from_settings(self.settings, self._algorithm.weights),
+                )
+                batched = load_or_export_solve_batched(
+                    batched, cache_file, sample_state, self._parameters
+                )
+            else:
+                batched = jax.jit(batched)
+            self._solve_batched_fn = batched
             self._solve_batched_key = key
         return self._solve_batched_fn
 
@@ -1296,11 +1331,22 @@ class Problem:
 
         Why this exists alongside ``jax.vmap(solve_jax)``: because the batch axis
         is owned here rather than by the caller, the whole vmapped loop is a
-        single function that can be exported to disk and reused across processes
-        (Phase 2). ``jax.vmap(solve_jax)`` is the right tool for in-program
-        batching that composes with ``grad``/``scan``; ``solve_batched`` is for
-        when cross-process cold-start dominates. With no export wired up the two
-        produce identical results.
+        single function that ``jax.export`` can serialize. Under
+        ``save_compiled=True`` the artifact is written to the solver cache on the
+        first call and deserialized on later processes — skipping the XLA compile
+        that ``jax.vmap(solve_jax)`` pays on every fresh launch. ``jax.vmap(
+        solve_jax)`` is the right tool for in-program batching that composes with
+        ``grad``/``scan``; ``solve_batched`` is for when cross-process cold-start
+        dominates. With ``save_compiled=False`` the two produce identical results
+        in-process.
+
+        Export requires a pure-JAX backend: under ``save_compiled=True`` the
+        CVXPy backend raises (its solve is a ``jax.pure_callback``, which
+        ``jax.export`` cannot serialize), pointing at QPAX / Moreau. The cache
+        key invalidates on any change that alters the exported loop — backend +
+        ``solver_args``, algorithm + autotuner + thresholds + weights,
+        discretizer, scaling, ``B``, and the JAX version — so a stale artifact is
+        never silently reused.
 
         Args:
             x0_stack: Stacked initial-state boundary pins, shape
@@ -1326,7 +1372,13 @@ class Problem:
         states = jax.vmap(self._resolve_initial_state)(x0_stack, xf_stack)
         params = parameters if parameters is not None else self._parameters
         batched_solve = self._get_or_build_solve_batched(x0_stack.shape[0], max_iters)
-        final_states = batched_solve(states, params)
+        # The exported (``save_compiled``) artifact is a ``jax.export`` wrapper
+        # dispatched via ``.call``; the in-process artifact is a plain callable.
+        final_states = (
+            batched_solve.call(states, params)
+            if hasattr(batched_solve, "call")
+            else batched_solve(states, params)
+        )
         return OptimizationResults.from_final_state(final_states, problem=self)
 
     def post_process(self) -> OptimizationResults:

--- a/openscvx/problem.py
+++ b/openscvx/problem.py
@@ -1193,7 +1193,9 @@ class Problem:
             self._solve_loop_k_max = k_max
         return self._solve_loop_fn
 
-    def _get_or_build_solve_batched(self, B: int, max_iters: Optional[int]) -> callable:
+    def _get_or_build_solve_batched(
+        self, B: int, max_iters: Optional[int], params: dict
+    ) -> callable:
         """Return the cached ``jax.jit``'d batched ``lax.while_loop`` wrapper.
 
         Mirrors :meth:`_get_or_build_solve_loop` but the loop body is
@@ -1240,13 +1242,17 @@ class Problem:
                     self._solver,
                     self._discretizer,
                     B,
+                    k_max,
                 )
                 sample_state = jax.tree_util.tree_map(
                     lambda a: jnp.broadcast_to(a, (B,) + jnp.shape(a)),
                     AlgorithmState.from_settings(self.settings, self._algorithm.weights),
                 )
+                # Trace the export against the same ``params`` the call will use,
+                # not ``self._parameters`` — under an export the input avals are
+                # frozen at trace time, so the two must agree.
                 batched = load_or_export_solve_batched(
-                    batched, cache_file, sample_state, self._parameters
+                    batched, cache_file, sample_state, params
                 )
             else:
                 batched = jax.jit(batched)
@@ -1355,10 +1361,13 @@ class Problem:
             xf_stack: Stacked terminal-state boundary pins, shape
                 ``(B, n_states)``. Same per-row convention as ``x0_stack``.
             parameters: Problem parameters dict shared across the batch.
-                ``None`` reuses ``self._parameters``.
+                ``None`` reuses ``self._parameters``. Values flow as runtime
+                inputs to the exported artifact; its pytree structure is fixed
+                at the first ``solve_batched`` call that builds the artifact.
             max_iters: SCP iteration cap. ``None`` uses ``algorithm.k_max``; a
                 different value (or a different ``B``) rebuilds the cached
-                batched closure.
+                batched closure *and* keys a distinct exported artifact, so an
+                override never reuses an artifact compiled at another bound.
 
         Returns:
             :class:`OptimizationResults` pytree with a leading ``B`` axis on
@@ -1371,7 +1380,7 @@ class Problem:
 
         states = jax.vmap(self._resolve_initial_state)(x0_stack, xf_stack)
         params = parameters if parameters is not None else self._parameters
-        batched_solve = self._get_or_build_solve_batched(x0_stack.shape[0], max_iters)
+        batched_solve = self._get_or_build_solve_batched(x0_stack.shape[0], max_iters, params)
         # The exported (``save_compiled``) artifact is a ``jax.export`` wrapper
         # dispatched via ``.call``; the in-process artifact is a plain callable.
         final_states = (

--- a/openscvx/problem.py
+++ b/openscvx/problem.py
@@ -506,6 +506,7 @@ class Problem:
         self._columns = None
 
         self.timing_init = None
+        self.timing_compile = None
         self.timing_solve = None
         self.timing_post = None
         self._profiling_session = None
@@ -1007,6 +1008,7 @@ class Problem:
         self._solve_loop_k_max = None
         self._solve_batched_fn = None
         self._solve_batched_key = None
+        self._solve_batched_is_exported = False
         self._iteration_fn = jax.jit(
             make_scp_iteration(
                 dis_continuous=discretization_solver,
@@ -1382,8 +1384,19 @@ class Problem:
                 # not ``self._parameters`` — under an export the input avals are
                 # frozen at trace time, so the two must agree.
                 batched = load_or_export_solve_batched(batched, cache_file, sample_state, params)
+                self._solve_batched_is_exported = True
             else:
-                batched = jax.jit(batched)
+                # AOT-compile now so solve_batched() execution is compile-free.
+                # sample_state provides concrete shapes/dtypes; the compiled
+                # artifact accepts any inputs with those same shapes/dtypes.
+                sample_state = jax.tree_util.tree_map(
+                    lambda a: jnp.broadcast_to(a, (B,) + jnp.shape(a)),
+                    AlgorithmState.from_settings(self.settings, self._algorithm.weights),
+                )
+                t_0_compile = time.time()
+                batched = jax.jit(batched).lower(sample_state, params).compile()
+                self.timing_compile = time.time() - t_0_compile
+                self._solve_batched_is_exported = False
             self._solve_batched_fn = batched
             self._solve_batched_key = key
         return self._solve_batched_fn
@@ -1586,16 +1599,23 @@ class Problem:
                 xf_stack = jnp.asarray(xf_np)
 
         states = jax.vmap(self._resolve_initial_state)(x0_stack, xf_stack)
+        # _get_or_build_solve_batched triggers AOT compilation on the first call
+        # and stores self.timing_compile.  Subsequent calls return the cached
+        # compiled artifact immediately, so t_0_solve captures execution only.
         batched_solve = self._get_or_build_solve_batched(
             x0_stack.shape[0], max_iters, params_for_solve
         )
-        # The exported (``save_compiled``) artifact is a ``jax.export`` wrapper
-        # dispatched via ``.call``; the in-process artifact is a plain callable.
-        final_states = (
-            batched_solve.call(states, params_for_solve)
-            if hasattr(batched_solve, "call")
-            else batched_solve(states, params_for_solve)
-        )
+        t_0_solve = time.time()
+        # jax.export.Exported wrappers (save_compiled path) are invoked via
+        # .call(); jax.stages.Compiled (AOT path) is a plain callable.
+        # We track which case we have via self._solve_batched_is_exported rather
+        # than hasattr() since Compiled also happens to have a .call attribute.
+        if getattr(self, "_solve_batched_is_exported", False):
+            final_states = batched_solve.call(states, params_for_solve)
+        else:
+            final_states = batched_solve(states, params_for_solve)
+        jax.block_until_ready(final_states)
+        self.timing_solve = time.time() - t_0_solve
         return OptimizationResults.from_final_state(final_states, problem=self)
 
     def post_process(self) -> OptimizationResults:
@@ -1705,6 +1725,7 @@ class Problem:
         costs: List[float] = []
         ctcs_violations = []
 
+        t_0_post = time.time()
         for b in range(B):
             single = _make_single_result(results, b)
             prop = propagate_trajectory_results(
@@ -1724,6 +1745,8 @@ class Problem:
             costs.append(prop.cost)
             ctcs_violations.append(prop.ctcs_violation)
 
+        self.timing_post = time.time() - t_0_post
+
         results.t_full = np.stack(t_fulls)        # (B, n_times)
         results.x_full = np.stack(x_fulls)        # (B, n_times, n_prop_states)
         results.u_full = np.stack(u_fulls)        # (B, n_times, n_controls)
@@ -1734,6 +1757,14 @@ class Problem:
         results.cost = np.array(costs)            # (B,)
         if ctcs_violations[0] is not None:
             results.ctcs_violation = np.stack(ctcs_violations)
+
+        printing.print_batch_results_summary(
+            results,
+            self.timing_post,
+            self.timing_init,
+            self.timing_solve,
+            timing_compile=self.timing_compile,
+        )
         return results
 
     def citation(self) -> str:

--- a/openscvx/problem.py
+++ b/openscvx/problem.py
@@ -1251,9 +1251,7 @@ class Problem:
                 # Trace the export against the same ``params`` the call will use,
                 # not ``self._parameters`` — under an export the input avals are
                 # frozen at trace time, so the two must agree.
-                batched = load_or_export_solve_batched(
-                    batched, cache_file, sample_state, params
-                )
+                batched = load_or_export_solve_batched(batched, cache_file, sample_state, params)
             else:
                 batched = jax.jit(batched)
             self._solve_batched_fn = batched

--- a/openscvx/problem.py
+++ b/openscvx/problem.py
@@ -1487,6 +1487,7 @@ class Problem:
         xf_stack: Optional[jnp.ndarray] = None,
         parameters: Optional[dict] = None,
         *,
+        x_guess_stack: Optional[jnp.ndarray] = None,
         max_iters: Optional[int] = None,
     ) -> OptimizationResults:
         """Run ``B`` SCP solves over stacked boundary conditions — batch baked in.
@@ -1540,6 +1541,17 @@ class Problem:
                 shared across the batch. Values flow as runtime inputs to the
                 exported artifact; its pytree structure is fixed at the first
                 ``solve_batched`` call that builds the artifact.
+            x_guess_stack: Per-element initial guess for the state trajectory,
+                shape ``(B, N, n_states)``.  When provided, replaces the
+                shared ``AlgorithmState.x`` after the vmapped boundary pins
+                are built but before the SCP iterations start.  Each batch
+                element therefore starts from its own warm starting point
+                rather than the global problem-level guess stored in
+                ``problem.settings.sim.x.guess``.  ``None`` falls back to the
+                shared guess (broadcast from the single problem-level guess).
+                The AOT-compiled artifact is unaffected because shapes and
+                dtypes are identical to the default; only the concrete values
+                differ at runtime.
             max_iters: SCP iteration cap. ``None`` uses ``algorithm.k_max``; a
                 different value (or a different ``B``) rebuilds the cached
                 batched closure *and* keys a distinct exported artifact, so an
@@ -1605,6 +1617,12 @@ class Problem:
         batched_solve = self._get_or_build_solve_batched(
             x0_stack.shape[0], max_iters, params_for_solve
         )
+        # Inject per-element initial guesses after compilation (shapes/dtypes
+        # match the compiled artifact) but before execution.
+        if x_guess_stack is not None:
+            states = states.replace(
+                x=jnp.asarray(x_guess_stack, dtype=states.x.dtype)
+            )
         t_0_solve = time.time()
         # jax.export.Exported wrappers (save_compiled path) are invoked via
         # .call(); jax.stages.Compiled (AOT path) is a plain callable.

--- a/openscvx/problem.py
+++ b/openscvx/problem.py
@@ -18,7 +18,7 @@ import os
 import queue
 import threading
 import time
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import jax
 
@@ -370,11 +370,24 @@ class Problem:
         # Fused JAX-pure SCP iteration body (built in initialize()).
         self._iteration_fn: callable = None
 
+        # Sibling iteration body built over plain-``jax.jit`` inner solvers
+        # (never the ``jax.export`` wrappers ``save_compiled`` may produce),
+        # so it stays ``vmap``-safe and can be folded into the single exported
+        # ``solve_batched`` artifact. Equals ``_iteration_fn`` when
+        # ``save_compiled=False``. Built in initialize().
+        self._iteration_fn_jit_inner: callable = None
+
         # Closure cache for the ``lax.while_loop`` wrapper that backs
         # :meth:`solve_jax`. Keyed on ``k_max`` — rebuilt only when the caller
         # supplies a non-default ``max_iters``.
         self._solve_loop_fn: Optional[callable] = None
         self._solve_loop_k_max: Optional[int] = None
+
+        # Closure cache for the batched ``vmap``'d loop that backs
+        # :meth:`solve_batched`. Keyed on ``(B, k_max)`` — the fixed batch
+        # size is baked into the artifact, so a different ``B`` rebuilds.
+        self._solve_batched_fn: Optional[callable] = None
+        self._solve_batched_key: Optional[Tuple[int, int]] = None
 
         # Set up emitter & queue (thread started in initialize() after columns are known)
         if self.settings.dev.printing:
@@ -761,6 +774,13 @@ class Problem:
         discretization_solver_impulsive = get_impulsive_discretization_solver(
             self._lowered.dynamics_discrete
         )
+        # Keep the raw (un-jit, un-exported) solvers: under ``save_compiled``
+        # the versions below become ``jax.export`` wrappers, which have no
+        # ``vmap`` rule and so cannot back :meth:`solve_batched`'s internal
+        # ``vmap``. The jit-inner iteration body (built after ``_iteration_fn``)
+        # wraps these in plain ``jax.jit`` instead.
+        discretization_solver_raw = discretization_solver
+        discretization_solver_impulsive_raw = discretization_solver_impulsive
         self._propagation_solver = get_propagation_solver(
             self._compiled_dynamics_prop.f, self.settings, self._discretizer
         )
@@ -851,11 +871,13 @@ class Problem:
         # iteration_callback), and folds the result through the autotuner — one
         # JIT'd call per SCP step in place of the old NumPy↔JAX stitching.
         print("Initializing the SCvx Subproblem Solver...")
-        # Drop any prior ``solve_jax`` closure — it captures the previous
-        # ``iteration_fn`` and would re-use stale traces if ``initialize()``
-        # is invoked twice.
+        # Drop any prior ``solve_jax`` / ``solve_batched`` closures — they
+        # capture the previous ``iteration_fn`` and would re-use stale traces
+        # if ``initialize()`` is invoked twice.
         self._solve_loop_fn = None
         self._solve_loop_k_max = None
+        self._solve_batched_fn = None
+        self._solve_batched_key = None
         self._iteration_fn = jax.jit(
             make_scp_iteration(
                 dis_continuous=discretization_solver,
@@ -866,6 +888,25 @@ class Problem:
                 settings=self.settings,
             )
         )
+        # Sibling body for :meth:`solve_batched`'s internal ``vmap``. Under
+        # ``save_compiled`` the inner solvers above are ``jax.export`` wrappers
+        # that can't be vmapped, so rebuild over plain-``jax.jit`` solvers; the
+        # whole vmapped loop is exported as one artifact instead. When
+        # ``save_compiled=False`` the inner solvers are already jit, so reuse
+        # ``_iteration_fn`` rather than recompile the dynamics (§3, Q3).
+        if self.settings.sim.save_compiled and not self.settings.dev.debug:
+            self._iteration_fn_jit_inner = jax.jit(
+                make_scp_iteration(
+                    dis_continuous=jax.jit(discretization_solver_raw),
+                    dis_impulsive=jax.jit(discretization_solver_impulsive_raw),
+                    jax_constraints=self._compiled_constraints,
+                    solver_callback=self._solver.iteration_callback(),
+                    autotuner=self._algorithm.autotuner,
+                    settings=self.settings,
+                )
+            )
+        else:
+            self._iteration_fn_jit_inner = self._iteration_fn
         self._algorithm.initialize(
             self._iteration_fn,
             self.emitter_function,
@@ -1150,6 +1191,34 @@ class Problem:
             self._solve_loop_k_max = k_max
         return self._solve_loop_fn
 
+    def _get_or_build_solve_batched(self, B: int, max_iters: Optional[int]) -> callable:
+        """Return the cached ``jax.jit``'d batched ``lax.while_loop`` wrapper.
+
+        Mirrors :meth:`_get_or_build_solve_loop` but the loop body is
+        ``jax.vmap``'d over the leading batch axis of the ``AlgorithmState``
+        (parameters shared), so a single XLA program runs all ``B`` SCP solves.
+        It is built over :attr:`_iteration_fn_jit_inner` — the body whose inner
+        discretization solvers are plain ``jax.jit``, hence ``vmap``-safe — not
+        :attr:`_iteration_fn`, which under ``save_compiled`` wraps
+        ``call_exported`` solvers that have no ``vmap`` rule (§3). The closure
+        is cached on ``(B, k_max)``: the batch size is baked into the program,
+        so a different ``B`` retraces.
+        """
+        k_max = max_iters if max_iters is not None else self._algorithm.k_max
+        key = (B, k_max)
+        if self._solve_batched_fn is None or self._solve_batched_key != key:
+            loop = make_solve_loop(
+                self._iteration_fn_jit_inner,
+                self._algorithm.ep_tr,
+                self._algorithm.ep_vb,
+                self._algorithm.ep_vc,
+                k_max,
+            )
+            batched = jax.vmap(loop, in_axes=(0, None))
+            self._solve_batched_fn = jax.jit(batched)
+            self._solve_batched_key = key
+        return self._solve_batched_fn
+
     def solve_jax(
         self,
         x_initial: Optional[jnp.ndarray] = None,
@@ -1204,6 +1273,61 @@ class Problem:
         solve_fn = self._get_or_build_solve_loop(max_iters)
         final_state = solve_fn(initial_state, params)
         return OptimizationResults.from_final_state(final_state, problem=self)
+
+    def solve_batched(
+        self,
+        x0_stack: jnp.ndarray,
+        xf_stack: jnp.ndarray,
+        parameters: Optional[dict] = None,
+        *,
+        max_iters: Optional[int] = None,
+    ) -> OptimizationResults:
+        """Run ``B`` SCP solves over stacked boundary conditions — batch baked in.
+
+        Applies ``jax.vmap`` *internally* over ``x0_stack`` / ``xf_stack`` (the
+        parameters are shared across the batch) and drives the same fused
+        ``iteration_fn`` core as :meth:`solve_jax` inside one ``lax.while_loop``.
+        The result is a batched :class:`OptimizationResults` pytree: every array
+        leaf carries the leading batch axis ``B`` (``result.x.shape ==
+        (B, N, n_x)``), exactly as ``jax.vmap(solve_jax)`` produces. Per-iteration
+        history is empty, the same asymmetry :meth:`solve_jax` carries — list
+        growth doesn't fit inside ``lax.while_loop``; use :meth:`solve` for
+        populated history.
+
+        Why this exists alongside ``jax.vmap(solve_jax)``: because the batch axis
+        is owned here rather than by the caller, the whole vmapped loop is a
+        single function that can be exported to disk and reused across processes
+        (Phase 2). ``jax.vmap(solve_jax)`` is the right tool for in-program
+        batching that composes with ``grad``/``scan``; ``solve_batched`` is for
+        when cross-process cold-start dominates. With no export wired up the two
+        produce identical results.
+
+        Args:
+            x0_stack: Stacked initial-state boundary pins, shape
+                ``(B, n_states)``. Each row follows the :meth:`solve_jax`
+                ``x_initial`` convention (``jnp.nan`` at non-Fix entries).
+            xf_stack: Stacked terminal-state boundary pins, shape
+                ``(B, n_states)``. Same per-row convention as ``x0_stack``.
+            parameters: Problem parameters dict shared across the batch.
+                ``None`` reuses ``self._parameters``.
+            max_iters: SCP iteration cap. ``None`` uses ``algorithm.k_max``; a
+                different value (or a different ``B``) rebuilds the cached
+                batched closure.
+
+        Returns:
+            :class:`OptimizationResults` pytree with a leading ``B`` axis on
+            every leaf and empty histories.
+        """
+        if self._iteration_fn_jit_inner is None:
+            raise ValueError(
+                "Problem has not been initialized. Call initialize() before solve_batched()"
+            )
+
+        states = jax.vmap(self._resolve_initial_state)(x0_stack, xf_stack)
+        params = parameters if parameters is not None else self._parameters
+        batched_solve = self._get_or_build_solve_batched(x0_stack.shape[0], max_iters)
+        final_states = batched_solve(states, params)
+        return OptimizationResults.from_final_state(final_states, problem=self)
 
     def post_process(self) -> OptimizationResults:
         """Propagate solution through full nonlinear dynamics for high-fidelity trajectory.

--- a/openscvx/propagation/post_processing.py
+++ b/openscvx/propagation/post_processing.py
@@ -1,7 +1,6 @@
 import copy
 from typing import Callable, Optional
 
-import jax.numpy as jnp
 import numpy as np
 
 from openscvx.algorithms import OptimizationResults
@@ -20,6 +19,7 @@ def propagate_trajectory_results(
     dynamics_discrete: Optional[Callable] = None,
     algebraic_prop: Optional[dict] = None,
     discretizer: Optional[Discretizer] = None,
+    n_times: Optional[int] = None,
 ) -> OptimizationResults:
     """Propagate the optimal trajectory and compute additional results.
 
@@ -42,6 +42,11 @@ def propagate_trajectory_results(
         algebraic_prop (dict, optional): Dictionary mapping output names to vmapped JAX functions.
         discretizer: Discretizer instance (used for ``dis_type``).
             Defaults to ``None`` which uses FOH.
+        n_times (int, optional): When provided, build the dense output time grid as
+            ``np.linspace(t[0], t[-1], n_times)`` instead of the default
+            ``np.arange(t[0], t[-1], settings.prp.dt)``.  Useful when multiple
+            trajectories must be stacked into a uniform array (e.g. the output of
+            :meth:`~openscvx.problem.Problem.post_process_batched`).
 
     Returns:
         OptimizationResults: Updated results object containing:
@@ -58,35 +63,36 @@ def propagate_trajectory_results(
 
     t = np.array(s_to_t(x, u, settings, discretizer)).squeeze()
 
-    # Build dense output times and always include the exact terminal time.
-    # This ensures trajectory[..., -1] corresponds to the true final state.
-    t_full = np.arange(t[0], t[-1], settings.prp.dt)
-    if t_full.size == 0 or not np.isclose(t_full[-1], t[-1]):
-        t_full = np.concatenate([t_full, np.array([t[-1]])])
+    # Build dense output times.
+    if n_times is not None:
+        t_full = np.linspace(t[0], t[-1], n_times)
+    else:
+        # Default: step at prp.dt and always include the exact terminal time so
+        # that trajectory[..., -1] corresponds to the true final state.
+        t_full = np.arange(t[0], t[-1], settings.prp.dt)
+        if t_full.size == 0 or not np.isclose(t_full[-1], t[-1]):
+            t_full = np.concatenate([t_full, np.array([t[-1]])])
 
     tau_vals, u_full = t_to_tau(u, t_full, t, settings, discretizer)
 
-    # Create a copy of x_prop for propagation to avoid mutating settings
-    # Match free values from initial state to the initial value from the result
+    # Create a copy of x_prop for propagation to avoid mutating settings.
     x_prop_for_propagation = copy.copy(settings.sim.x_prop)
 
-    # Only copy for states that exist in optimization (propagation may have extra states at the end)
     n_opt_states = x.shape[1]
     n_prop_states = settings.sim.x_prop.initial.shape[0]
 
+    # For a converged solution x[0, :] is the actual IC for every optimisation-state
+    # component regardless of initial_type (Fix / Free / Maximize).  Using the
+    # trajectory value directly avoids a subtle bug where "Fix" components would
+    # be seeded from settings.sim.x_prop.initial — the lowering-time default —
+    # rather than the value enforced by a param-fix pin for this particular solve.
     if n_opt_states == n_prop_states:
-        # Same size - copy all
-        # Use metadata from settings (immutable configuration)
-        mask = jnp.array([t == "Free" for t in settings.sim.x.initial_type], dtype=bool)
-        x_prop_for_propagation.initial = jnp.where(mask, x[0, :], settings.sim.x_prop.initial)
+        x_prop_for_propagation.initial = np.array(x[0, :], dtype=float)
     else:
-        # Propagation has extra states - only copy the overlapping portion
-        # Use metadata from settings (immutable configuration)
-        mask = jnp.array([t == "Free" for t in settings.sim.x.initial_type], dtype=bool)
-        x_prop_initial_updated = settings.sim.x_prop.initial.copy()
-        x_prop_initial_updated[:n_opt_states] = jnp.where(
-            mask, x[0, :], settings.sim.x_prop.initial[:n_opt_states]
-        )
+        # Propagation has extra states appended beyond the optimisation states;
+        # copy only the overlapping prefix and leave prop-only states untouched.
+        x_prop_initial_updated = np.array(settings.sim.x_prop.initial, dtype=float)
+        x_prop_initial_updated[:n_opt_states] = np.array(x[0, :], dtype=float)
         x_prop_for_propagation.initial = x_prop_initial_updated
 
     # Temporarily replace x_prop with our modified copy for propagation

--- a/openscvx/solvers/cones.py
+++ b/openscvx/solvers/cones.py
@@ -1,0 +1,100 @@
+"""Cone-constraint data types for the principled convex constraint pipeline.
+
+Each :class:`ConeConstraint` subclass represents a family of convex constraints
+that can be assembled directly into a JAX-native solver's constraint matrix
+without going through CVXPy.  The hierarchy mirrors the three fundamental
+cones used by most interior-point solvers:
+
+* :class:`ZeroConeConstraint` — affine equality ``f(x,u) = 0``.
+* :class:`NonnegConeConstraint` — affine inequality ``f(x,u) ≤ 0``.
+* :class:`SOCConstraint` — second-order-cone ``‖arg(x,u)‖₂ ≤ bound(x,u)``.
+
+All three are produced by :func:`~openscvx.symbolic.canonicalize.canonicalize_nodal_constraint`
+and consumed by the solver assembly methods of
+:class:`~openscvx.solvers.qpax_ptr_solver.QPAXPTRSolver` and
+:class:`~openscvx.solvers.moreau_ptr_solver.MoreauPTRSolver`.
+
+Design notes
+------------
+* Every constraint stores its **output dimension** (``m``) so that
+  :meth:`~openscvx.solvers.moreau_ptr_solver.MoreauPTRSolver._structural_pass`
+  can compute the static CSR sparsity pattern at ``initialize()`` time.
+* The :attr:`nodes` tuple records which discrete nodes the constraint is
+  active at; the solver assembly loops over ``nodes`` and adds the
+  appropriate rows for each.
+* JAX callables have the uniform signature
+  ``(x, u, node, params) -> array``, matching the rest of the lowering
+  pipeline.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Tuple
+
+
+@dataclass
+class ConeConstraint:
+    """Abstract base for a single canonicalised convex constraint block.
+
+    Attributes:
+        nodes: Discrete-node indices at which this constraint is enforced.
+    """
+
+    nodes: Tuple[int, ...]
+
+
+@dataclass
+class ZeroConeConstraint(ConeConstraint):
+    """Affine equality constraint: ``f(x, u, node, params) = 0``.
+
+    The JAX callable :attr:`jax_fn` returns the residual vector of shape
+    ``(m,)`` (or scalar when ``m == 1``).  At the solution the residual
+    must be zero; no virtual-buffer slack is introduced.
+
+    Attributes:
+        jax_fn: ``(x, u, node, params) -> array[m]`` — the constraint
+            residual ``lhs − rhs`` in standard form.
+        m: Output dimension of *jax_fn*.  Must be ≥ 1.
+    """
+
+    jax_fn: Callable
+    m: int
+
+
+@dataclass
+class NonnegConeConstraint(ConeConstraint):
+    """Affine inequality constraint: ``f(x, u, node, params) ≤ 0``.
+
+    The JAX callable :attr:`jax_fn` returns a residual vector of shape
+    ``(m,)`` (or scalar when ``m == 1``) that must be component-wise
+    non-positive at the solution.
+
+    Attributes:
+        jax_fn: ``(x, u, node, params) -> array[m]`` — the constraint
+            residual ``lhs − rhs`` in standard form (≤ 0).
+        m: Output dimension of *jax_fn*.  Must be ≥ 1.
+    """
+
+    jax_fn: Callable
+    m: int
+
+
+@dataclass
+class SOCConstraint(ConeConstraint):
+    """Second-order-cone constraint: ``‖arg(x, u, node, params)‖₂ ≤ bound(…)``.
+
+    Represents a Lorentz cone constraint of dimension ``m_arg + 1``.
+
+    Attributes:
+        arg_fn: ``(x, u, node, params) -> array[m_arg]`` — the vector whose
+            L2 norm must not exceed *bound_fn*.
+        bound_fn: ``(x, u, node, params) -> scalar`` — the upper bound on
+            the norm.
+        m_arg: Dimension of the argument vector (``m_arg ≥ 1``).  The full
+            SOC cone dimension is ``m_arg + 1``.
+    """
+
+    arg_fn: Callable
+    bound_fn: Callable
+    m_arg: int

--- a/openscvx/solvers/cvxpy_ptr_solver.py
+++ b/openscvx/solvers/cvxpy_ptr_solver.py
@@ -210,6 +210,18 @@ class CVXPyPTRSolver(PTRSolver):
         self._slice_imp = slice(0, 0)
 
     @property
+    def exportable(self) -> bool:
+        """CVXPy is not ``jax.export``-serializable — see :attr:`PTRSolver.exportable`.
+
+        The JAX-pure :meth:`iteration_callback` wraps the host CVXPy solve in a
+        :func:`jax.pure_callback`, and ``jax.export`` cannot serialize host
+        callbacks. ``solve_batched(save_compiled=True)`` therefore refuses this
+        backend with a teaching error pointing at QPAX / Moreau rather than
+        silently falling back to an uncached in-process solve.
+        """
+        return False
+
+    @property
     def ocp_vars(self) -> "CVXPyVariables":
         """The CVXPy variables and parameters.
 

--- a/openscvx/solvers/moreau_ptr_solver.py
+++ b/openscvx/solvers/moreau_ptr_solver.py
@@ -67,7 +67,6 @@ from .cones import NonnegConeConstraint, SOCConstraint, ZeroConeConstraint
 from .ptr_solver import (
     PTRSolver,
     PTRSolveResult,
-    ParamFixPin,
     StatusCode,
     SubproblemData,
     SubproblemSolution,
@@ -1569,7 +1568,7 @@ class MoreauPTRSolver(PTRSolver):
         # User ZeroConeConstraint rows (hard equality).
         # Coefficients scaled by S_x/S_u: dx_scaled = Δx_phys / S_x, so the
         # coefficient for dx_scaled[k, j] is J_x_phys[i, j] * S_x[j].
-        params_user = self._parameters_dict
+        params_user = data.params
         for cc in self._user_cone_constraints:
             if isinstance(cc, ZeroConeConstraint):
                 for k in cc.nodes:

--- a/openscvx/solvers/moreau_ptr_solver.py
+++ b/openscvx/solvers/moreau_ptr_solver.py
@@ -63,6 +63,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 import numpy as np
 from scipy import sparse as sp
 
+from .cones import NonnegConeConstraint, SOCConstraint, ZeroConeConstraint
 from .ptr_solver import (
     PTRSolver,
     PTRSolveResult,
@@ -266,8 +267,8 @@ class MoreauPTRSolver(PTRSolver):
     Compared to :class:`QPAXPTRSolver`, this backend uses fewer decision
     variables and constraint rows for the same PTR physics (SOC epigraphs for
     ``|nu|`` instead of two nonneg slack rows each), warm-starts between SCP
-    iterations on successful solves, and opens a path to user ``.convex()``
-    SOCP support in a follow-up.
+    iterations on successful solves, and natively handles user
+    :class:`~openscvx.solvers.cones.SOCConstraint` convex constraints.
 
     The JAX-pure entry point :meth:`iteration_callback` builds Moreau's
     functional factory ``moreau.jax.solver(...)`` once at
@@ -288,17 +289,23 @@ class MoreauPTRSolver(PTRSolver):
     Scope:
         Supported — state/control box, dynamics linearization (continuous
         and impulsive), boundary Fix, uniform time grid, linearized nodal
-        nonconvex, CTCS LICQ rows.
+        nonconvex, CTCS LICQ rows, user ``.convex()`` affine equality,
+        affine inequality, and second-order-cone constraints.
 
-        Not supported — user ``.convex()`` constraints and cross-node
-        constraints. Each raises :class:`NotImplementedError` with a "use
-        :class:`openscvx.solvers.cvxpy_ptr_solver.CVXPyPTRSolver`" pointer.
+        Not supported — cross-node constraints (raises
+        :class:`NotImplementedError` with a "use CVXPyPTRSolver" pointer).
 
     Differentiability hook for future work:
         ``moreau.jax.Solver`` differentiates through the solve via implicit
         differentiation on the KKT conditions. Once the surrounding SCP
         pipeline stays in ``jit``, ``jax.grad`` / ``jax.vmap`` can reach
         through a full SCvx solve.
+
+    Class attributes:
+        SUPPORTED_CONE_TYPES: Accepts
+            :class:`~openscvx.solvers.cones.ZeroConeConstraint`,
+            :class:`~openscvx.solvers.cones.NonnegConeConstraint`, and
+            :class:`~openscvx.solvers.cones.SOCConstraint`.
 
     Args:
         max_iter: Maximum number of IPM iterations forwarded to
@@ -324,6 +331,8 @@ class MoreauPTRSolver(PTRSolver):
         layout: :class:`_ConicLayout` describing flat decision-vector slot
             ranges. Populated by :meth:`create_variables`.
     """
+
+    SUPPORTED_CONE_TYPES = frozenset({ZeroConeConstraint, NonnegConeConstraint, SOCConstraint})
 
     def __init__(
         self,
@@ -407,10 +416,10 @@ class MoreauPTRSolver(PTRSolver):
         self._coo_cols: Optional[np.ndarray] = None
         self._n_con: int = 0
 
-        # Populated by lower_convex_constraints. Auto-augmented impulsive
-        # zero-pin constraints land here; any genuine user .convex() trips
-        # the default refusal.
+        # Populated by PTRSolver.lower_convex_constraints.
         self._impulsive_pins: List[Tuple[List[int], slice]] = []
+        self._user_cone_constraints: List = []
+        self._parameters_dict: dict = {}
 
         # Per-iteration data, set by update_* methods.
         self._dyn: dict = {}
@@ -484,28 +493,6 @@ class MoreauPTRSolver(PTRSolver):
 
         self.layout = _ConicLayout(N=N, n_x=n_x, n_u=n_u, n_nodal=len(jax_constraints.nodal))
         self._jax_constraints = jax_constraints
-
-    def lower_convex_constraints(
-        self,
-        constraints: "ConstraintSet",
-        parameters: Optional[Dict] = None,
-    ) -> Tuple[List, Dict]:
-        """Absorb auto-generated impulsive zero-pin constraints; refuse the rest.
-
-        :func:`openscvx.symbolic.lower._augment_impulsive_constraints` injects
-        ``Control == 0`` equalities at non-impulse nodes for every impulsive
-        control. Those constraints live in ``constraints.nodal_convex`` even
-        though no user ``.convex()`` was written; we recognize their fixed
-        shape and stash a pin list for the structural pass / assembler to
-        emit as plain zero-cone rows. Anything that doesn't match the
-        auto-augmentation shape (e.g. a genuine user ``.convex()`` SOC) falls
-        through to the default refusal in :class:`ConvexSolver`.
-        """
-        pins = self._extract_impulsive_pins(constraints)
-        if pins is None:
-            return super().lower_convex_constraints(constraints, parameters)
-        self._impulsive_pins = pins
-        return [], {}
 
     def initialize(self, lowered: "LoweredProblem", settings: "Config") -> None:
         """Build the static conic structure and construct ``moreau.jax.Solver``.
@@ -834,6 +821,17 @@ class MoreauPTRSolver(PTRSolver):
                     add(row, L.u_idx(node, j))
                     row += 1
 
+        # User ZeroConeConstraint rows (hard equality, one row per scalar output).
+        for cc in self._user_cone_constraints:
+            if isinstance(cc, ZeroConeConstraint):
+                for k in cc.nodes:
+                    for _ in range(cc.m):
+                        for j in range(n_x):
+                            add(row, L.dx_idx(k, j))
+                        for j in range(n_u):
+                            add(row, L.du_idx(k, j))
+                        row += 1
+
         # Uniform time grid: u[k,j] − u[k-1,j] = 0
         if settings.sim._uniform_time_grid:
             td = settings.sim.time_dilation_slice
@@ -907,6 +905,17 @@ class MoreauPTRSolver(PTRSolver):
                 add(row, L.t_vb_idx(c_idx, k))
                 row += 1
 
+        # User NonnegConeConstraint rows.
+        for cc in self._user_cone_constraints:
+            if isinstance(cc, NonnegConeConstraint):
+                for k in cc.nodes:
+                    for _ in range(cc.m):
+                        for j in range(n_x):
+                            add(row, L.dx_idx(k, j))
+                        for j in range(n_u):
+                            add(row, L.du_idx(k, j))
+                        row += 1
+
         n_nn = row - n_eq
 
         # ================================================================
@@ -922,6 +931,22 @@ class MoreauPTRSolver(PTRSolver):
                 add(row, L.nu_idx(k, j))
                 row += 1
                 soc_dims.append(2)
+
+        # User SOCConstraint rows: each node contributes SOC(m_arg + 1).
+        # Row layout: [bound, arg[0], arg[1], ..., arg[m_arg-1]].
+        # Moreau convention s = b - Az ∈ K_soc: ‖s[1:]‖ ≤ s[0].
+        # Since arg and bound are affine in (x, u), columns are dx[k, :] and du[k, :].
+        for cc in self._user_cone_constraints:
+            if isinstance(cc, SOCConstraint):
+                soc_dim = cc.m_arg + 1
+                for k in cc.nodes:
+                    for _ in range(soc_dim):
+                        for j in range(n_x):
+                            add(row, L.dx_idx(k, j))
+                        for j in range(n_u):
+                            add(row, L.du_idx(k, j))
+                        row += 1
+                    soc_dims.append(soc_dim)
 
         return coo_rows, coo_cols, n_eq, n_nn, soc_dims
 
@@ -1123,6 +1148,28 @@ class MoreauPTRSolver(PTRSolver):
                 for j in range(ctrl_slice.start, ctrl_slice.stop):
                     emit([1.0], -inv_S_u[j] * c_u[j])
 
+        # User ZeroConeConstraint rows.
+        # Linearize: (J_x·S_x)·dx_scaled + (J_u·S_u)·du_scaled = -f0.
+        # Jacobians are w.r.t. physical x/u; dx_scaled = Δx_phys / S_x, so
+        # the coefficient for dx_scaled[k, j] is J_x_phys[i, j] * S_x[j].
+        params = self._parameters_dict
+        for cc in self._user_cone_constraints:
+            if isinstance(cc, ZeroConeConstraint):
+                for k in cc.nodes:
+                    x_k = x_bar[k]
+                    u_k = u_bar[k]
+                    f0 = np.asarray(cc.jax_fn(x_k, u_k, k, params), dtype=float).reshape(cc.m)
+                    J_x = np.asarray(
+                        jax.jacfwd(cc.jax_fn, argnums=0)(x_k, u_k, k, params), dtype=float
+                    ).reshape(cc.m, n_x) * S_x[None, :]
+                    J_u = np.asarray(
+                        jax.jacfwd(cc.jax_fn, argnums=1)(x_k, u_k, k, params), dtype=float
+                    ).reshape(cc.m, n_u) * S_u[None, :]
+                    rhs = -f0
+                    for i in range(cc.m):
+                        coeffs = list(J_x[i]) + list(J_u[i])
+                        emit(coeffs, float(rhs[i]))
+
         # Uniform time grid: u[k,j] − u[k-1,j] = 0
         if settings.sim._uniform_time_grid:
             td = settings.sim.time_dilation_slice
@@ -1193,6 +1240,27 @@ class MoreauPTRSolver(PTRSolver):
             for k in range(N):
                 emit([-1.0], 0.0)  # s = 0 − (−t_vb) = t_vb ≥ 0
 
+        # User NonnegConeConstraint rows.
+        # s = b − Az ≥ 0;  A = J·S (scaled Jacobian), b = -f0.
+        # Jacobians are w.r.t. physical x/u; multiply by S_x/S_u to get
+        # coefficients for the scaled decision variables dx_scaled / du_scaled.
+        for cc in self._user_cone_constraints:
+            if isinstance(cc, NonnegConeConstraint):
+                for k in cc.nodes:
+                    x_k = x_bar[k]
+                    u_k = u_bar[k]
+                    f0 = np.asarray(cc.jax_fn(x_k, u_k, k, params), dtype=float).reshape(cc.m)
+                    J_x = np.asarray(
+                        jax.jacfwd(cc.jax_fn, argnums=0)(x_k, u_k, k, params), dtype=float
+                    ).reshape(cc.m, n_x) * S_x[None, :]
+                    J_u = np.asarray(
+                        jax.jacfwd(cc.jax_fn, argnums=1)(x_k, u_k, k, params), dtype=float
+                    ).reshape(cc.m, n_u) * S_u[None, :]
+                    rhs = -f0
+                    for i in range(cc.m):
+                        coeffs = list(J_x[i]) + list(J_u[i])
+                        emit(coeffs, float(rhs[i]))
+
         # ================================================================
         # SOC rows: SOC(2) for |nu[k,j]| ≤ t_vc[k,j]
         # s = b − Az: row 0 has only t_vc (coeff −1), row 1 has only nu (coeff −1)
@@ -1203,6 +1271,39 @@ class MoreauPTRSolver(PTRSolver):
             for j in range(n_x):
                 emit([-1.0], 0.0)  # row for t_vc
                 emit([-1.0], 0.0)  # row for nu
+
+        # User SOCConstraint rows: SOC(m_arg + 1) per node.
+        # Layout: [bound_row, arg_row_0, …, arg_row_{m_arg-1}].
+        # Moreau convention: s = b − Az ∈ K_soc, ‖s[1:]‖ ≤ s[0].
+        # Linearized: s[0] = bound0 + J_b·Δ, s[1+i] = arg0[i] + J_a[i]·Δ.
+        # s = b − A·z → A = −J·S, b = val.  Jacobians scaled by S_x/S_u to
+        # convert from physical-space to scaled-decision-variable coefficients.
+        for cc in self._user_cone_constraints:
+            if isinstance(cc, SOCConstraint):
+                for k in cc.nodes:
+                    x_k = x_bar[k]
+                    u_k = u_bar[k]
+                    # Bound function.
+                    bound0 = float(np.asarray(cc.bound_fn(x_k, u_k, k, params)))
+                    Jb_x = np.asarray(
+                        jax.jacfwd(cc.bound_fn, argnums=0)(x_k, u_k, k, params), dtype=float
+                    ).reshape(n_x) * S_x
+                    Jb_u = np.asarray(
+                        jax.jacfwd(cc.bound_fn, argnums=1)(x_k, u_k, k, params), dtype=float
+                    ).reshape(n_u) * S_u
+                    # Arg function.
+                    arg0 = np.asarray(cc.arg_fn(x_k, u_k, k, params), dtype=float).reshape(cc.m_arg)
+                    Ja_x = np.asarray(
+                        jax.jacfwd(cc.arg_fn, argnums=0)(x_k, u_k, k, params), dtype=float
+                    ).reshape(cc.m_arg, n_x) * S_x[None, :]
+                    Ja_u = np.asarray(
+                        jax.jacfwd(cc.arg_fn, argnums=1)(x_k, u_k, k, params), dtype=float
+                    ).reshape(cc.m_arg, n_u) * S_u[None, :]
+                    # Bound row: A = −J_b·S, b = bound0  →  s[0] = bound0 + J_b·Δ.
+                    emit(list(-Jb_x) + list(-Jb_u), bound0)
+                    # Arg rows: A = −J_a[i]·S, b = arg0[i]  →  s[1+i] = arg0[i] + J_a[i]·Δ.
+                    for i in range(cc.m_arg):
+                        emit(list(-Ja_x[i]) + list(-Ja_u[i]), float(arg0[i]))
 
         return (
             P_data,
@@ -1461,6 +1562,26 @@ class MoreauPTRSolver(PTRSolver):
                     coo_blocks.append(jnp.asarray([1.0], dtype=f))
                     b_blocks.append((-inv_S_u[j] * c_u[j])[None])
 
+        # User ZeroConeConstraint rows (hard equality).
+        # Coefficients scaled by S_x/S_u: dx_scaled = Δx_phys / S_x, so the
+        # coefficient for dx_scaled[k, j] is J_x_phys[i, j] * S_x[j].
+        params_user = self._parameters_dict
+        for cc in self._user_cone_constraints:
+            if isinstance(cc, ZeroConeConstraint):
+                for k in cc.nodes:
+                    x_k = data.x_bar[k]
+                    u_k = data.u_bar[k]
+                    f0 = jnp.reshape(cc.jax_fn(x_k, u_k, k, params_user), (cc.m,))
+                    J_x = jnp.reshape(
+                        jax.jacfwd(cc.jax_fn, argnums=0)(x_k, u_k, k, params_user), (cc.m, n_x)
+                    ) * S_x[None, :]
+                    J_u = jnp.reshape(
+                        jax.jacfwd(cc.jax_fn, argnums=1)(x_k, u_k, k, params_user), (cc.m, n_u)
+                    ) * S_u[None, :]
+                    row_vals = jnp.concatenate([J_x, J_u], axis=1)  # (cc.m, n_x+n_u)
+                    coo_blocks.append(row_vals.reshape(-1))
+                    b_blocks.append(-f0)
+
         # Uniform time grid: u[k, j] - u[k-1, j] = 0.
         if sim._uniform_time_grid:
             td = sim.time_dilation_slice
@@ -1523,11 +1644,62 @@ class MoreauPTRSolver(PTRSolver):
             coo_blocks.append(jnp.full((N,), -1.0, dtype=f))
             b_blocks.append(jnp.zeros((N,), dtype=f))
 
+        # User NonnegConeConstraint rows.
+        # Jacobians scaled by S_x/S_u for the dx_scaled / du_scaled convention.
+        for cc in self._user_cone_constraints:
+            if isinstance(cc, NonnegConeConstraint):
+                for k in cc.nodes:
+                    x_k = data.x_bar[k]
+                    u_k = data.u_bar[k]
+                    f0 = jnp.reshape(cc.jax_fn(x_k, u_k, k, params_user), (cc.m,))
+                    J_x = jnp.reshape(
+                        jax.jacfwd(cc.jax_fn, argnums=0)(x_k, u_k, k, params_user), (cc.m, n_x)
+                    ) * S_x[None, :]
+                    J_u = jnp.reshape(
+                        jax.jacfwd(cc.jax_fn, argnums=1)(x_k, u_k, k, params_user), (cc.m, n_u)
+                    ) * S_u[None, :]
+                    row_vals = jnp.concatenate([J_x, J_u], axis=1)
+                    coo_blocks.append(row_vals.reshape(-1))
+                    b_blocks.append(-f0)
+
         # SOC: 2 rows per |nu| pair, coeffs [-1] each (t_vc row, then nu row).
         n_soc = 2 * (N - 1) * n_x
         soc_coeffs = jnp.full((n_soc,), -1.0, dtype=f)
         coo_blocks.append(soc_coeffs)
         b_blocks.append(jnp.zeros((n_soc,), dtype=f))
+
+        # User SOCConstraint rows: SOC(m_arg + 1) per node.
+        # Bound row:  A = −J_b·S, b = bound0  →  s[0] = b − A·z = bound0 + J_b·Δ.
+        # Arg rows:   A = −J_a[i]·S, b = arg0[i].
+        # Jacobians scaled by S_x/S_u to convert physical Jacobians to
+        # coefficients for scaled decision variables dx_scaled / du_scaled.
+        for cc in self._user_cone_constraints:
+            if isinstance(cc, SOCConstraint):
+                for k in cc.nodes:
+                    x_k = data.x_bar[k]
+                    u_k = data.u_bar[k]
+                    bound0 = jnp.reshape(cc.bound_fn(x_k, u_k, k, params_user), ())
+                    Jb_x = jnp.reshape(
+                        jax.jacfwd(cc.bound_fn, argnums=0)(x_k, u_k, k, params_user), (n_x,)
+                    ) * S_x
+                    Jb_u = jnp.reshape(
+                        jax.jacfwd(cc.bound_fn, argnums=1)(x_k, u_k, k, params_user), (n_u,)
+                    ) * S_u
+                    arg0 = jnp.reshape(cc.arg_fn(x_k, u_k, k, params_user), (cc.m_arg,))
+                    Ja_x = jnp.reshape(
+                        jax.jacfwd(cc.arg_fn, argnums=0)(x_k, u_k, k, params_user), (cc.m_arg, n_x)
+                    ) * S_x[None, :]
+                    Ja_u = jnp.reshape(
+                        jax.jacfwd(cc.arg_fn, argnums=1)(x_k, u_k, k, params_user), (cc.m_arg, n_u)
+                    ) * S_u[None, :]
+                    # Bound row A coeffs (negated, concatenated x then u).
+                    bound_A = jnp.concatenate([-Jb_x, -Jb_u])  # (n_x + n_u,)
+                    coo_blocks.append(bound_A)
+                    b_blocks.append(bound0[None])
+                    # Arg rows A coeffs (negated).
+                    arg_A = jnp.concatenate([-Ja_x, -Ja_u], axis=1)  # (m_arg, n_x+n_u)
+                    coo_blocks.append(arg_A.reshape(-1))
+                    b_blocks.append(arg0)
 
         coo_vals = jnp.concatenate(coo_blocks) if coo_blocks else jnp.zeros((0,), dtype=f)
         b_vec = jnp.concatenate(b_blocks) if b_blocks else jnp.zeros((0,), dtype=f)

--- a/openscvx/solvers/moreau_ptr_solver.py
+++ b/openscvx/solvers/moreau_ptr_solver.py
@@ -67,6 +67,7 @@ from .cones import NonnegConeConstraint, SOCConstraint, ZeroConeConstraint
 from .ptr_solver import (
     PTRSolver,
     PTRSolveResult,
+    ParamFixPin,
     StatusCode,
     SubproblemData,
     SubproblemSolution,
@@ -493,6 +494,9 @@ class MoreauPTRSolver(PTRSolver):
 
         self.layout = _ConicLayout(N=N, n_x=n_x, n_u=n_u, n_nodal=len(jax_constraints.nodal))
         self._jax_constraints = jax_constraints
+        self._x_unified = x_unified
+
+
 
     def initialize(self, lowered: "LoweredProblem", settings: "Config") -> None:
         """Build the static conic structure and construct ``moreau.jax.Solver``.

--- a/openscvx/solvers/moreau_ptr_solver.py
+++ b/openscvx/solvers/moreau_ptr_solver.py
@@ -93,7 +93,6 @@ if TYPE_CHECKING:
     from openscvx.lowered import LoweredProblem
     from openscvx.lowered.jax_constraints import LoweredJaxConstraints
     from openscvx.lowered.unified import UnifiedControl, UnifiedState
-    from openscvx.symbolic.constraint_set import ConstraintSet
 
 # Tiny diagonal regularisation added to P on dx/du slots.  Moreau's IPM
 # Cholesky factors (P + Gᵀ diag(z/s) G); keeping the diagonal positive avoids
@@ -494,8 +493,6 @@ class MoreauPTRSolver(PTRSolver):
         self.layout = _ConicLayout(N=N, n_x=n_x, n_u=n_u, n_nodal=len(jax_constraints.nodal))
         self._jax_constraints = jax_constraints
         self._x_unified = x_unified
-
-
 
     def initialize(self, lowered: "LoweredProblem", settings: "Config") -> None:
         """Build the static conic structure and construct ``moreau.jax.Solver``.
@@ -1162,12 +1159,18 @@ class MoreauPTRSolver(PTRSolver):
                     x_k = x_bar[k]
                     u_k = u_bar[k]
                     f0 = np.asarray(cc.jax_fn(x_k, u_k, k, params), dtype=float).reshape(cc.m)
-                    J_x = np.asarray(
-                        jax.jacfwd(cc.jax_fn, argnums=0)(x_k, u_k, k, params), dtype=float
-                    ).reshape(cc.m, n_x) * S_x[None, :]
-                    J_u = np.asarray(
-                        jax.jacfwd(cc.jax_fn, argnums=1)(x_k, u_k, k, params), dtype=float
-                    ).reshape(cc.m, n_u) * S_u[None, :]
+                    J_x = (
+                        np.asarray(
+                            jax.jacfwd(cc.jax_fn, argnums=0)(x_k, u_k, k, params), dtype=float
+                        ).reshape(cc.m, n_x)
+                        * S_x[None, :]
+                    )
+                    J_u = (
+                        np.asarray(
+                            jax.jacfwd(cc.jax_fn, argnums=1)(x_k, u_k, k, params), dtype=float
+                        ).reshape(cc.m, n_u)
+                        * S_u[None, :]
+                    )
                     rhs = -f0
                     for i in range(cc.m):
                         coeffs = list(J_x[i]) + list(J_u[i])
@@ -1253,12 +1256,18 @@ class MoreauPTRSolver(PTRSolver):
                     x_k = x_bar[k]
                     u_k = u_bar[k]
                     f0 = np.asarray(cc.jax_fn(x_k, u_k, k, params), dtype=float).reshape(cc.m)
-                    J_x = np.asarray(
-                        jax.jacfwd(cc.jax_fn, argnums=0)(x_k, u_k, k, params), dtype=float
-                    ).reshape(cc.m, n_x) * S_x[None, :]
-                    J_u = np.asarray(
-                        jax.jacfwd(cc.jax_fn, argnums=1)(x_k, u_k, k, params), dtype=float
-                    ).reshape(cc.m, n_u) * S_u[None, :]
+                    J_x = (
+                        np.asarray(
+                            jax.jacfwd(cc.jax_fn, argnums=0)(x_k, u_k, k, params), dtype=float
+                        ).reshape(cc.m, n_x)
+                        * S_x[None, :]
+                    )
+                    J_u = (
+                        np.asarray(
+                            jax.jacfwd(cc.jax_fn, argnums=1)(x_k, u_k, k, params), dtype=float
+                        ).reshape(cc.m, n_u)
+                        * S_u[None, :]
+                    )
                     rhs = -f0
                     for i in range(cc.m):
                         coeffs = list(J_x[i]) + list(J_u[i])
@@ -1288,20 +1297,32 @@ class MoreauPTRSolver(PTRSolver):
                     u_k = u_bar[k]
                     # Bound function.
                     bound0 = float(np.asarray(cc.bound_fn(x_k, u_k, k, params)))
-                    Jb_x = np.asarray(
-                        jax.jacfwd(cc.bound_fn, argnums=0)(x_k, u_k, k, params), dtype=float
-                    ).reshape(n_x) * S_x
-                    Jb_u = np.asarray(
-                        jax.jacfwd(cc.bound_fn, argnums=1)(x_k, u_k, k, params), dtype=float
-                    ).reshape(n_u) * S_u
+                    Jb_x = (
+                        np.asarray(
+                            jax.jacfwd(cc.bound_fn, argnums=0)(x_k, u_k, k, params), dtype=float
+                        ).reshape(n_x)
+                        * S_x
+                    )
+                    Jb_u = (
+                        np.asarray(
+                            jax.jacfwd(cc.bound_fn, argnums=1)(x_k, u_k, k, params), dtype=float
+                        ).reshape(n_u)
+                        * S_u
+                    )
                     # Arg function.
                     arg0 = np.asarray(cc.arg_fn(x_k, u_k, k, params), dtype=float).reshape(cc.m_arg)
-                    Ja_x = np.asarray(
-                        jax.jacfwd(cc.arg_fn, argnums=0)(x_k, u_k, k, params), dtype=float
-                    ).reshape(cc.m_arg, n_x) * S_x[None, :]
-                    Ja_u = np.asarray(
-                        jax.jacfwd(cc.arg_fn, argnums=1)(x_k, u_k, k, params), dtype=float
-                    ).reshape(cc.m_arg, n_u) * S_u[None, :]
+                    Ja_x = (
+                        np.asarray(
+                            jax.jacfwd(cc.arg_fn, argnums=0)(x_k, u_k, k, params), dtype=float
+                        ).reshape(cc.m_arg, n_x)
+                        * S_x[None, :]
+                    )
+                    Ja_u = (
+                        np.asarray(
+                            jax.jacfwd(cc.arg_fn, argnums=1)(x_k, u_k, k, params), dtype=float
+                        ).reshape(cc.m_arg, n_u)
+                        * S_u[None, :]
+                    )
                     # Bound row: A = −J_b·S, b = bound0  →  s[0] = bound0 + J_b·Δ.
                     emit(list(-Jb_x) + list(-Jb_u), bound0)
                     # Arg rows: A = −J_a[i]·S, b = arg0[i]  →  s[1+i] = arg0[i] + J_a[i]·Δ.
@@ -1575,12 +1596,18 @@ class MoreauPTRSolver(PTRSolver):
                     x_k = data.x_bar[k]
                     u_k = data.u_bar[k]
                     f0 = jnp.reshape(cc.jax_fn(x_k, u_k, k, params_user), (cc.m,))
-                    J_x = jnp.reshape(
-                        jax.jacfwd(cc.jax_fn, argnums=0)(x_k, u_k, k, params_user), (cc.m, n_x)
-                    ) * S_x[None, :]
-                    J_u = jnp.reshape(
-                        jax.jacfwd(cc.jax_fn, argnums=1)(x_k, u_k, k, params_user), (cc.m, n_u)
-                    ) * S_u[None, :]
+                    J_x = (
+                        jnp.reshape(
+                            jax.jacfwd(cc.jax_fn, argnums=0)(x_k, u_k, k, params_user), (cc.m, n_x)
+                        )
+                        * S_x[None, :]
+                    )
+                    J_u = (
+                        jnp.reshape(
+                            jax.jacfwd(cc.jax_fn, argnums=1)(x_k, u_k, k, params_user), (cc.m, n_u)
+                        )
+                        * S_u[None, :]
+                    )
                     row_vals = jnp.concatenate([J_x, J_u], axis=1)  # (cc.m, n_x+n_u)
                     coo_blocks.append(row_vals.reshape(-1))
                     b_blocks.append(-f0)
@@ -1655,12 +1682,18 @@ class MoreauPTRSolver(PTRSolver):
                     x_k = data.x_bar[k]
                     u_k = data.u_bar[k]
                     f0 = jnp.reshape(cc.jax_fn(x_k, u_k, k, params_user), (cc.m,))
-                    J_x = jnp.reshape(
-                        jax.jacfwd(cc.jax_fn, argnums=0)(x_k, u_k, k, params_user), (cc.m, n_x)
-                    ) * S_x[None, :]
-                    J_u = jnp.reshape(
-                        jax.jacfwd(cc.jax_fn, argnums=1)(x_k, u_k, k, params_user), (cc.m, n_u)
-                    ) * S_u[None, :]
+                    J_x = (
+                        jnp.reshape(
+                            jax.jacfwd(cc.jax_fn, argnums=0)(x_k, u_k, k, params_user), (cc.m, n_x)
+                        )
+                        * S_x[None, :]
+                    )
+                    J_u = (
+                        jnp.reshape(
+                            jax.jacfwd(cc.jax_fn, argnums=1)(x_k, u_k, k, params_user), (cc.m, n_u)
+                        )
+                        * S_u[None, :]
+                    )
                     row_vals = jnp.concatenate([J_x, J_u], axis=1)
                     coo_blocks.append(row_vals.reshape(-1))
                     b_blocks.append(-f0)
@@ -1682,19 +1715,33 @@ class MoreauPTRSolver(PTRSolver):
                     x_k = data.x_bar[k]
                     u_k = data.u_bar[k]
                     bound0 = jnp.reshape(cc.bound_fn(x_k, u_k, k, params_user), ())
-                    Jb_x = jnp.reshape(
-                        jax.jacfwd(cc.bound_fn, argnums=0)(x_k, u_k, k, params_user), (n_x,)
-                    ) * S_x
-                    Jb_u = jnp.reshape(
-                        jax.jacfwd(cc.bound_fn, argnums=1)(x_k, u_k, k, params_user), (n_u,)
-                    ) * S_u
+                    Jb_x = (
+                        jnp.reshape(
+                            jax.jacfwd(cc.bound_fn, argnums=0)(x_k, u_k, k, params_user), (n_x,)
+                        )
+                        * S_x
+                    )
+                    Jb_u = (
+                        jnp.reshape(
+                            jax.jacfwd(cc.bound_fn, argnums=1)(x_k, u_k, k, params_user), (n_u,)
+                        )
+                        * S_u
+                    )
                     arg0 = jnp.reshape(cc.arg_fn(x_k, u_k, k, params_user), (cc.m_arg,))
-                    Ja_x = jnp.reshape(
-                        jax.jacfwd(cc.arg_fn, argnums=0)(x_k, u_k, k, params_user), (cc.m_arg, n_x)
-                    ) * S_x[None, :]
-                    Ja_u = jnp.reshape(
-                        jax.jacfwd(cc.arg_fn, argnums=1)(x_k, u_k, k, params_user), (cc.m_arg, n_u)
-                    ) * S_u[None, :]
+                    Ja_x = (
+                        jnp.reshape(
+                            jax.jacfwd(cc.arg_fn, argnums=0)(x_k, u_k, k, params_user),
+                            (cc.m_arg, n_x),
+                        )
+                        * S_x[None, :]
+                    )
+                    Ja_u = (
+                        jnp.reshape(
+                            jax.jacfwd(cc.arg_fn, argnums=1)(x_k, u_k, k, params_user),
+                            (cc.m_arg, n_u),
+                        )
+                        * S_u[None, :]
+                    )
                     # Bound row A coeffs (negated, concatenated x then u).
                     bound_A = jnp.concatenate([-Jb_x, -Jb_u])  # (n_x + n_u,)
                     coo_blocks.append(bound_A)

--- a/openscvx/solvers/ptr_solver.py
+++ b/openscvx/solvers/ptr_solver.py
@@ -56,6 +56,30 @@ if TYPE_CHECKING:
 
 
 # ---------------------------------------------------------------------------
+# Param-fix pin descriptor
+# ---------------------------------------------------------------------------
+
+
+class ParamFixPin(NamedTuple):
+    """Boundary-condition pin derived from a ``(State == Parameter).convex().at([0/N-1])`` constraint.
+
+    Attributes:
+        state_slice: Absolute slice into the unified-state vector for the
+            pinned components. For a full-state pin this equals
+            ``state._slice``; for a sub-slice pin (e.g. ``position[1:3]``)
+            it is offset by ``state._slice.start``.
+        param_name: Name of the ``Parameter`` whose runtime value drives
+            the pin.
+        node_type: ``"init"`` for a node-0 pin; ``"term"`` for a node-N-1
+            pin.
+    """
+
+    state_slice: slice
+    param_name: str
+    node_type: str  # "init" or "term"
+
+
+# ---------------------------------------------------------------------------
 # Status codes
 # ---------------------------------------------------------------------------
 
@@ -593,6 +617,118 @@ class PTRSolver(ConvexSolver):
                 return None
             pins.append(([int(k) for k in entry.nodes], lhs._slice))
         return pins
+
+    @staticmethod
+    def _classify_nodal_convex(
+        constraints: "ConstraintSet",
+        N: int,
+    ) -> Optional[Tuple[List[Tuple[List[int], slice]], List[ParamFixPin]]]:
+        """Classify every ``nodal_convex`` entry as an impulsive or param-fix pin.
+
+        Returns ``(impulsive_pins, param_fix_pins)`` when every entry in
+        ``constraints.nodal_convex`` is recognised as one of:
+
+        * **Impulsive zero-pin** — ``NodalConstraint(Equality(Control[s], 0), nodes)``,
+          auto-injected by
+          :func:`openscvx.symbolic.lower._augment_impulsive_constraints`.
+        * **Param-fix pin** — ``NodalConstraint(Equality(lhs, Parameter), nodes=[0])``
+          or ``nodes=[N-1]``, where *lhs* is either a ``State`` or an
+          ``Index(State, slice)``.  Accepts both the original form and the
+          canonicalised form ``Equality(Sub(lhs, Parameter), Constant(0))``.
+
+        Returns ``None`` if any entry does not match either shape, so the
+        caller can fall back to ``super().lower_convex_constraints()``.
+        """
+        from openscvx.symbolic.expr.arithmetic import Sub
+        from openscvx.symbolic.expr.array import Index
+        from openscvx.symbolic.expr.constraint import Equality, NodalConstraint
+        from openscvx.symbolic.expr.control import Control
+        from openscvx.symbolic.expr.expr import Constant
+        from openscvx.symbolic.expr.parameter import Parameter
+        from openscvx.symbolic.expr.state import State
+
+        def _unwrap_state_param(
+            lhs: "Expr", rhs: "Expr"
+        ) -> Optional[Tuple["Expr", "Parameter"]]:
+            """Return (state_expr, param) from either:
+
+            * original form  ``lhs=State/Index(State), rhs=Parameter``
+            * canonical form ``lhs=Sub(State/Index(State), Parameter), rhs=Constant(0)``
+            """
+            if isinstance(rhs, Parameter):
+                return lhs, rhs
+            if (
+                isinstance(lhs, Sub)
+                and isinstance(rhs, Constant)
+                and np.all(np.asarray(rhs.value) == 0)
+                and isinstance(lhs.right, Parameter)
+            ):
+                return lhs.left, lhs.right
+            return None
+
+        if constraints.cross_node_convex:
+            return None
+
+        impulsive: List[Tuple[List[int], slice]] = []
+        param_fix: List[ParamFixPin] = []
+
+        for entry in constraints.nodal_convex:
+            if not isinstance(entry, NodalConstraint):
+                return None
+            inner = entry.constraint
+            if not isinstance(inner, Equality):
+                return None
+            lhs, rhs = inner.lhs, inner.rhs
+
+            # -- Impulsive zero-pin: Control[s] == 0 --
+            if (
+                isinstance(lhs, Control)
+                and lhs._slice is not None
+                and isinstance(rhs, Constant)
+                and np.all(np.asarray(rhs.value) == 0)
+            ):
+                impulsive.append(([int(k) for k in entry.nodes], lhs._slice))
+                continue
+
+            # -- Param-fix pin: (State or State[s1:s2]) == Parameter at node 0 or N-1 --
+            nodes = entry.nodes
+            if nodes == [0]:
+                node_type = "init"
+            elif nodes == [N - 1]:
+                node_type = "term"
+            else:
+                return None  # multi-node or mid-trajectory — not supported
+
+            unwrapped = _unwrap_state_param(lhs, rhs)
+            if unwrapped is None:
+                return None
+            state_expr, param = unwrapped
+
+            if isinstance(state_expr, State) and state_expr._slice is not None:
+                state_unified_slice = state_expr._slice
+            elif (
+                isinstance(state_expr, Index)
+                and isinstance(state_expr.base, State)
+                and state_expr.base._slice is not None
+                and isinstance(state_expr.index, slice)
+            ):
+                state_start = state_expr.base._slice.start
+                sub_start, sub_stop, sub_step = state_expr.index.indices(state_expr.base._shape[0])
+                if sub_step != 1:
+                    return None
+                state_unified_slice = slice(state_start + sub_start, state_start + sub_stop)
+            else:
+                return None
+
+            param_fix.append(
+                ParamFixPin(
+                    state_slice=state_unified_slice,
+                    param_name=param.name,
+                    node_type=node_type,
+                )
+            )
+
+        return impulsive, param_fix
 
     @staticmethod
     def _scaling(unified: Union["UnifiedState", "UnifiedControl"]) -> Tuple[np.ndarray, np.ndarray]:

--- a/openscvx/solvers/ptr_solver.py
+++ b/openscvx/solvers/ptr_solver.py
@@ -56,30 +56,6 @@ if TYPE_CHECKING:
 
 
 # ---------------------------------------------------------------------------
-# Param-fix pin descriptor
-# ---------------------------------------------------------------------------
-
-
-class ParamFixPin(NamedTuple):
-    """Boundary-condition pin derived from a ``(State == Parameter).convex().at([0/N-1])`` constraint.
-
-    Attributes:
-        state_slice: Absolute slice into the unified-state vector for the
-            pinned components. For a full-state pin this equals
-            ``state._slice``; for a sub-slice pin (e.g. ``position[1:3]``)
-            it is offset by ``state._slice.start``.
-        param_name: Name of the ``Parameter`` whose runtime value drives
-            the pin.
-        node_type: ``"init"`` for a node-0 pin; ``"term"`` for a node-N-1
-            pin.
-    """
-
-    state_slice: slice
-    param_name: str
-    node_type: str  # "init" or "term"
-
-
-# ---------------------------------------------------------------------------
 # Status codes
 # ---------------------------------------------------------------------------
 
@@ -175,6 +151,10 @@ class SubproblemData:
         lam_vb_cross: Cross-node virtual-buffer weights, shape ``(n_cross,)``.
         x_init: Initial state, shape ``(n_x,)``. ``jnp.nan`` sentinel where free.
         x_term: Terminal state, shape ``(n_x,)``. ``jnp.nan`` sentinel where free.
+        params: Runtime parameters dict from the outer solve loop.  Threaded
+            here so JAX-pure assembly functions see the per-batch vmapped
+            parameter values (e.g. ``initial_position[b]``) rather than the
+            frozen ``_parameters_dict`` captured at initialisation.
     """
 
     x_bar: jnp.ndarray
@@ -199,6 +179,10 @@ class SubproblemData:
     lam_vb_cross: jnp.ndarray
     x_init: jnp.ndarray
     x_term: jnp.ndarray
+    #: Runtime parameters dict forwarded from the outer solve loop so that
+    #: JAX-pure assembly paths (``_assemble_conic_jax``, ``_assemble_qp_jax``)
+    #: see the per-batch vmapped values rather than the frozen init-time copy.
+    params: dict
 
     def tree_flatten(self):
         children = tuple(getattr(self, f.name) for f in fields(self))
@@ -617,118 +601,6 @@ class PTRSolver(ConvexSolver):
                 return None
             pins.append(([int(k) for k in entry.nodes], lhs._slice))
         return pins
-
-    @staticmethod
-    def _classify_nodal_convex(
-        constraints: "ConstraintSet",
-        N: int,
-    ) -> Optional[Tuple[List[Tuple[List[int], slice]], List[ParamFixPin]]]:
-        """Classify every ``nodal_convex`` entry as an impulsive or param-fix pin.
-
-        Returns ``(impulsive_pins, param_fix_pins)`` when every entry in
-        ``constraints.nodal_convex`` is recognised as one of:
-
-        * **Impulsive zero-pin** — ``NodalConstraint(Equality(Control[s], 0), nodes)``,
-          auto-injected by
-          :func:`openscvx.symbolic.lower._augment_impulsive_constraints`.
-        * **Param-fix pin** — ``NodalConstraint(Equality(lhs, Parameter), nodes=[0])``
-          or ``nodes=[N-1]``, where *lhs* is either a ``State`` or an
-          ``Index(State, slice)``.  Accepts both the original form and the
-          canonicalised form ``Equality(Sub(lhs, Parameter), Constant(0))``.
-
-        Returns ``None`` if any entry does not match either shape, so the
-        caller can fall back to ``super().lower_convex_constraints()``.
-        """
-        from openscvx.symbolic.expr.arithmetic import Sub
-        from openscvx.symbolic.expr.array import Index
-        from openscvx.symbolic.expr.constraint import Equality, NodalConstraint
-        from openscvx.symbolic.expr.control import Control
-        from openscvx.symbolic.expr.expr import Constant
-        from openscvx.symbolic.expr.parameter import Parameter
-        from openscvx.symbolic.expr.state import State
-
-        def _unwrap_state_param(
-            lhs: "Expr", rhs: "Expr"
-        ) -> Optional[Tuple["Expr", "Parameter"]]:
-            """Return (state_expr, param) from either:
-
-            * original form  ``lhs=State/Index(State), rhs=Parameter``
-            * canonical form ``lhs=Sub(State/Index(State), Parameter), rhs=Constant(0)``
-            """
-            if isinstance(rhs, Parameter):
-                return lhs, rhs
-            if (
-                isinstance(lhs, Sub)
-                and isinstance(rhs, Constant)
-                and np.all(np.asarray(rhs.value) == 0)
-                and isinstance(lhs.right, Parameter)
-            ):
-                return lhs.left, lhs.right
-            return None
-
-        if constraints.cross_node_convex:
-            return None
-
-        impulsive: List[Tuple[List[int], slice]] = []
-        param_fix: List[ParamFixPin] = []
-
-        for entry in constraints.nodal_convex:
-            if not isinstance(entry, NodalConstraint):
-                return None
-            inner = entry.constraint
-            if not isinstance(inner, Equality):
-                return None
-            lhs, rhs = inner.lhs, inner.rhs
-
-            # -- Impulsive zero-pin: Control[s] == 0 --
-            if (
-                isinstance(lhs, Control)
-                and lhs._slice is not None
-                and isinstance(rhs, Constant)
-                and np.all(np.asarray(rhs.value) == 0)
-            ):
-                impulsive.append(([int(k) for k in entry.nodes], lhs._slice))
-                continue
-
-            # -- Param-fix pin: (State or State[s1:s2]) == Parameter at node 0 or N-1 --
-            nodes = entry.nodes
-            if nodes == [0]:
-                node_type = "init"
-            elif nodes == [N - 1]:
-                node_type = "term"
-            else:
-                return None  # multi-node or mid-trajectory — not supported
-
-            unwrapped = _unwrap_state_param(lhs, rhs)
-            if unwrapped is None:
-                return None
-            state_expr, param = unwrapped
-
-            if isinstance(state_expr, State) and state_expr._slice is not None:
-                state_unified_slice = state_expr._slice
-            elif (
-                isinstance(state_expr, Index)
-                and isinstance(state_expr.base, State)
-                and state_expr.base._slice is not None
-                and isinstance(state_expr.index, slice)
-            ):
-                state_start = state_expr.base._slice.start
-                sub_start, sub_stop, sub_step = state_expr.index.indices(state_expr.base._shape[0])
-                if sub_step != 1:
-                    return None
-                state_unified_slice = slice(state_start + sub_start, state_start + sub_stop)
-            else:
-                return None
-
-            param_fix.append(
-                ParamFixPin(
-                    state_slice=state_unified_slice,
-                    param_name=param.name,
-                    node_type=node_type,
-                )
-            )
-
-        return impulsive, param_fix
 
     @staticmethod
     def _scaling(unified: Union["UnifiedState", "UnifiedControl"]) -> Tuple[np.ndarray, np.ndarray]:

--- a/openscvx/solvers/ptr_solver.py
+++ b/openscvx/solvers/ptr_solver.py
@@ -49,6 +49,8 @@ from .base import ConvexSolver
 from .cones import ConeConstraint, NonnegConeConstraint, SOCConstraint, ZeroConeConstraint
 
 if TYPE_CHECKING:
+    import hashlib
+
     from openscvx.lowered.unified import UnifiedControl, UnifiedState
     from openscvx.symbolic.constraint_set import ConstraintSet
 

--- a/openscvx/solvers/ptr_solver.py
+++ b/openscvx/solvers/ptr_solver.py
@@ -39,13 +39,14 @@ Backends:
 from abc import abstractmethod
 from dataclasses import dataclass, fields
 from enum import IntEnum
-from typing import TYPE_CHECKING, Callable, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, FrozenSet, List, Optional, Tuple, Type, Union
 
 import jax
 import jax.numpy as jnp
 import numpy as np
 
 from .base import ConvexSolver
+from .cones import ConeConstraint, NonnegConeConstraint, SOCConstraint, ZeroConeConstraint
 
 if TYPE_CHECKING:
     from openscvx.lowered.unified import UnifiedControl, UnifiedState
@@ -260,7 +261,137 @@ class PTRSolver(ConvexSolver):
 
     Subclasses must additionally implement :meth:`create_variables` and
     :meth:`initialize` from :class:`ConvexSolver`.
+
+    Attributes:
+        SUPPORTED_CONE_TYPES: The set of
+            :class:`~openscvx.solvers.cones.ConeConstraint` subclasses this
+            backend can assemble.  An empty frozenset (the default) means the
+            backend rejects **all** user ``.convex()`` constraints.  Concrete
+            subclasses declare their capabilities by overriding this attribute.
     """
+
+    # Subclasses declare which cone types they support.
+    SUPPORTED_CONE_TYPES: ClassVar[FrozenSet[Type[ConeConstraint]]] = frozenset()
+
+    # Registry populated via __init_subclass__ so _raise_unsupported_cone_error
+    # can suggest which backends do support a given cone type.
+    _solver_registry: ClassVar[List[Type["PTRSolver"]]] = []
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        PTRSolver._solver_registry.append(cls)
+
+    # ------------------------------------------------------------------
+    # Principled convex-constraint lowering (shared by QPAX and Moreau)
+    # ------------------------------------------------------------------
+
+    def lower_convex_constraints(
+        self,
+        constraints: "ConstraintSet",
+        parameters: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[List[Any], Dict[str, Any]]:
+        """Lower user ``.convex()`` constraints into cone constraints.
+
+        Separates auto-generated impulsive zero-pin equalities from genuine
+        user constraints, canonicalises the latter via
+        :func:`~openscvx.symbolic.canonicalize.canonicalize_nodal_constraint`,
+        and verifies each cone type against :attr:`SUPPORTED_CONE_TYPES`.
+
+        Cross-node convex constraints are not yet supported by the JAX
+        backends and raise :class:`NotImplementedError`.
+
+        Raises:
+            NotImplementedError: For cross-node convex constraints or
+                unsupported cone types (with a message listing which backends
+                do support the cone type).
+            ValueError: If a constraint is not affine in state/control.
+        """
+        from openscvx.symbolic.canonicalize import canonicalize_nodal_constraint
+
+        if constraints.cross_node_convex:
+            raise NotImplementedError(
+                f"{type(self).__name__} does not support cross-node .convex() "
+                f"constraints ({len(constraints.cross_node_convex)} defined). "
+                "Use CVXPyPTRSolver."
+            )
+
+        pins, user_nodal = self._partition_nodal_convex(constraints)
+        self._impulsive_pins = pins
+
+        user_cones: List[ConeConstraint] = []
+        for nc in user_nodal:
+            cones = canonicalize_nodal_constraint(nc)
+            for cone in cones:
+                if type(cone) not in self.SUPPORTED_CONE_TYPES:
+                    self._raise_unsupported_cone_error(cone)
+                user_cones.append(cone)
+
+        self._user_cone_constraints: List[ConeConstraint] = user_cones
+        self._parameters_dict: Dict[str, Any] = parameters or {}
+        return [], {}
+
+    @staticmethod
+    def _partition_nodal_convex(
+        constraints: "ConstraintSet",
+    ) -> Tuple[List[Tuple[List[int], slice]], List]:
+        """Separate auto-generated impulsive zero-pin constraints from genuine
+        user-defined convex constraints.
+
+        Auto-generated pins match the pattern ``Control == 0`` injected by
+        :func:`~openscvx.symbolic.lower._augment_impulsive_constraints`.  All
+        other ``nodal_convex`` entries are returned as user-defined constraints.
+
+        Returns:
+            tuple: ``(pins, user_nodal)`` where *pins* is a list of
+            ``(nodes, ctrl_slice)`` pairs and *user_nodal* is the list of
+            :class:`~openscvx.symbolic.expr.constraint.NodalConstraint`
+            objects that need full canonicalization.
+        """
+        from openscvx.symbolic.expr.constraint import Equality, NodalConstraint
+        from openscvx.symbolic.expr.control import Control
+        from openscvx.symbolic.expr.expr import Constant
+
+        pins: List[Tuple[List[int], slice]] = []
+        user_nodal: List = []
+
+        for entry in constraints.nodal_convex:
+            if (
+                isinstance(entry, NodalConstraint)
+                and isinstance(entry.constraint, Equality)
+                and isinstance(entry.constraint.rhs, Constant)
+                and np.all(np.asarray(entry.constraint.rhs.value) == 0)
+                and isinstance(entry.constraint.lhs, Control)
+                and entry.constraint.lhs._slice is not None
+            ):
+                pins.append(([int(k) for k in entry.nodes], entry.constraint.lhs._slice))
+            else:
+                user_nodal.append(entry)
+
+        return pins, user_nodal
+
+    def _raise_unsupported_cone_error(self, cone: ConeConstraint) -> None:
+        """Raise :class:`NotImplementedError` naming which backends support *cone*.
+
+        Scans :attr:`_solver_registry` to find alternatives.
+        """
+        cone_cls = type(cone)
+        alternatives = [
+            cls.__name__
+            for cls in PTRSolver._solver_registry
+            if cone_cls in cls.SUPPORTED_CONE_TYPES
+        ]
+        msg = (
+            f"{type(self).__name__} does not support "
+            f"{cone_cls.__name__} constraints."
+        )
+        if alternatives:
+            msg += f"  Backends that do: {', '.join(alternatives)}."
+        else:
+            msg += (
+                "  No registered JAX backend supports this cone type; "
+                "use CVXPyPTRSolver instead."
+            )
+        raise NotImplementedError(msg)
 
     @abstractmethod
     def update_dynamics_linearization(

--- a/openscvx/solvers/ptr_solver.py
+++ b/openscvx/solvers/ptr_solver.py
@@ -277,6 +277,12 @@ class PTRSolver(ConvexSolver):
     # can suggest which backends do support a given cone type.
     _solver_registry: ClassVar[List[Type["PTRSolver"]]] = []
 
+    #: Backend-specific solve options (tolerances, iteration caps, ...). Each
+    #: concrete backend assigns its own in ``__init__``; declared here with a
+    #: ``None`` default so the base :meth:`_hash_into` contract is self-contained
+    #: — a subclass that omits it hashes as an empty mapping rather than raising.
+    solver_args: Optional[dict] = None
+
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
         PTRSolver._solver_registry.append(cls)

--- a/openscvx/solvers/ptr_solver.py
+++ b/openscvx/solvers/ptr_solver.py
@@ -39,14 +39,26 @@ Backends:
 from abc import abstractmethod
 from dataclasses import dataclass, fields
 from enum import IntEnum
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, FrozenSet, List, Optional, Tuple, Type, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    ClassVar,
+    Dict,
+    FrozenSet,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+)
 
 import jax
 import jax.numpy as jnp
 import numpy as np
 
 from .base import ConvexSolver
-from .cones import ConeConstraint, NonnegConeConstraint, SOCConstraint, ZeroConeConstraint
+from .cones import ConeConstraint
 
 if TYPE_CHECKING:
     import hashlib
@@ -396,16 +408,12 @@ class PTRSolver(ConvexSolver):
             for cls in PTRSolver._solver_registry
             if cone_cls in cls.SUPPORTED_CONE_TYPES
         ]
-        msg = (
-            f"{type(self).__name__} does not support "
-            f"{cone_cls.__name__} constraints."
-        )
+        msg = f"{type(self).__name__} does not support {cone_cls.__name__} constraints."
         if alternatives:
             msg += f"  Backends that do: {', '.join(alternatives)}."
         else:
             msg += (
-                "  No registered JAX backend supports this cone type; "
-                "use CVXPyPTRSolver instead."
+                "  No registered JAX backend supports this cone type; use CVXPyPTRSolver instead."
             )
         raise NotImplementedError(msg)
 

--- a/openscvx/solvers/ptr_solver.py
+++ b/openscvx/solvers/ptr_solver.py
@@ -508,6 +508,39 @@ class PTRSolver(ConvexSolver):
         """
         raise NotImplementedError
 
+    @property
+    def exportable(self) -> bool:
+        """Whether this backend's solve survives ``jax.export`` serialization.
+
+        :meth:`~openscvx.problem.Problem.solve_batched` exports the whole
+        vmapped SCP loop to disk under ``save_compiled=True``, which requires
+        every op in the loop — the backend solve included — to lower to
+        serializable XLA. The pure-JAX backends (QPAX, Moreau) qualify, so the
+        base default is ``True``. CVXPy's :meth:`iteration_callback` is a
+        :func:`jax.pure_callback`, whose host call ``jax.export`` cannot
+        serialize, so it overrides this to ``False`` and ``solve_batched``
+        raises a teaching error rather than silently degrading to an in-process
+        solve.
+        """
+        return True
+
+    def _hash_into(self, hasher: "hashlib._Hash") -> None:
+        """Contribute this backend's identity to the ``solve_batched`` cache key.
+
+        The exported batched loop bakes in the backend class and its
+        ``solver_args`` (tolerances, iteration caps, ...), neither of which the
+        symbolic problem hash covers. Mirrors the symbolic ``_hash_into``
+        protocol (see :meth:`~openscvx.symbolic.expr.expr.Expr._hash_into`) so a
+        backend that adds a field affecting the artifact updates the hash right
+        next to that field.
+        """
+        from openscvx.utils.caching import hash_value_into
+
+        hasher.update(type(self).__name__.encode())
+        for key in sorted(self.solver_args or {}):
+            hasher.update(str(key).encode())
+            hash_value_into(hasher, self.solver_args[key])
+
     @staticmethod
     def _extract_impulsive_pins(
         constraints: "ConstraintSet",

--- a/openscvx/solvers/qpax_ptr_solver.py
+++ b/openscvx/solvers/qpax_ptr_solver.py
@@ -58,6 +58,7 @@ from .cones import NonnegConeConstraint, SOCConstraint, ZeroConeConstraint
 from .ptr_solver import (
     PTRSolver,
     PTRSolveResult,
+    ParamFixPin,
     StatusCode,
     SubproblemData,
     SubproblemSolution,
@@ -332,6 +333,9 @@ class QPAXPTRSolver(PTRSolver):
 
         self.layout = _QPLayout(N=N, n_x=n_x, n_u=n_u, n_nodal=len(jax_constraints.nodal))
         self._jax_constraints = jax_constraints
+        self._x_unified = x_unified
+
+
 
     def initialize(self, lowered: "LoweredProblem", settings: "Config") -> None:
         """Validate the constraint subset QPAX supports and stash settings.

--- a/openscvx/solvers/qpax_ptr_solver.py
+++ b/openscvx/solvers/qpax_ptr_solver.py
@@ -54,6 +54,7 @@ import numpy as np
 
 from openscvx.config import Config
 
+from .cones import NonnegConeConstraint, SOCConstraint, ZeroConeConstraint
 from .ptr_solver import (
     PTRSolver,
     PTRSolveResult,
@@ -178,14 +179,16 @@ class QPAXPTRSolver(PTRSolver):
     Scope:
         Supported — state/control box, dynamics linearization (continuous
         and impulsive), boundary ``Fix``, uniform time grid, linearized
-        nodal nonconvex, CTCS LICQ-style rows.
+        nodal nonconvex, CTCS LICQ-style rows, user affine equality /
+        inequality ``.convex()`` constraints
+        (:class:`~openscvx.solvers.cones.ZeroConeConstraint` and
+        :class:`~openscvx.solvers.cones.NonnegConeConstraint`).
 
-        Not supported — user ``.convex()`` constraints and cross-node
-        constraints. Each raises :class:`NotImplementedError` with a "use
-        :class:`openscvx.solvers.cvxpy_ptr_solver.CVXPyPTRSolver`" pointer.
-        Cross-node support may be added in the future; ``.convex()`` would
-        need a second-order-cone solver and is unlikely to land here
-        directly.
+        Not supported — SOC ``.convex()`` constraints and cross-node
+        constraints.  Each raises :class:`NotImplementedError`.  SOC
+        support requires a second-order-cone solver; use
+        :class:`openscvx.solvers.moreau_ptr_solver.MoreauPTRSolver` or
+        :class:`openscvx.solvers.cvxpy_ptr_solver.CVXPyPTRSolver` instead.
 
     Differentiability hook for future work:
         ``qpax.solve_qp_primal`` is differentiable via ``jax.custom_vjp``.
@@ -208,6 +211,8 @@ class QPAXPTRSolver(PTRSolver):
         layout: ``_QPLayout`` describing the flat decision-vector slot ranges.
             Populated by :meth:`create_variables`.
     """
+
+    SUPPORTED_CONE_TYPES = frozenset({ZeroConeConstraint, NonnegConeConstraint})
 
     def __init__(
         self,
@@ -257,9 +262,11 @@ class QPAXPTRSolver(PTRSolver):
         self._n_constraints: int = 0
 
         # Populated by lower_convex_constraints. Auto-augmented impulsive
-        # zero-pin constraints land here; any genuine user .convex() trips
-        # the default refusal.
+        # zero-pin constraints land here; genuine user .convex() constraints
+        # land in _user_cone_constraints after canonicalization.
         self._impulsive_pins: List[Tuple[List[int], slice]] = []
+        self._user_cone_constraints: List = []
+        self._parameters_dict: dict = {}
 
         # Per-iteration data, set by update_* methods.
         self._dyn: dict = {}
@@ -326,28 +333,6 @@ class QPAXPTRSolver(PTRSolver):
         self.layout = _QPLayout(N=N, n_x=n_x, n_u=n_u, n_nodal=len(jax_constraints.nodal))
         self._jax_constraints = jax_constraints
 
-    def lower_convex_constraints(
-        self,
-        constraints: "ConstraintSet",
-        parameters: Optional[dict] = None,
-    ) -> Tuple[List, dict]:
-        """Absorb auto-generated impulsive zero-pin constraints; refuse the rest.
-
-        :func:`openscvx.symbolic.lower._augment_impulsive_constraints` injects
-        ``Control == 0`` equalities at non-impulse nodes for every impulsive
-        control. Those constraints live in ``constraints.nodal_convex`` even
-        though no user ``.convex()`` was written; we recognize their fixed
-        shape and stash a pin list for :meth:`_assemble_qp` to emit as
-        plain equality rows. Anything that doesn't match the auto-augmentation
-        shape (e.g. a genuine user ``.convex()`` constraint) falls through to
-        the default refusal in :class:`ConvexSolver`.
-        """
-        pins = self._extract_impulsive_pins(constraints)
-        if pins is None:
-            return super().lower_convex_constraints(constraints, parameters)
-        self._impulsive_pins = pins
-        return [], {}
-
     def initialize(self, lowered: "LoweredProblem", settings: "Config") -> None:
         """Validate the constraint subset QPAX supports and stash settings.
 
@@ -410,6 +395,13 @@ class QPAXPTRSolver(PTRSolver):
             n_ineq += 2 * (nodes[1] - start_i)
         n_ineq += 2 * (N - 1) * n_x  # |nu| L1 slack
         n_ineq += 2 * N * L.n_nodal  # pos(nu_vb) slack
+
+        # User cone constraints (hard, no virtual buffer).
+        for cc in self._user_cone_constraints:
+            if isinstance(cc, ZeroConeConstraint):
+                n_eq += len(cc.nodes) * cc.m
+            elif isinstance(cc, NonnegConeConstraint):
+                n_ineq += len(cc.nodes) * cc.m
 
         return n_eq + n_ineq
 
@@ -822,6 +814,44 @@ class QPAXPTRSolver(PTRSolver):
                 G_rows.append(row)
                 h_rows.append(0.0)
 
+        # User cone constraints — hard (no virtual buffer), affine.
+        # J_x/J_u are physical-space Jacobians; multiply by S_x/S_u to convert
+        # to coefficients for scaled decision variables dx_scaled / du_scaled.
+        x_bar_np = self._dyn["x_bar"]  # (N, n_x) unscaled
+        u_bar_np = self._dyn["u_bar"]  # (N, n_u) unscaled
+        params = self._parameters_dict
+
+        for cc in self._user_cone_constraints:
+            for k in cc.nodes:
+                x_k = x_bar_np[k]
+                u_k = u_bar_np[k]
+                f0 = np.asarray(cc.jax_fn(x_k, u_k, k, params), dtype=float).reshape(cc.m)
+                J_x = np.asarray(
+                    jax.jacfwd(cc.jax_fn, argnums=0)(x_k, u_k, k, params), dtype=float
+                ).reshape(cc.m, n_x) * S_x[None, :]
+                J_u = np.asarray(
+                    jax.jacfwd(cc.jax_fn, argnums=1)(x_k, u_k, k, params), dtype=float
+                ).reshape(cc.m, n_u) * S_u[None, :]
+                rhs = -f0
+                if isinstance(cc, ZeroConeConstraint):
+                    for i in range(cc.m):
+                        row = np.zeros(L.n_z, dtype=float)
+                        row[L.sl_dx.start + k * n_x : L.sl_dx.start + (k + 1) * n_x] = J_x[i]
+                        row[L.sl_du.start + k * n_u : L.sl_du.start + (k + 1) * n_u] = J_u[i]
+                        A_rows.append(row)
+                        b_rows.append(float(rhs[i]))
+                elif isinstance(cc, NonnegConeConstraint):
+                    for i in range(cc.m):
+                        row = np.zeros(L.n_z, dtype=float)
+                        row[L.sl_dx.start + k * n_x : L.sl_dx.start + (k + 1) * n_x] = J_x[i]
+                        row[L.sl_du.start + k * n_u : L.sl_du.start + (k + 1) * n_u] = J_u[i]
+                        G_rows.append(row)
+                        h_rows.append(float(rhs[i]))
+
+        # Rebuild A_mat/b_vec now that user-cone equality rows may have been added.
+        A_mat = np.asarray(A_rows, dtype=float) if A_rows else np.zeros((0, L.n_z))
+        b_vec = np.asarray(b_rows, dtype=float) if b_rows else np.zeros(0)
+
         G_mat = np.asarray(G_rows, dtype=float) if G_rows else np.zeros((0, L.n_z))
         h_vec = np.asarray(h_rows, dtype=float) if h_rows else np.zeros(0)
 
@@ -1231,9 +1261,6 @@ class QPAXPTRSolver(PTRSolver):
             A_blocks.append(block)
             b_blocks.append(-c_x[ctcs_idx_arr])
 
-        A_mat = jnp.concatenate(A_blocks, axis=0) if A_blocks else jnp.zeros((0, L.n_z), dtype=f)
-        b_vec = jnp.concatenate(b_blocks, axis=0) if b_blocks else jnp.zeros((0,), dtype=f)
-
         # ---------- inequality rows (G z ≤ h) ----------
         G_blocks: List[jnp.ndarray] = []
         h_blocks: List[jnp.ndarray] = []
@@ -1314,6 +1341,40 @@ class QPAXPTRSolver(PTRSolver):
             block = block.at[2 * row_idx + 1, spos_cols].set(-1.0)
             G_blocks.append(block)
             h_blocks.append(jnp.zeros((2 * N,), dtype=f))
+
+        # User cone constraints (hard, affine).
+        # J_x/J_u are physical-space Jacobians; multiply by S_x/S_u to convert
+        # to coefficients for scaled decision variables dx_scaled / du_scaled.
+        params = self._parameters_dict
+        for cc in self._user_cone_constraints:
+            for k in cc.nodes:
+                x_k = data.x_bar[k]
+                u_k = data.u_bar[k]
+                f0 = jnp.reshape(cc.jax_fn(x_k, u_k, k, params), (cc.m,))
+                J_x = jnp.reshape(
+                    jax.jacfwd(cc.jax_fn, argnums=0)(x_k, u_k, k, params), (cc.m, n_x)
+                ) * S_x[None, :]
+                J_u = jnp.reshape(
+                    jax.jacfwd(cc.jax_fn, argnums=1)(x_k, u_k, k, params), (cc.m, n_u)
+                ) * S_u[None, :]
+                # Build dense row block: (cc.m, n_z).
+                block = jnp.zeros((cc.m, L.n_z), dtype=f)
+                dx_start = L.sl_dx.start + k * n_x
+                du_start = L.sl_du.start + k * n_u
+                dx_idx_range = jnp.arange(dx_start, dx_start + n_x)
+                du_idx_range = jnp.arange(du_start, du_start + n_u)
+                block = block.at[:, dx_idx_range].set(J_x)
+                block = block.at[:, du_idx_range].set(J_u)
+                rhs = -f0
+                if isinstance(cc, ZeroConeConstraint):
+                    A_blocks.append(block)
+                    b_blocks.append(rhs)
+                elif isinstance(cc, NonnegConeConstraint):
+                    G_blocks.append(block)
+                    h_blocks.append(rhs)
+
+        A_mat = jnp.concatenate(A_blocks, axis=0) if A_blocks else jnp.zeros((0, L.n_z), dtype=f)
+        b_vec = jnp.concatenate(b_blocks, axis=0) if b_blocks else jnp.zeros((0,), dtype=f)
 
         G_mat = jnp.concatenate(G_blocks, axis=0) if G_blocks else jnp.zeros((0, L.n_z), dtype=f)
         h_vec = jnp.concatenate(h_blocks, axis=0) if h_blocks else jnp.zeros((0,), dtype=f)

--- a/openscvx/solvers/qpax_ptr_solver.py
+++ b/openscvx/solvers/qpax_ptr_solver.py
@@ -54,7 +54,7 @@ import numpy as np
 
 from openscvx.config import Config
 
-from .cones import NonnegConeConstraint, SOCConstraint, ZeroConeConstraint
+from .cones import NonnegConeConstraint, ZeroConeConstraint
 from .ptr_solver import (
     PTRSolver,
     PTRSolveResult,
@@ -80,7 +80,6 @@ if TYPE_CHECKING:
     from openscvx.lowered import LoweredProblem
     from openscvx.lowered.jax_constraints import LoweredJaxConstraints
     from openscvx.lowered.unified import UnifiedControl, UnifiedState
-    from openscvx.symbolic.constraint_set import ConstraintSet
 
 
 # Tiny diagonal regularization added to Q on rows whose cost is purely
@@ -333,8 +332,6 @@ class QPAXPTRSolver(PTRSolver):
         self.layout = _QPLayout(N=N, n_x=n_x, n_u=n_u, n_nodal=len(jax_constraints.nodal))
         self._jax_constraints = jax_constraints
         self._x_unified = x_unified
-
-
 
     def initialize(self, lowered: "LoweredProblem", settings: "Config") -> None:
         """Validate the constraint subset QPAX supports and stash settings.
@@ -829,12 +826,18 @@ class QPAXPTRSolver(PTRSolver):
                 x_k = x_bar_np[k]
                 u_k = u_bar_np[k]
                 f0 = np.asarray(cc.jax_fn(x_k, u_k, k, params), dtype=float).reshape(cc.m)
-                J_x = np.asarray(
-                    jax.jacfwd(cc.jax_fn, argnums=0)(x_k, u_k, k, params), dtype=float
-                ).reshape(cc.m, n_x) * S_x[None, :]
-                J_u = np.asarray(
-                    jax.jacfwd(cc.jax_fn, argnums=1)(x_k, u_k, k, params), dtype=float
-                ).reshape(cc.m, n_u) * S_u[None, :]
+                J_x = (
+                    np.asarray(
+                        jax.jacfwd(cc.jax_fn, argnums=0)(x_k, u_k, k, params), dtype=float
+                    ).reshape(cc.m, n_x)
+                    * S_x[None, :]
+                )
+                J_u = (
+                    np.asarray(
+                        jax.jacfwd(cc.jax_fn, argnums=1)(x_k, u_k, k, params), dtype=float
+                    ).reshape(cc.m, n_u)
+                    * S_u[None, :]
+                )
                 rhs = -f0
                 if isinstance(cc, ZeroConeConstraint):
                     for i in range(cc.m):
@@ -1354,12 +1357,14 @@ class QPAXPTRSolver(PTRSolver):
                 x_k = data.x_bar[k]
                 u_k = data.u_bar[k]
                 f0 = jnp.reshape(cc.jax_fn(x_k, u_k, k, params), (cc.m,))
-                J_x = jnp.reshape(
-                    jax.jacfwd(cc.jax_fn, argnums=0)(x_k, u_k, k, params), (cc.m, n_x)
-                ) * S_x[None, :]
-                J_u = jnp.reshape(
-                    jax.jacfwd(cc.jax_fn, argnums=1)(x_k, u_k, k, params), (cc.m, n_u)
-                ) * S_u[None, :]
+                J_x = (
+                    jnp.reshape(jax.jacfwd(cc.jax_fn, argnums=0)(x_k, u_k, k, params), (cc.m, n_x))
+                    * S_x[None, :]
+                )
+                J_u = (
+                    jnp.reshape(jax.jacfwd(cc.jax_fn, argnums=1)(x_k, u_k, k, params), (cc.m, n_u))
+                    * S_u[None, :]
+                )
                 # Build dense row block: (cc.m, n_z).
                 block = jnp.zeros((cc.m, L.n_z), dtype=f)
                 dx_start = L.sl_dx.start + k * n_x

--- a/openscvx/solvers/qpax_ptr_solver.py
+++ b/openscvx/solvers/qpax_ptr_solver.py
@@ -58,7 +58,6 @@ from .cones import NonnegConeConstraint, SOCConstraint, ZeroConeConstraint
 from .ptr_solver import (
     PTRSolver,
     PTRSolveResult,
-    ParamFixPin,
     StatusCode,
     SubproblemData,
     SubproblemSolution,
@@ -1349,7 +1348,7 @@ class QPAXPTRSolver(PTRSolver):
         # User cone constraints (hard, affine).
         # J_x/J_u are physical-space Jacobians; multiply by S_x/S_u to convert
         # to coefficients for scaled decision variables dx_scaled / du_scaled.
-        params = self._parameters_dict
+        params = data.params
         for cc in self._user_cone_constraints:
             for k in cc.nodes:
                 x_k = data.x_bar[k]

--- a/openscvx/symbolic/affine.py
+++ b/openscvx/symbolic/affine.py
@@ -99,9 +99,7 @@ def is_affine_in_state_control(expr: "Expr") -> bool:
     # Sub: .left, .right
     # -----------------------------------------------------------------
     if isinstance(expr, Sub):
-        return is_affine_in_state_control(expr.left) and is_affine_in_state_control(
-            expr.right
-        )
+        return is_affine_in_state_control(expr.left) and is_affine_in_state_control(expr.right)
 
     # -----------------------------------------------------------------
     # Neg: .operand
@@ -156,11 +154,7 @@ def is_affine_in_state_control(expr: "Expr") -> bool:
         return all(is_affine_in_state_control(c) for c in expr.children())
 
     if isinstance(expr, Block):
-        return all(
-            is_affine_in_state_control(cell)
-            for row in expr.blocks
-            for cell in row
-        )
+        return all(is_affine_in_state_control(cell) for row in expr.blocks for cell in row)
 
     # -----------------------------------------------------------------
     # Everything else (Norm, Power, Sin, Cos, …) → not affine.

--- a/openscvx/symbolic/affine.py
+++ b/openscvx/symbolic/affine.py
@@ -1,0 +1,168 @@
+"""Static affine-in-state/control checker for symbolic expressions.
+
+Provides :func:`is_affine_in_state_control` and :func:`is_constant`, which
+are used by :mod:`openscvx.symbolic.canonicalize` to verify that user
+``.convex()`` constraints can be lowered to a :class:`~openscvx.solvers.cones.ConeConstraint`
+without requiring a non-linear solver.
+
+Both functions walk the expression AST without executing any JAX code, so
+they are safe to call before JIT compilation.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from openscvx.symbolic.expr.expr import Expr
+
+
+def is_constant(expr: "Expr") -> bool:
+    """Return ``True`` iff *expr* has no :class:`~openscvx.symbolic.expr.State`
+    or :class:`~openscvx.symbolic.expr.Control` leaves.
+
+    Parameters that are constant across a trajectory are treated as constant;
+    :class:`~openscvx.symbolic.expr.Variable` objects are treated as
+    non-constant (conservative assumption).
+    """
+    from openscvx.symbolic.expr.control import Control
+    from openscvx.symbolic.expr.expr import Constant
+    from openscvx.symbolic.expr.parameter import Parameter
+    from openscvx.symbolic.expr.state import State
+    from openscvx.symbolic.expr.variable import Variable
+
+    if isinstance(expr, Constant):
+        return True
+    if isinstance(expr, Parameter):
+        return True
+    if isinstance(expr, (State, Control, Variable)):
+        return False
+    # Compound nodes: constant iff every child is constant.
+    return all(is_constant(c) for c in expr.children())
+
+
+def is_affine_in_state_control(expr: "Expr") -> bool:
+    """Return ``True`` iff *expr* is affine in
+    :class:`~openscvx.symbolic.expr.State` and
+    :class:`~openscvx.symbolic.expr.Control` variables.
+
+    Recognises:
+
+    * Leaf nodes: :class:`Constant`, :class:`Parameter` → constant (affine).
+    * :class:`State`, :class:`Control` → linear.
+    * :class:`Add`, :class:`Sub` → affine iff all operands are affine.
+    * :class:`Neg` → affine iff operand is affine.
+    * :class:`Mul` → affine iff at most one factor is non-constant
+      (and the non-constant factor, if present, is itself affine).
+    * :class:`MatMul` → affine iff one side is constant and the other is
+      affine.
+    * :class:`Div` → affine iff numerator is affine and denominator is
+      constant.
+    * :class:`Transpose`, :class:`Sum`, :class:`Diag` → affine iff operand
+      is affine.
+    * :class:`Index`, :class:`Concat`, :class:`Stack`, :class:`Hstack`,
+      :class:`Vstack`, :class:`Block` → affine iff all children are affine.
+    * Anything else (norms, trig, powers, …) → **not affine**.
+    """
+    from openscvx.symbolic.expr.arithmetic import Div, MatMul, Mul, Neg, Sub
+    from openscvx.symbolic.expr.array import Block, Concat, Hstack, Index, Stack, Vstack
+    from openscvx.symbolic.expr.control import Control
+    from openscvx.symbolic.expr.expr import Constant
+    from openscvx.symbolic.expr.linalg import Diag, Sum, Transpose
+    from openscvx.symbolic.expr.parameter import Parameter
+    from openscvx.symbolic.expr.state import State
+    from openscvx.symbolic.expr.variable import Variable
+
+    # -----------------------------------------------------------------
+    # Leaf cases
+    # -----------------------------------------------------------------
+    if isinstance(expr, (Constant, Parameter)):
+        return True
+    if isinstance(expr, (State, Control)):
+        return True
+    if isinstance(expr, Variable):
+        return False
+
+    # -----------------------------------------------------------------
+    # Add: n-ary via .terms
+    # -----------------------------------------------------------------
+    # Import locally to avoid circular imports at module level.
+    try:
+        from openscvx.symbolic.expr.arithmetic import Add
+
+        if isinstance(expr, Add):
+            return all(is_affine_in_state_control(t) for t in expr.terms)
+    except ImportError:
+        pass
+
+    # -----------------------------------------------------------------
+    # Sub: .left, .right
+    # -----------------------------------------------------------------
+    if isinstance(expr, Sub):
+        return is_affine_in_state_control(expr.left) and is_affine_in_state_control(
+            expr.right
+        )
+
+    # -----------------------------------------------------------------
+    # Neg: .operand
+    # -----------------------------------------------------------------
+    if isinstance(expr, Neg):
+        return is_affine_in_state_control(expr.operand)
+
+    # -----------------------------------------------------------------
+    # Mul (element-wise, n-ary via .factors):
+    # affine iff at most one factor is non-constant AND that factor is
+    # itself affine.
+    # -----------------------------------------------------------------
+    if isinstance(expr, Mul):
+        non_const = [f for f in expr.factors if not is_constant(f)]
+        if len(non_const) == 0:
+            return True
+        if len(non_const) == 1:
+            return is_affine_in_state_control(non_const[0])
+        return False
+
+    # -----------------------------------------------------------------
+    # MatMul: .left, .right
+    # -----------------------------------------------------------------
+    if isinstance(expr, MatMul):
+        left_const = is_constant(expr.left)
+        right_const = is_constant(expr.right)
+        if left_const:
+            return is_affine_in_state_control(expr.right)
+        if right_const:
+            return is_affine_in_state_control(expr.left)
+        return False
+
+    # -----------------------------------------------------------------
+    # Div: .left (numerator), .right (denominator)
+    # -----------------------------------------------------------------
+    if isinstance(expr, Div):
+        return is_affine_in_state_control(expr.left) and is_constant(expr.right)
+
+    # -----------------------------------------------------------------
+    # Linear-algebra ops that preserve affinity
+    # -----------------------------------------------------------------
+    if isinstance(expr, (Transpose, Sum, Diag)):
+        return is_affine_in_state_control(expr.operand)
+
+    # -----------------------------------------------------------------
+    # Array ops: affine iff all children are affine
+    # -----------------------------------------------------------------
+    if isinstance(expr, Index):
+        return is_affine_in_state_control(expr.base)
+
+    if isinstance(expr, (Concat, Stack, Hstack, Vstack)):
+        return all(is_affine_in_state_control(c) for c in expr.children())
+
+    if isinstance(expr, Block):
+        return all(
+            is_affine_in_state_control(cell)
+            for row in expr.blocks
+            for cell in row
+        )
+
+    # -----------------------------------------------------------------
+    # Everything else (Norm, Power, Sin, Cos, …) → not affine.
+    # -----------------------------------------------------------------
+    return False

--- a/openscvx/symbolic/canonicalize.py
+++ b/openscvx/symbolic/canonicalize.py
@@ -1,0 +1,250 @@
+"""Canonicalise user ``.convex()`` nodal constraints into cone constraints.
+
+The function :func:`canonicalize_nodal_constraint` dispatches a single
+:class:`~openscvx.symbolic.expr.constraint.NodalConstraint` (whose inner
+constraint has ``is_convex == True``) to one or more
+:class:`~openscvx.solvers.cones.ConeConstraint` objects that a JAX-native
+solver can assemble directly.
+
+Dispatch table
+--------------
+
++--------------------------------------+-----------------------------------+
+| Symbolic pattern                     | Cone type                         |
++======================================+===================================+
+| ``Equality(affine, affine)``         | :class:`ZeroConeConstraint`       |
++--------------------------------------+-----------------------------------+
+| ``Inequality(affine, affine)``       | :class:`NonnegConeConstraint`     |
++--------------------------------------+-----------------------------------+
+| ``Inequality(Norm(e,2), t)``         | :class:`SOCConstraint`            |
+| ``Inequality(Norm(e,"fro"), t)``     |                                   |
++--------------------------------------+-----------------------------------+
+| ``Inequality(Norm(e,"inf"), t)``     | :class:`NonnegConeConstraint`     |
+|                                      | (2·dim rows)                      |
++--------------------------------------+-----------------------------------+
+| ``Inequality(Norm(e,1), t)``         | :exc:`NotImplementedError`        |
+|                                      | (needs auxiliary variables)       |
++--------------------------------------+-----------------------------------+
+
+where *affine* means :func:`~openscvx.symbolic.affine.is_affine_in_state_control`
+returns ``True``, and *t* is :func:`~openscvx.symbolic.affine.is_constant`
+(a :class:`~openscvx.symbolic.expr.Parameter` or literal scalar).
+
+For :class:`SOCConstraint` the ``bound_fn`` may also be affine in state/control
+(e.g. a state-dependent upper bound), as long as the bound itself is a scalar.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from openscvx.solvers.cones import ConeConstraint
+    from openscvx.symbolic.expr.constraint import NodalConstraint
+
+
+def canonicalize_nodal_constraint(
+    nc: "NodalConstraint",
+) -> List["ConeConstraint"]:
+    """Convert a single ``.convex()`` nodal constraint into cone constraints.
+
+    Parameters
+    ----------
+    nc:
+        A :class:`~openscvx.symbolic.expr.constraint.NodalConstraint` whose
+        inner :class:`~openscvx.symbolic.expr.constraint.Constraint` has
+        ``is_convex == True``.
+
+    Returns
+    -------
+    list[ConeConstraint]
+        One or more cone constraints that together express *nc*.  Each
+        constraint is active at ``nc.nodes``.
+
+    Raises
+    ------
+    ValueError
+        If the constraint pattern is recognised as non-affine in
+        state/control (and therefore cannot be assembled as a conic row).
+    NotImplementedError
+        For L1-norm constraints, which require auxiliary variables not
+        yet supported in the JAX assemblers.
+    TypeError
+        If the inner constraint is neither
+        :class:`~openscvx.symbolic.expr.constraint.Equality` nor
+        :class:`~openscvx.symbolic.expr.constraint.Inequality`.
+    """
+    from openscvx.solvers.cones import NonnegConeConstraint, SOCConstraint, ZeroConeConstraint
+    from openscvx.symbolic.affine import is_affine_in_state_control, is_constant
+    from openscvx.symbolic.expr.constraint import Equality, Inequality
+    from openscvx.symbolic.expr.linalg import Norm
+    from openscvx.symbolic.lower import lower_to_jax
+
+    constraint = nc.constraint
+    nodes = tuple(nc.nodes)
+
+    # ------------------------------------------------------------------
+    # Helper: get the flat output dimension of an expression.
+    # ------------------------------------------------------------------
+    def _m(expr) -> int:
+        shape = expr.check_shape()
+        return int(np.prod(shape)) if shape else 1
+
+    # ==================================================================
+    # EQUALITY  →  ZeroConeConstraint
+    # ==================================================================
+    if isinstance(constraint, Equality):
+        lhs, rhs = constraint.lhs, constraint.rhs
+        if not (is_affine_in_state_control(lhs) and is_affine_in_state_control(rhs)):
+            raise ValueError(
+                f"Equality constraint is not affine in state/control: {constraint!r}.\n"
+                "Only affine equality constraints are supported by the JAX "
+                "backends.  Use CVXPyPTRSolver for non-affine convex constraints."
+            )
+        jax_fn = lower_to_jax(constraint)  # returns lhs − rhs
+        m = _m(constraint)
+        return [ZeroConeConstraint(nodes=nodes, jax_fn=jax_fn, m=m)]
+
+    # ==================================================================
+    # INEQUALITY  →  varies by pattern
+    # ==================================================================
+    if isinstance(constraint, Inequality):
+        lhs, rhs = constraint.lhs, constraint.rhs
+
+        # --------------------------------------------------------------
+        # Detect canonical form produced by Constraint.canonicalize():
+        #   (Norm(e) - bound) <= 0   →  extract Norm and bound.
+        # builder.py canonicalises all constraints before lowering, so
+        # this is the form we typically receive.
+        # --------------------------------------------------------------
+        from openscvx.symbolic.expr.arithmetic import Sub
+
+        _norm_lhs: "Norm | None" = None
+        _norm_bound_rhs = None
+        if isinstance(lhs, Norm) and is_constant(rhs):
+            # Direct form: Norm(e) <= constant
+            _norm_lhs = lhs
+            _norm_bound_rhs = rhs
+        elif (
+            isinstance(lhs, Sub)
+            and isinstance(lhs.left, Norm)
+            and is_constant(lhs.right)
+            and is_constant(rhs)
+        ):
+            # Canonical form: (Norm(e) - bound) <= 0
+            _norm_lhs = lhs.left
+            _norm_bound_rhs = lhs.right
+
+        # --------------------------------------------------------------
+        # Special case: norm-cone  Norm(e) ≤ t
+        # --------------------------------------------------------------
+        if _norm_lhs is not None and _norm_bound_rhs is not None:
+            lhs = _norm_lhs  # type: ignore[assignment]
+            rhs = _norm_bound_rhs  # type: ignore[assignment]
+
+        if isinstance(lhs, Norm):
+            norm_arg = lhs.operand
+            ord_ = lhs.ord
+
+            # The argument of the norm must be affine in state/control.
+            if not is_affine_in_state_control(norm_arg):
+                raise ValueError(
+                    f"Norm argument is not affine in state/control: {norm_arg!r}.\n"
+                    "Only norms of affine expressions are supported."
+                )
+
+            # The bound must be affine in state/control (scalar).
+            if not is_affine_in_state_control(rhs):
+                raise ValueError(
+                    f"Norm upper bound is not affine in state/control: {rhs!r}."
+                )
+
+            # L1 norm: not yet supported (needs auxiliary variables).
+            if ord_ == 1:
+                raise NotImplementedError(
+                    "L1-norm constraints require auxiliary epigraph variables "
+                    "that are not yet supported in the JAX assemblers.  "
+                    "Use CVXPyPTRSolver or reformulate manually."
+                )
+
+            # L2 / Frobenius  →  SOCConstraint
+            if ord_ in (2, "fro"):
+                arg_fn = lower_to_jax(norm_arg)
+                bound_fn = lower_to_jax(rhs)
+                norm_arg_shape = norm_arg.check_shape()
+                m_arg = int(np.prod(norm_arg_shape)) if norm_arg_shape else 1
+
+                # Wrap arg_fn to ensure it always returns a 1-D array.
+                _raw_arg_fn = arg_fn
+
+                def _flat_arg_fn(x, u, node, params, _fn=_raw_arg_fn, _m=m_arg):
+                    import jax.numpy as _jnp
+
+                    return _jnp.reshape(_fn(x, u, node, params), (_m,))
+
+                # Ensure bound_fn returns a scalar.
+                _raw_bound_fn = bound_fn
+
+                def _scalar_bound_fn(x, u, node, params, _fn=_raw_bound_fn):
+                    import jax.numpy as _jnp
+
+                    return _jnp.reshape(_fn(x, u, node, params), ())
+
+                return [
+                    SOCConstraint(
+                        nodes=nodes,
+                        arg_fn=_flat_arg_fn,
+                        bound_fn=_scalar_bound_fn,
+                        m_arg=m_arg,
+                    )
+                ]
+
+            # L-infinity  →  NonnegConeConstraint  (2·dim rows)
+            if ord_ == "inf":
+                # ‖v‖∞ ≤ t  ⟺  v_i ≤ t  AND  −v_i ≤ t  for all i
+                # Residual: [v - t·1; −v - t·1] ≤ 0  →  shape (2·dim_v,)
+                arg_fn = lower_to_jax(norm_arg)
+                bound_fn = lower_to_jax(rhs)
+                norm_arg_shape = norm_arg.check_shape()
+                dim_v = int(np.prod(norm_arg_shape)) if norm_arg_shape else 1
+                _raw_arg_fn = arg_fn
+                _raw_bound_fn = bound_fn
+
+                def _inf_fn(x, u, node, params, _afn=_raw_arg_fn, _bfn=_raw_bound_fn, _dv=dim_v):
+                    import jax.numpy as _jnp
+
+                    v = _jnp.reshape(_afn(x, u, node, params), (_dv,))
+                    t = _jnp.reshape(_bfn(x, u, node, params), ())
+                    return _jnp.concatenate([v - t, -v - t])
+
+                return [NonnegConeConstraint(nodes=nodes, jax_fn=_inf_fn, m=2 * dim_v)]
+
+            # Unknown norm order.
+            raise NotImplementedError(
+                f"Norm order {ord_!r} is not supported.  Supported orders: "
+                "1, 2, 'fro', 'inf'."
+            )
+
+        # --------------------------------------------------------------
+        # General affine inequality  →  NonnegConeConstraint
+        # --------------------------------------------------------------
+        if not (is_affine_in_state_control(lhs) and is_affine_in_state_control(rhs)):
+            raise ValueError(
+                f"Inequality constraint is not affine in state/control: {constraint!r}.\n"
+                "Only affine inequalities and norm-cone inequalities are "
+                "supported by the JAX backends.  Use CVXPyPTRSolver for "
+                "non-affine convex constraints."
+            )
+        jax_fn = lower_to_jax(constraint)  # returns lhs − rhs  (≤ 0)
+        m = _m(constraint)
+        return [NonnegConeConstraint(nodes=nodes, jax_fn=jax_fn, m=m)]
+
+    # ==================================================================
+    # Unsupported inner constraint type
+    # ==================================================================
+    raise TypeError(
+        f"Unsupported constraint type for canonicalization: {type(constraint).__name__}. "
+        "Expected Equality or Inequality."
+    )

--- a/openscvx/symbolic/canonicalize.py
+++ b/openscvx/symbolic/canonicalize.py
@@ -157,9 +157,7 @@ def canonicalize_nodal_constraint(
 
             # The bound must be affine in state/control (scalar).
             if not is_affine_in_state_control(rhs):
-                raise ValueError(
-                    f"Norm upper bound is not affine in state/control: {rhs!r}."
-                )
+                raise ValueError(f"Norm upper bound is not affine in state/control: {rhs!r}.")
 
             # L1 norm: not yet supported (needs auxiliary variables).
             if ord_ == 1:
@@ -223,8 +221,7 @@ def canonicalize_nodal_constraint(
 
             # Unknown norm order.
             raise NotImplementedError(
-                f"Norm order {ord_!r} is not supported.  Supported orders: "
-                "1, 2, 'fro', 'inf'."
+                f"Norm order {ord_!r} is not supported.  Supported orders: 1, 2, 'fro', 'inf'."
             )
 
         # --------------------------------------------------------------

--- a/openscvx/utils/caching.py
+++ b/openscvx/utils/caching.py
@@ -45,6 +45,27 @@ def _hash_byof(byof: Optional["ByofSpec"]) -> bytes:
     return b"".join(codes)
 
 
+def hash_value_into(hasher: "hashlib._Hash", value: Any) -> None:
+    """Fold a scalar / array / ``None`` into ``hasher`` deterministically.
+
+    Shared by the ``_hash_into`` methods of the runtime objects the
+    ``solve_batched`` artifact closes over — the convex backend, the
+    algorithm/autotuner, the discretizer — and by
+    :func:`get_solve_batched_cache_path` for the scaling matrices. Mirrors the
+    symbolic ``_hash_into`` protocol's byte-level updates so the same value
+    always contributes the same bytes (arrays by shape + dtype + contents,
+    everything else by ``repr``).
+    """
+    if value is None:
+        hasher.update(b"None")
+    elif isinstance(value, np.ndarray):
+        arr = np.ascontiguousarray(value)
+        hasher.update(f"{arr.shape}:{arr.dtype}:".encode())
+        hasher.update(arr.tobytes())
+    else:
+        hasher.update(repr(value).encode())
+
+
 def get_solver_cache_paths(
     symbolic_problem: "SymbolicProblem",
     dt: float,
@@ -93,6 +114,72 @@ def get_solver_cache_paths(
     prop_solver_file = solver_dir / f"compiled_propagation_solver_{final_hash}.jax"
 
     return dis_solver_file, prop_solver_file
+
+
+def get_solve_batched_cache_path(
+    symbolic_problem: "SymbolicProblem",
+    settings: Any,
+    algorithm: Any,
+    solver: Any,
+    discretizer: Any,
+    B: int,
+    cache_dir: Optional[Path] = None,
+) -> Path:
+    """Cache path for the exported :meth:`Problem.solve_batched` artifact.
+
+    The vmapped SCP loop closes over far more than the symbolic problem does, so
+    caching it on :func:`get_solver_cache_paths`' key would silently deserialize
+    a **stale artifact** whenever any of the extra closed-over state changes — a
+    wrong-answer bug, not a cache miss. This assembler extends
+    :func:`hash_symbolic_problem` (dynamics, constraints, boundary-condition
+    types, parameter shapes) with everything *additionally* baked into the loop:
+
+    * the convex backend class and its ``solver_args`` (via ``solver._hash_into``),
+    * the algorithm + autotuner + convergence thresholds + initial penalty
+      weights (via ``algorithm._hash_into``),
+    * the discretizer scheme (via ``discretizer._hash_into``),
+    * the state/control scaling matrices ``inv_S_x`` / ``inv_S_u`` (settings-
+      derived, not covered by any subsystem hash),
+    * the fixed batch size ``B`` (the artifact is exported at one ``B``), and
+    * the JAX version (exported artifacts are not guaranteed to survive an
+      incompatible jax bump — the worst failure mode is deserializing one).
+
+    Each runtime object contributes through its own ``_hash_into`` — the same
+    two-tier split the symbolic layer uses — so a new field that changes the
+    artifact is hashed next to where it lives, never reached into from here.
+
+    Args:
+        symbolic_problem: The preprocessed :class:`SymbolicProblem`.
+        settings: Problem :class:`~openscvx.config.Config`; supplies the
+            scaling matrices.
+        algorithm: The SCP algorithm (and its autotuner / weights).
+        solver: The convex subproblem backend.
+        discretizer: The dynamics discretizer.
+        B: Fixed batch size the artifact is exported at.
+        cache_dir: Override for the cache directory. ``None`` uses
+            :func:`openscvx.get_cache_dir`.
+
+    Returns:
+        Path to the ``compiled_solve_batched_<hash>.jax`` artifact.
+    """
+    from openscvx.symbolic.hashing import hash_symbolic_problem
+
+    hasher = hashlib.sha256()
+    hasher.update(hash_symbolic_problem(symbolic_problem).encode())
+    solver._hash_into(hasher)
+    algorithm._hash_into(hasher)
+    discretizer._hash_into(hasher)
+    hash_value_into(hasher, settings.sim.inv_S_x)
+    hash_value_into(hasher, settings.sim.inv_S_u)
+    hasher.update(f"B:{B}".encode())
+    hasher.update(f"jax:{jax.__version__}".encode())
+
+    final_hash = hasher.hexdigest()[:32]
+
+    solver_dir = cache_dir if cache_dir is not None else get_cache_dir()
+    solver_dir.mkdir(parents=True, exist_ok=True)
+
+    return solver_dir / f"compiled_solve_batched_{final_hash}.jax"
 
 
 def load_or_compile_discretization_solver(
@@ -158,6 +245,54 @@ def load_or_compile_discretization_solver(
     print(f"✓ {name} discretization solver compiled and saved")
 
     return compiled_solver
+
+
+def load_or_export_solve_batched(
+    batched_fn: callable,
+    cache_file: Path,
+    sample_state: Any,
+    sample_params: Dict[str, Any],
+) -> Any:
+    """Load the exported batched solve from disk, or export and cache it.
+
+    Mirrors :func:`load_or_compile_discretization_solver` but at whole-loop
+    granularity: the single artifact is the *entire* vmapped SCP loop exported
+    at a fixed batch size, not a per-solver piece. On a cache hit the artifact
+    is deserialized with no XLA compile; on a miss the loop is exported against
+    the sample batched :class:`~openscvx.algorithms.base.AlgorithmState` and
+    parameters, serialized, and returned.
+
+    Unlike the per-solver solvers — whose ``call_exported`` has no ``vmap`` rule
+    and so cannot be folded into an outer ``vmap`` — this artifact already has
+    the batch baked in, so it is the one exportable form of a batched solve.
+
+    Args:
+        batched_fn: The ``jax.vmap``'d ``lax.while_loop`` to export — a pure
+            ``(batched_state, params) -> batched_state`` over an exportable
+            (QPAX / Moreau) backend.
+        cache_file: Path from :func:`get_solve_batched_cache_path`.
+        sample_state: A batched ``AlgorithmState`` with the artifact's leading
+            axis ``B``; supplies shapes/dtypes for the export trace.
+        sample_params: Problem parameters dict; supplies shapes/dtypes.
+
+    Returns:
+        A ``jax.export`` wrapper — call it via ``.call(state, params)``.
+    """
+    try:
+        with open(cache_file, "rb") as f:
+            wrapper = export.deserialize(f.read())
+        print("✓ Loaded existing batched solve")
+        return wrapper
+    except FileNotFoundError:
+        print("Exporting batched solve...")
+
+    wrapper = export.export(jax.jit(batched_fn))(sample_state, sample_params)
+
+    with open(cache_file, "wb") as f:
+        f.write(wrapper.serialize())
+    print("✓ Batched solve exported and saved")
+
+    return wrapper
 
 
 def load_or_compile_propagation_solver(

--- a/openscvx/utils/caching.py
+++ b/openscvx/utils/caching.py
@@ -123,6 +123,7 @@ def get_solve_batched_cache_path(
     solver: Any,
     discretizer: Any,
     B: int,
+    k_max: int,
     cache_dir: Optional[Path] = None,
 ) -> Path:
     """Cache path for the exported :meth:`Problem.solve_batched` artifact.
@@ -140,7 +141,10 @@ def get_solve_batched_cache_path(
     * the discretizer scheme (via ``discretizer._hash_into``),
     * the state/control scaling matrices ``inv_S_x`` / ``inv_S_u`` (settings-
       derived, not covered by any subsystem hash),
-    * the fixed batch size ``B`` (the artifact is exported at one ``B``), and
+    * the fixed batch size ``B`` (the artifact is exported at one ``B``),
+    * the resolved iteration cap ``k_max`` — the *actual* loop bound baked into
+      the exported ``lax.while_loop``, which a ``solve_batched(max_iters=...)``
+      override can change independently of ``algorithm.k_max``, and
     * the JAX version (exported artifacts are not guaranteed to survive an
       incompatible jax bump — the worst failure mode is deserializing one).
 
@@ -156,6 +160,8 @@ def get_solve_batched_cache_path(
         solver: The convex subproblem backend.
         discretizer: The dynamics discretizer.
         B: Fixed batch size the artifact is exported at.
+        k_max: Resolved SCP iteration cap baked into the exported loop
+            (``max_iters`` if the caller overrode it, else ``algorithm.k_max``).
         cache_dir: Override for the cache directory. ``None`` uses
             :func:`openscvx.get_cache_dir`.
 
@@ -172,6 +178,7 @@ def get_solve_batched_cache_path(
     hash_value_into(hasher, settings.sim.inv_S_x)
     hash_value_into(hasher, settings.sim.inv_S_u)
     hasher.update(f"B:{B}".encode())
+    hasher.update(f"k_max:{k_max}".encode())
     hasher.update(f"jax:{jax.__version__}".encode())
 
     final_hash = hasher.hexdigest()[:32]

--- a/openscvx/utils/printing.py
+++ b/openscvx/utils/printing.py
@@ -333,10 +333,10 @@ def print_batch_results_summary(
     """
     converged = np.asarray(result.converged, dtype=bool).reshape(-1)
     B = converged.shape[0]
-    n_ok  = int(converged.sum())
+    n_ok = int(converged.sum())
     n_bad = B - n_ok
 
-    t_full_arr = np.asarray(result.t_full)          # (B, T)
+    t_full_arr = np.asarray(result.t_full)  # (B, T)
     T = t_full_arr.shape[1]
     dt = float(t_full_arr[0, 1] - t_full_arr[0, 0]) if T > 1 else 0.0
 
@@ -344,8 +344,7 @@ def print_batch_results_summary(
     if converged.any():
         t_f_conv = t_finals[converged]
         t_f_str = (
-            f"{t_f_conv.mean():.3f} s  "
-            f"(min {t_f_conv.min():.3f} s, max {t_f_conv.max():.3f} s)"
+            f"{t_f_conv.mean():.3f} s  (min {t_f_conv.min():.3f} s, max {t_f_conv.max():.3f} s)"
         )
     else:
         t_f_str = "N/A (no converged solutions)"
@@ -353,10 +352,7 @@ def print_batch_results_summary(
     cost_arr = np.asarray(result.cost)
     if converged.any():
         c_conv = cost_arr[converged]
-        cost_str = (
-            f"{c_conv.mean():.4f}  "
-            f"(min {c_conv.min():.4f}, max {c_conv.max():.4f})"
-        )
+        cost_str = f"{c_conv.mean():.4f}  (min {c_conv.min():.4f}, max {c_conv.max():.4f})"
     else:
         cost_str = "N/A"
 
@@ -367,9 +363,9 @@ def print_batch_results_summary(
     else:
         ctcs_str = "N/A"
 
-    t_init    = timing_init    or 0.0
+    t_init = timing_init or 0.0
     t_compile = timing_compile or 0.0
-    t_solve   = timing_solve   or 0.0
+    t_solve = timing_solve or 0.0
     total_time = t_init + t_compile + t_solve + timing_post
 
     lines = [

--- a/openscvx/utils/printing.py
+++ b/openscvx/utils/printing.py
@@ -8,6 +8,7 @@ from importlib.metadata import PackageNotFoundError, version
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
 import jax
+import numpy as np
 from termcolor import colored
 
 if TYPE_CHECKING:
@@ -305,6 +306,90 @@ def print_results_summary(result: "OptimizationResults", timing_post, timing_ini
     ]
 
     print_summary_box(lines, "Results Summary")
+
+
+def print_batch_results_summary(
+    result: "OptimizationResults",
+    timing_post: float,
+    timing_init: Optional[float],
+    timing_solve: Optional[float],
+    *,
+    timing_compile: Optional[float] = None,
+) -> None:
+    """Print a results summary box for a batched post-processed solve.
+
+    Mirrors :func:`print_results_summary` for the output of
+    :meth:`~openscvx.problem.Problem.post_process_batched`.
+
+    Args:
+        result: Post-processed :class:`~openscvx.algorithms.OptimizationResults`
+            with ``x_full``, ``t_full``, ``cost``, and ``ctcs_violation`` set.
+        timing_post:    Propagation wall-clock time in seconds.
+        timing_init:    Initialize wall-clock time in seconds (``None`` if unknown).
+        timing_solve:   Batched-solve execution time in seconds (``None`` if unknown).
+            Compile time is excluded; see ``timing_compile``.
+        timing_compile: XLA/AOT compile time in seconds for the batched solve
+            (``None`` when the compiled artifact was loaded from cache).
+    """
+    converged = np.asarray(result.converged, dtype=bool).reshape(-1)
+    B = converged.shape[0]
+    n_ok  = int(converged.sum())
+    n_bad = B - n_ok
+
+    t_full_arr = np.asarray(result.t_full)          # (B, T)
+    T = t_full_arr.shape[1]
+    dt = float(t_full_arr[0, 1] - t_full_arr[0, 0]) if T > 1 else 0.0
+
+    t_finals = t_full_arr[:, -1]
+    if converged.any():
+        t_f_conv = t_finals[converged]
+        t_f_str = (
+            f"{t_f_conv.mean():.3f} s  "
+            f"(min {t_f_conv.min():.3f} s, max {t_f_conv.max():.3f} s)"
+        )
+    else:
+        t_f_str = "N/A (no converged solutions)"
+
+    cost_arr = np.asarray(result.cost)
+    if converged.any():
+        c_conv = cost_arr[converged]
+        cost_str = (
+            f"{c_conv.mean():.4f}  "
+            f"(min {c_conv.min():.4f}, max {c_conv.max():.4f})"
+        )
+    else:
+        cost_str = "N/A"
+
+    ctcs = result.ctcs_violation
+    if ctcs is not None and converged.any():
+        ctcs_arr = np.abs(np.asarray(ctcs)[converged])
+        ctcs_str = f"{ctcs_arr.max():.2e}"
+    else:
+        ctcs_str = "N/A"
+
+    t_init    = timing_init    or 0.0
+    t_compile = timing_compile or 0.0
+    t_solve   = timing_solve   or 0.0
+    total_time = t_init + t_compile + t_solve + timing_post
+
+    lines = [
+        "Batch Results Summary",
+        f"Batch size:              {B}",
+        f"Converged:               {n_ok} / {B}  ({100 * n_ok / B:.0f}%)",
+        f"Diverged:                {n_bad} / {B}",
+        "SEP",
+        f"Initialize time:         {t_init:.3f} s",
+        f"Compile time:            {t_compile:.3f} s",
+        f"Batched solve time:      {t_solve:.3f} s",
+        f"Propagation time:        {timing_post:.3f} s",
+        f"Total time:              {total_time:.3f} s",
+        "SEP",
+        f"Propagated steps:        {T}  (dt \u2248 {dt:.4f} s)",
+        f"Terminal time (conv.):   {t_f_str}",
+        f"Cost (conv.):            {cost_str}",
+        f"Max CTCS violation:      {ctcs_str}",
+    ]
+    print_summary_box(lines, "Batch Results Summary")
 
 
 def intro():

--- a/tests/solvers/_iteration_callback_helpers.py
+++ b/tests/solvers/_iteration_callback_helpers.py
@@ -272,4 +272,5 @@ def subproblem_data_from_numpy_stash(solver) -> SubproblemData:
         lam_vb_cross=jnp.zeros((0,)),
         x_init=jnp.asarray(x_init),
         x_term=jnp.asarray(x_term),
+        params=solver._parameters_dict,
     )

--- a/tests/solvers/test_iteration_callback_cvxpy.py
+++ b/tests/solvers/test_iteration_callback_cvxpy.py
@@ -144,6 +144,7 @@ def _subproblem_data_from_solver(prob) -> SubproblemData:
         lam_vb_cross=jnp.asarray(lam_vb_cross),
         x_init=jnp.asarray(x_init),
         x_term=jnp.asarray(x_term),
+        params={},
     )
 
 

--- a/tests/solvers/test_iteration_callback_vmap.py
+++ b/tests/solvers/test_iteration_callback_vmap.py
@@ -52,7 +52,7 @@ def _make_batch(data: SubproblemData, scales) -> SubproblemData:
     leaves = {f.name: getattr(data, f.name) for f in data.__dataclass_fields__.values()}
     leaves["lam_prox"] = stack_lam_prox(leaves["lam_prox"])
     for name in list(leaves):
-        if name == "lam_prox":
+        if name in ("lam_prox", "params"):
             continue
         leaves[name] = stack_other(leaves[name])
     return SubproblemData(**leaves)

--- a/tests/solvers/test_moreau_ptr_solver.py
+++ b/tests/solvers/test_moreau_ptr_solver.py
@@ -203,12 +203,8 @@ def test_moreau_spec_rejects_qpax_only_fields():
 # ============================================================================
 
 
-def test_moreau_rejects_user_convex_constraints():
-    """User .convex() constraints lower to second-order cones — not yet
-    supported by MoreauPTRSolver v1.  The refusal lives on
-    ``ConvexSolver.lower_convex_constraints`` (inherited default), so Moreau
-    rejects them during ``Problem(...)`` lowering — fail-fast before setup."""
-    n = 5
+def _make_pos_vel_problem_base(n=5):
+    """Return the (pos, vel, u, dyn, time) fixtures used by rejection tests."""
     pos = ox.State("pos", shape=(2,))
     pos.min = np.array([-10.0, -10.0])
     pos.max = np.array([10.0, 10.0])
@@ -225,9 +221,42 @@ def test_moreau_rejects_user_convex_constraints():
     u.guess = np.zeros((n, 2))
     dyn = {"pos": vel, "vel": u}
     time = ox.Time(initial=0.0, final=("minimize", 2.0), min=0.0, max=10.0)
+    return pos, vel, u, dyn, time
 
+
+def test_moreau_accepts_soc_convex_constraints():
+    """MoreauPTRSolver now supports SOC (.convex()) constraints.
+
+    An L2-norm inequality ``‖pos‖₂ ≤ 8`` canonicalises to a
+    :class:`~openscvx.solvers.cones.SOCConstraint` which is in
+    :attr:`MoreauPTRSolver.SUPPORTED_CONE_TYPES`.  Problem construction
+    must succeed without raising."""
+    n = 5
+    pos, vel, u, dyn, time = _make_pos_vel_problem_base(n)
     cvx_constraint = (ox.linalg.Norm(pos) <= 8.0).convex()
+    # Should not raise — Moreau supports SOC.
+    Problem(
+        dynamics=dyn,
+        states=[pos, vel],
+        controls=[u],
+        time=time,
+        constraints=[cvx_constraint],
+        N=n,
+        float_dtype="float64",
+        solver={"backend": "moreau"},
+    )
 
+
+def test_moreau_rejects_l1_norm_convex_constraints():
+    """L1-norm .convex() constraints are not yet supported by any JAX backend.
+
+    They require auxiliary epigraph variables that the current assemblers
+    do not introduce.  :func:`~openscvx.symbolic.canonicalize.canonicalize_nodal_constraint`
+    must raise :exc:`NotImplementedError` for this pattern."""
+    n = 5
+    pos, vel, u, dyn, time = _make_pos_vel_problem_base(n)
+    # L1 norm — requires auxiliary variables, not yet supported.
+    cvx_constraint = (ox.linalg.Norm(pos, ord=1) <= 8.0).convex()
     with pytest.raises(NotImplementedError):
         Problem(
             dynamics=dyn,
@@ -238,6 +267,29 @@ def test_moreau_rejects_user_convex_constraints():
             N=n,
             float_dtype="float64",
             solver={"backend": "moreau"},
+        )
+
+
+def test_qpax_rejects_soc_convex_constraints():
+    """QPAXPTRSolver does not support SOC constraints.
+
+    An L2-norm inequality canonicalises to
+    :class:`~openscvx.solvers.cones.SOCConstraint` which is **not** in
+    :attr:`QPAXPTRSolver.SUPPORTED_CONE_TYPES`.  The solver must raise
+    :exc:`NotImplementedError` during lowering."""
+    n = 5
+    pos, vel, u, dyn, time = _make_pos_vel_problem_base(n)
+    cvx_constraint = (ox.linalg.Norm(pos) <= 8.0).convex()
+    with pytest.raises(NotImplementedError):
+        Problem(
+            dynamics=dyn,
+            states=[pos, vel],
+            controls=[u],
+            time=time,
+            constraints=[cvx_constraint],
+            N=n,
+            float_dtype="float64",
+            solver={"backend": "qpax"},
         )
 
 

--- a/tests/solvers/test_qpax_ptr_solver.py
+++ b/tests/solvers/test_qpax_ptr_solver.py
@@ -187,10 +187,10 @@ def test_cvxpy_spec_rejects_jax_backend_fields():
 
 
 def test_qpax_rejects_user_convex_constraints():
-    """User .convex() constraints lower to second-order cones — outside QP.
-    The refusal lives on ``ConvexSolver.lower_convex_constraints`` (default
-    implementation), so QPAX rejects them during ``Problem(...)`` lowering —
-    fail-fast, before any heavier setup runs."""
+    """User .convex() norm constraints canonicalise to SOCConstraint.
+    QPAXPTRSolver's ``SUPPORTED_CONE_TYPES`` excludes SOC, so lowering must
+    raise ``NotImplementedError`` with a message naming the unsupported cone
+    and suggesting MoreauPTRSolver as an alternative."""
     n = 5
     pos = ox.State("pos", shape=(2,))
     pos.min = np.array([-10.0, -10.0])
@@ -217,7 +217,7 @@ def test_qpax_rejects_user_convex_constraints():
 
     with pytest.raises(
         NotImplementedError,
-        match=r"QPAXPTRSolver does not support user-defined \.convex\(\)",
+        match=r"QPAXPTRSolver does not support SOCConstraint",
     ):
         Problem(
             dynamics=dyn,

--- a/tests/solvers/test_subproblem_pytree.py
+++ b/tests/solvers/test_subproblem_pytree.py
@@ -54,6 +54,7 @@ def _dummy_subproblem_data(N=4, n_x=3, n_u=2, n_nodal=2, n_cross=1):
         lam_vb_cross=jnp.ones((n_cross,)),
         x_init=jnp.array([0.0, jnp.nan, 1.0]),
         x_term=jnp.full((n_x,), jnp.nan),
+        params={},
     )
 
 

--- a/tests/test_solve_batched_brachistochrone.py
+++ b/tests/test_solve_batched_brachistochrone.py
@@ -1,0 +1,67 @@
+"""``Problem.solve_batched`` matches ``jax.vmap(solve_jax)`` element-wise.
+
+``solve_batched`` owns the batch axis internally (``jax.vmap`` applied inside
+the method) where :func:`jax.vmap` over :meth:`Problem.solve_jax` leaves it to
+the caller. With no export wired up (Phase 1) the two are just different
+spellings of the same batched solve, so over a stack of boundary conditions
+each batch element must agree with the corresponding ``jax.vmap(solve_jax)``
+result. CVXPy runs the ``B`` solves sequentially (host CVXPy isn't
+thread-safe); QPAX runs them in parallel under vmap. Parallels
+``tests/test_solve_jax_vmap_brachistochrone.py``.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from tests.solvers._iteration_callback_helpers import build_brachistochrone
+
+
+@pytest.mark.parametrize("backend", ["cvxpy", "qpax"])
+def test_solve_batched_matches_vmap_solve_jax(backend):
+    if backend == "qpax":
+        pytest.importorskip("qpax")
+
+    prob = build_brachistochrone(backend, n=8, k_max=20)
+    prob.initialize()
+
+    # Default pins (full unified vectors with ``nan`` at non-Fix entries).
+    x_init_default = prob.state.x_init_pin
+    x_term_default = prob.state.x_term_pin
+
+    # Stack four ICs by varying the x-coordinate of position (component 0);
+    # the terminal pin is shared, so broadcast it to the same leading axis.
+    shifts = jnp.array([0.0, 0.3, -0.3, 0.6])
+    x0_stack = jnp.stack([x_init_default.at[0].set(x_init_default[0] + s) for s in shifts])
+    xf_stack = jnp.broadcast_to(x_term_default, x0_stack.shape)
+
+    # Reference: caller-owned vmap over solve_jax across both stacks.
+    reference = jax.vmap(prob.solve_jax, in_axes=(0, 0, None))(x0_stack, xf_stack, None)
+
+    # Internal-vmap batched solve.
+    batched = prob.solve_batched(x0_stack, xf_stack)
+
+    assert batched.x.shape == reference.x.shape == (x0_stack.shape[0], 8, x0_stack.shape[1])
+    np.testing.assert_allclose(np.asarray(batched.x), np.asarray(reference.x), atol=1e-5, rtol=1e-5)
+    np.testing.assert_allclose(np.asarray(batched.u), np.asarray(reference.u), atol=1e-5, rtol=1e-5)
+    # ``converged`` carries the per-batch leading axis.
+    assert batched.converged.shape == (x0_stack.shape[0],)
+
+    jax.clear_caches()
+
+
+def test_solve_batched_before_initialize_raises():
+    prob = build_brachistochrone("qpax" if _has_qpax() else "cvxpy", n=8, k_max=1)
+    x_stack = jnp.zeros((2, prob.settings.sim.n_states))
+    with pytest.raises(ValueError, match="initialize"):
+        prob.solve_batched(x_stack, x_stack)
+
+
+def _has_qpax() -> bool:
+    try:
+        import qpax  # noqa: F401
+
+        return True
+    except ImportError:
+        return False

--- a/tests/test_solve_batched_brachistochrone.py
+++ b/tests/test_solve_batched_brachistochrone.py
@@ -3,7 +3,7 @@
 ``solve_batched`` owns the batch axis internally (``jax.vmap`` applied inside
 the method) where :func:`jax.vmap` over :meth:`Problem.solve_jax` leaves it to
 the caller. With no export wired up (Phase 1) the two are just different
-spellings of the same batched solve, so over a stack of boundary conditions
+spellings of the same batched solve, so over a stack of trajectory guesses
 each batch element must agree with the corresponding ``jax.vmap(solve_jax)``
 result. CVXPy runs the ``B`` solves sequentially (host CVXPy isn't
 thread-safe); QPAX runs them in parallel under vmap. Parallels
@@ -26,36 +26,40 @@ def test_solve_batched_matches_vmap_solve_jax(backend):
     prob = build_brachistochrone(backend, n=8, k_max=20)
     prob.initialize()
 
-    # Default pins (full unified vectors with ``nan`` at non-Fix entries).
-    x_init_default = prob.state.x_init_pin
-    x_term_default = prob.state.x_term_pin
+    base_x = prob.state.x
 
-    # Stack four ICs by varying the x-coordinate of position (component 0);
-    # the terminal pin is shared, so broadcast it to the same leading axis.
+    # Stack four guesses by varying the x-coordinate of position (component 0).
     shifts = jnp.array([0.0, 0.3, -0.3, 0.6])
-    x0_stack = jnp.stack([x_init_default.at[0].set(x_init_default[0] + s) for s in shifts])
-    xf_stack = jnp.broadcast_to(x_term_default, x0_stack.shape)
+    x_guess_stack = jnp.stack([base_x.at[0, 0].set(base_x[0, 0] + s) for s in shifts])
 
-    # Reference: caller-owned vmap over solve_jax across both stacks.
-    reference = jax.vmap(prob.solve_jax, in_axes=(0, 0, None))(x0_stack, xf_stack, None)
+    # Per-element reference.
+    bare_xs = []
+    bare_us = []
+    for i in range(x_guess_stack.shape[0]):
+        res = prob.solve_jax(x_guess=x_guess_stack[i])
+        bare_xs.append(np.asarray(res.x))
+        bare_us.append(np.asarray(res.u))
+    bare_xs = np.stack(bare_xs)
+    bare_us = np.stack(bare_us)
 
     # Internal-vmap batched solve.
-    batched = prob.solve_batched(x0_stack, xf_stack)
+    batched = prob.solve_batched(x_guess=x_guess_stack)
 
-    assert batched.x.shape == reference.x.shape == (x0_stack.shape[0], 8, x0_stack.shape[1])
-    np.testing.assert_allclose(np.asarray(batched.x), np.asarray(reference.x), atol=1e-5, rtol=1e-5)
-    np.testing.assert_allclose(np.asarray(batched.u), np.asarray(reference.u), atol=1e-5, rtol=1e-5)
-    # ``converged`` carries the per-batch leading axis.
-    assert batched.converged.shape == (x0_stack.shape[0],)
+    assert batched.x.shape == bare_xs.shape == (x_guess_stack.shape[0], 8, base_x.shape[1])
+    np.testing.assert_allclose(np.asarray(batched.x), bare_xs, atol=1e-5, rtol=1e-5)
+    np.testing.assert_allclose(np.asarray(batched.u), bare_us, atol=1e-5, rtol=1e-5)
+    assert batched.converged.shape == (x_guess_stack.shape[0],)
 
     jax.clear_caches()
 
 
 def test_solve_batched_before_initialize_raises():
     prob = build_brachistochrone("qpax" if _has_qpax() else "cvxpy", n=8, k_max=1)
-    x_stack = jnp.zeros((2, prob.settings.sim.n_states))
+    N = prob.settings.sim.n
+    n_x = prob.settings.sim.n_states
+    x_stack = jnp.zeros((2, N, n_x))
     with pytest.raises(ValueError, match="initialize"):
-        prob.solve_batched(x_stack, x_stack)
+        prob.solve_batched(x_guess=x_stack)
 
 
 def _has_qpax() -> bool:

--- a/tests/test_solve_batched_cvxpy_export_errors.py
+++ b/tests/test_solve_batched_cvxpy_export_errors.py
@@ -19,13 +19,11 @@ def test_cvxpy_export_raises_teaching_error():
     prob.settings.sim.save_compiled = True
     prob.initialize()
 
-    x_init = prob.state.x_init_pin
-    x_term = prob.state.x_term_pin
-    x0_stack = jnp.broadcast_to(x_init, (3,) + x_init.shape)
-    xf_stack = jnp.broadcast_to(x_term, (3,) + x_term.shape)
+    base_x = prob.state.x
+    x_guess_stack = jnp.broadcast_to(base_x, (3,) + base_x.shape)
 
     with pytest.raises(ValueError, match="pure_callback|QPAX|Moreau"):
-        prob.solve_batched(x0_stack, xf_stack)
+        prob.solve_batched(x_guess=x_guess_stack)
 
 
 def test_cvxpy_sequential_path_still_works_without_export():
@@ -33,10 +31,8 @@ def test_cvxpy_sequential_path_still_works_without_export():
     prob.settings.sim.save_compiled = False
     prob.initialize()
 
-    x_init = prob.state.x_init_pin
-    x_term = prob.state.x_term_pin
-    x0_stack = jnp.stack([x_init.at[0].set(x_init[0] + s) for s in (0.0, 0.3)])
-    xf_stack = jnp.broadcast_to(x_term, x0_stack.shape)
+    base_x = prob.state.x
+    x_guess_stack = jnp.stack([base_x.at[0, 0].set(base_x[0, 0] + s) for s in (0.0, 0.3)])
 
-    batched = prob.solve_batched(x0_stack, xf_stack)
-    assert batched.x.shape == (2, 8, x_init.shape[0])
+    batched = prob.solve_batched(x_guess=x_guess_stack)
+    assert batched.x.shape == (2, 8, base_x.shape[1])

--- a/tests/test_solve_batched_cvxpy_export_errors.py
+++ b/tests/test_solve_batched_cvxpy_export_errors.py
@@ -1,0 +1,42 @@
+"""``solve_batched(save_compiled=True)`` refuses the CVXPy backend.
+
+CVXPy's :meth:`iteration_callback` wraps the host solve in a
+``jax.pure_callback``, which ``jax.export`` cannot serialize. Rather than
+silently degrading to an uncached in-process solve — defeating the whole reason
+the user set ``save_compiled`` — ``solve_batched`` raises a teaching error
+pointing at the exportable backends. With ``save_compiled=False`` the same
+problem still runs ``B`` sequential CVXPy solves.
+"""
+
+import jax.numpy as jnp
+import pytest
+
+from tests.solvers._iteration_callback_helpers import build_brachistochrone
+
+
+def test_cvxpy_export_raises_teaching_error():
+    prob = build_brachistochrone("cvxpy", n=8, k_max=2)
+    prob.settings.sim.save_compiled = True
+    prob.initialize()
+
+    x_init = prob.state.x_init_pin
+    x_term = prob.state.x_term_pin
+    x0_stack = jnp.broadcast_to(x_init, (3,) + x_init.shape)
+    xf_stack = jnp.broadcast_to(x_term, (3,) + x_term.shape)
+
+    with pytest.raises(ValueError, match="pure_callback|QPAX|Moreau"):
+        prob.solve_batched(x0_stack, xf_stack)
+
+
+def test_cvxpy_sequential_path_still_works_without_export():
+    prob = build_brachistochrone("cvxpy", n=8, k_max=20)
+    prob.settings.sim.save_compiled = False
+    prob.initialize()
+
+    x_init = prob.state.x_init_pin
+    x_term = prob.state.x_term_pin
+    x0_stack = jnp.stack([x_init.at[0].set(x_init[0] + s) for s in (0.0, 0.3)])
+    xf_stack = jnp.broadcast_to(x_term, x0_stack.shape)
+
+    batched = prob.solve_batched(x0_stack, xf_stack)
+    assert batched.x.shape == (2, 8, x_init.shape[0])

--- a/tests/test_solve_batched_export_roundtrip.py
+++ b/tests/test_solve_batched_export_roundtrip.py
@@ -1,0 +1,117 @@
+"""``solve_batched`` exports once and deserializes across processes.
+
+Under ``save_compiled=True`` the whole vmapped SCP loop is exported to the
+solver cache on the first call; a later ``Problem`` with the same structure
+deserializes that artifact instead of recompiling. This is the entire reason
+``solve_batched`` exists over ``jax.vmap(solve_jax)`` (which re-traces every
+launch). The second half asserts the correctness-critical cache key (§4):
+anything that changes the exported loop — backend, ``solver_args``, ``k_max``,
+discretizer, scaling — must produce a *different* path, so a stale artifact is
+never silently reused.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from openscvx.utils.caching import get_solve_batched_cache_path
+from tests.solvers._iteration_callback_helpers import build_brachistochrone
+
+pytestmark = pytest.mark.filterwarnings("ignore")
+
+
+def _stacks(prob, shifts=(0.0, 0.3, -0.3, 0.6)):
+    x_init = prob.state.x_init_pin
+    x_term = prob.state.x_term_pin
+    x0_stack = jnp.stack([x_init.at[0].set(x_init[0] + s) for s in shifts])
+    xf_stack = jnp.broadcast_to(x_term, x0_stack.shape)
+    return x0_stack, xf_stack
+
+
+def test_export_roundtrip_matches_and_skips_recompile(monkeypatch, tmp_path):
+    pytest.importorskip("qpax")
+    monkeypatch.setenv("OPENSCVX_CACHE_DIR", str(tmp_path))
+
+    # Baseline: the in-process (``save_compiled=False``) batched solve, which
+    # Phase 1 verified equals ``jax.vmap(solve_jax)``. ``jax.vmap(solve_jax)``
+    # itself can't be the baseline once ``save_compiled=True`` — its inner
+    # solvers are then ``call_exported``, which has no outer vmap rule (FACT2).
+    ref_prob = build_brachistochrone("qpax", n=8, k_max=20)
+    ref_prob.settings.sim.save_compiled = False
+    ref_prob.initialize()
+    reference = ref_prob.solve_batched(*_stacks(ref_prob))
+    jax.clear_caches()
+
+    # First process: traces, exports, writes the artifact.
+    prob1 = build_brachistochrone("qpax", n=8, k_max=20)
+    prob1.settings.sim.save_compiled = True
+    prob1.initialize()
+    first = prob1.solve_batched(*_stacks(prob1))
+
+    artifacts = list(tmp_path.glob("compiled_solve_batched_*.jax"))
+    assert len(artifacts) == 1, "first solve_batched should write exactly one artifact"
+    artifact = artifacts[0]
+    mtime_after_first = artifact.stat().st_mtime_ns
+
+    assert first.x.shape == reference.x.shape == (4, 8, ref_prob.settings.sim.n_states)
+    np.testing.assert_allclose(np.asarray(first.x), np.asarray(reference.x), atol=1e-5, rtol=1e-5)
+
+    jax.clear_caches()
+
+    # Second process: a fresh Problem deserializes the artifact (no re-export).
+    prob2 = build_brachistochrone("qpax", n=8, k_max=20)
+    prob2.settings.sim.save_compiled = True
+    prob2.initialize()
+    second = prob2.solve_batched(*_stacks(prob2))
+
+    assert artifact.stat().st_mtime_ns == mtime_after_first, "second solve must not re-export"
+    np.testing.assert_allclose(np.asarray(second.x), np.asarray(first.x), atol=1e-5, rtol=1e-5)
+    np.testing.assert_allclose(np.asarray(second.u), np.asarray(first.u), atol=1e-5, rtol=1e-5)
+
+    jax.clear_caches()
+
+
+def test_cache_key_invalidates_on_artifact_changing_state(tmp_path):
+    pytest.importorskip("qpax")
+
+    prob = build_brachistochrone("qpax", n=8, k_max=20)
+    prob.initialize()
+
+    def path(p, B=4):
+        return get_solve_batched_cache_path(
+            p.symbolic, p.settings, p._algorithm, p._solver, p._discretizer, B, cache_dir=tmp_path
+        )
+
+    base = path(prob)
+
+    # Same problem, same call → identical path (a cache hit, not a stale miss).
+    assert path(prob) == base
+
+    # Batch size is baked into the artifact → part of the key.
+    assert path(prob, B=2) != base
+
+    # k_max changes the unrolled loop bound.
+    prob._algorithm.k_max += 1
+    assert path(prob) != base
+    prob._algorithm.k_max -= 1
+    assert path(prob) == base
+
+    # solver_args (tolerances / iteration caps) are baked into the backend solve.
+    saved_max_iter = prob._solver.solver_args.get("max_iter")
+    prob._solver.solver_args["max_iter"] = (saved_max_iter or 30) + 7
+    assert path(prob) != base
+    prob._solver.solver_args["max_iter"] = saved_max_iter
+    assert path(prob) == base
+
+    # Scaling matrices (derived from state/control bounds, Q2) feed the metrics.
+    saved = prob.settings.sim.inv_S_x
+    prob.settings.sim.inv_S_x = saved * 2.0
+    assert path(prob) != base
+    prob.settings.sim.inv_S_x = saved
+    assert path(prob) == base
+
+    # A different convex backend is a different exported program.
+    other = build_brachistochrone("cvxpy", n=8, k_max=20)
+    other.initialize()
+    assert path(other) != base

--- a/tests/test_solve_batched_export_roundtrip.py
+++ b/tests/test_solve_batched_export_roundtrip.py
@@ -78,9 +78,10 @@ def test_cache_key_invalidates_on_artifact_changing_state(tmp_path):
     prob = build_brachistochrone("qpax", n=8, k_max=20)
     prob.initialize()
 
-    def path(p, B=4):
+    def path(p, B=4, k_max=None):
         return get_solve_batched_cache_path(
-            p.symbolic, p.settings, p._algorithm, p._solver, p._discretizer, B, cache_dir=tmp_path
+            p.symbolic, p.settings, p._algorithm, p._solver, p._discretizer,
+            B, p._algorithm.k_max if k_max is None else k_max, cache_dir=tmp_path
         )
 
     base = path(prob)
@@ -91,11 +92,13 @@ def test_cache_key_invalidates_on_artifact_changing_state(tmp_path):
     # Batch size is baked into the artifact → part of the key.
     assert path(prob, B=2) != base
 
-    # k_max changes the unrolled loop bound.
+    # k_max is the resolved loop bound. Both routes that change it must re-key:
+    # bumping the algorithm default, and a per-call ``max_iters`` override.
     prob._algorithm.k_max += 1
     assert path(prob) != base
     prob._algorithm.k_max -= 1
     assert path(prob) == base
+    assert path(prob, k_max=prob._algorithm.k_max + 1) != base
 
     # solver_args (tolerances / iteration caps) are baked into the backend solve.
     saved_max_iter = prob._solver.solver_args.get("max_iter")

--- a/tests/test_solve_batched_export_roundtrip.py
+++ b/tests/test_solve_batched_export_roundtrip.py
@@ -21,12 +21,9 @@ from tests.solvers._iteration_callback_helpers import build_brachistochrone
 pytestmark = pytest.mark.filterwarnings("ignore")
 
 
-def _stacks(prob, shifts=(0.0, 0.3, -0.3, 0.6)):
-    x_init = prob.state.x_init_pin
-    x_term = prob.state.x_term_pin
-    x0_stack = jnp.stack([x_init.at[0].set(x_init[0] + s) for s in shifts])
-    xf_stack = jnp.broadcast_to(x_term, x0_stack.shape)
-    return x0_stack, xf_stack
+def _guess_stack(prob, shifts=(0.0, 0.3, -0.3, 0.6)):
+    base_x = prob.state.x
+    return jnp.stack([base_x.at[0, 0].set(base_x[0, 0] + s) for s in shifts])
 
 
 def test_export_roundtrip_matches_and_skips_recompile(monkeypatch, tmp_path):
@@ -40,14 +37,14 @@ def test_export_roundtrip_matches_and_skips_recompile(monkeypatch, tmp_path):
     ref_prob = build_brachistochrone("qpax", n=8, k_max=20)
     ref_prob.settings.sim.save_compiled = False
     ref_prob.initialize()
-    reference = ref_prob.solve_batched(*_stacks(ref_prob))
+    reference = ref_prob.solve_batched(x_guess=_guess_stack(ref_prob))
     jax.clear_caches()
 
     # First process: traces, exports, writes the artifact.
     prob1 = build_brachistochrone("qpax", n=8, k_max=20)
     prob1.settings.sim.save_compiled = True
     prob1.initialize()
-    first = prob1.solve_batched(*_stacks(prob1))
+    first = prob1.solve_batched(x_guess=_guess_stack(prob1))
 
     artifacts = list(tmp_path.glob("compiled_solve_batched_*.jax"))
     assert len(artifacts) == 1, "first solve_batched should write exactly one artifact"
@@ -63,7 +60,7 @@ def test_export_roundtrip_matches_and_skips_recompile(monkeypatch, tmp_path):
     prob2 = build_brachistochrone("qpax", n=8, k_max=20)
     prob2.settings.sim.save_compiled = True
     prob2.initialize()
-    second = prob2.solve_batched(*_stacks(prob2))
+    second = prob2.solve_batched(x_guess=_guess_stack(prob2))
 
     assert artifact.stat().st_mtime_ns == mtime_after_first, "second solve must not re-export"
     np.testing.assert_allclose(np.asarray(second.x), np.asarray(first.x), atol=1e-5, rtol=1e-5)

--- a/tests/test_solve_batched_export_roundtrip.py
+++ b/tests/test_solve_batched_export_roundtrip.py
@@ -80,8 +80,14 @@ def test_cache_key_invalidates_on_artifact_changing_state(tmp_path):
 
     def path(p, B=4, k_max=None):
         return get_solve_batched_cache_path(
-            p.symbolic, p.settings, p._algorithm, p._solver, p._discretizer,
-            B, p._algorithm.k_max if k_max is None else k_max, cache_dir=tmp_path
+            p.symbolic,
+            p.settings,
+            p._algorithm,
+            p._solver,
+            p._discretizer,
+            B,
+            p._algorithm.k_max if k_max is None else k_max,
+            cache_dir=tmp_path,
         )
 
     base = path(prob)


### PR DESCRIPTION
## Summary

Adds `Problem.solve_batched(x0_stack, xf_stack, parameters)` — a third solve entry point alongside `solve()` (stateful, since v0.5.2) and `solve_jax()` (JAX-pure, #514). It applies `jax.vmap` **internally** so the whole batched SCP loop becomes a single `jax.export`-serializable artifact: under `save_compiled=True` it is written to the solver cache on the first call and deserialized on later processes, skipping the XLA compile that `jax.vmap(solve_jax)` pays on every fresh launch.

This is the **only** way to get a disk-cached batched solve — `call_exported` has no outer-vmap rule, so a user cannot `jax.vmap` an already-exported artifact. Owning the batch axis internally is what makes the solve exportable.

Plan: `plans/solve-batched-export.md` (local-only). Builds on #514.

## What's in it

- **Phase 1** — in-process `solve_batched` with internal vmap, batched `OptimizationResults` (always-jit, no disk).
- **Phase 2** — `jax.export` round-trip + the correctness-critical cache key. The export call is trivial; the cache **invalidation** is the real work: a stale artifact reused across a config change is a wrong-answer bug, not a perf miss.
  - New `_hash_into` contributions on `PTRSolver` (backend + `solver_args`), the algorithm/autotuner (`ep_*` / `k_max` / weights), and the discretizer (class + `dis_type` + `ode_solver`), mirroring the symbolic `_hash_into` protocol — "what about me matters for the hash" lives *with* each object.
  - Assembler `get_solve_batched_cache_path` folds those in plus `inv_S_x`/`inv_S_u`, `B`, and `jax.__version__`.
  - `PTRSolver.exportable` property → CVXPy (a `jax.pure_callback`) raises a teaching error pointing at QPAX/Moreau rather than silently degrading.
  - `AlgorithmState` registered with `jax.export.register_pytree_node_serialization` (the export in/out pytree).

## Tests

`pytest -n auto -m 'not integration'` green on the touched suites (122 passed / 22 skipped). New: batched-vs-`vmap(solve_jax)` equivalence, export round-trip + cache invalidation, CVXPy teaching error.

## Review status

Ran a four-lens review panel (technical correctness, bloat, maintainability, API/scope) — **no blockers**; all four said land. Folded in two cheap hardening fixes (declare `solver_args` on base `PTRSolver`; document the `AutotuningBase` `vars(self)` sweep). Remaining should-fixes tracked below.

## Follow-ups (not gating)

- **Tighten in-process-batching steering.** `solve_batched(save_compiled=False)` and `jax.vmap(solve_jax)` overlap; the docstring should label the former a fallback so `jax.vmap(solve_jax)` is the unambiguous answer for in-program batching ("one way to do common things").
- **`max_iters` public-door test** — the keyword is symmetric with `solve_jax` but never driven through `solve_batched(max_iters=...)` end-to-end.
- **Formalize the `_hash_into` extension contract** (the modularity concern). It's now a required behavior when adding a solver/algorithm/autotuner/discretizer, but it's inconsistent (base default on solver/discretizer/autotuner, none on `Algorithm`) and unenforced (not `@abstractmethod`), and only exercised on the export path. A new algorithm that omits it passes every non-export test, then `AttributeError`s on `solve_batched(save_compiled=True)`. Worth: a base default or `@abstractmethod` on `Algorithm`, a CI test that a throwaway subclass at each extension point re-keys, and a short "extending OpenSCvx" doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

Retroactive link: part of the batchable-solve line for #493 and #494.
