### PR TITLE
solve_batched: unified rank-based batching API with in_axes override

### DIFF
--- a/docs/UnderTheHood/batching_jit_grad.md
+++ b/docs/UnderTheHood/batching_jit_grad.md
@@ -111,26 +111,62 @@ results = problem.solve_batched(
 )
 ```
 
-### Hyperparameter sweeps
+### Hyperparameter sweeps: the `overrides` dict
 
-The SCP loop constants — `ep_tr` / `ep_vb` / `ep_vc` / `lam_cost_drop` /
-`max_iters` — ride the `AlgorithmState` pytree as runtime inputs rather than
-closure constants. Two consequences:
+Every `AlgorithmState` field is a runtime input riding the state pytree, and
+one `overrides` dict reaches any of them by name — convergence thresholds
+(`ep_tr` / `ep_vb` / `ep_vc`), penalty weights (`lam_prox` / `lam_vc` /
+`lam_cost`), the seed iterate, autotuner hyperparameters. There is no
+whitelist: the field declaration is the registration, and the
+`AlgorithmState` attribute docs are the override reference. (`max_iters`
+survives as a named kwarg — sugar for `overrides={"k_max": ...}`; passing
+both raises, as does an override that shadows any other named kwarg's
+field.)
 
-* On `solve_jax`, each is a per-solve keyword: `solve_jax(ep_tr=1e-6,
-  max_iters=50)` retraces nothing.
-* On `solve_batched`, each follows the same rank rule (declared `()`): a
-  `(B,)` vector sweeps it per element, batched alongside (or instead of) any
-  other input, against one cached artifact:
+* On `solve_jax`, each value matches the field's shape, or is a scalar
+  broadcast to it: `solve_jax(overrides={"ep_tr": 1e-6, "lam_prox": 2.0})`
+  retraces nothing.
+* On `solve_batched`, each value follows the rank rule against the field's
+  shape, plus two **fill** forms for array-shaped fields: a scalar (shared)
+  or a `(B,)` vector (one scalar per element, broadcast to the field shape).
+  Exact shapes win when both parse; `in_axes={"overrides": {name: 0}}`
+  forces the per-element reading. All against one cached artifact:
 
 ```python
-sweep = problem.solve_batched(ep_tr=jnp.logspace(-6, -3, B))   # tolerance sweep
+sweep = problem.solve_batched(overrides={"ep_tr": jnp.logspace(-6, -3, B)})
+weights = problem.solve_batched(overrides={"lam_prox": jnp.array([0.5, 1.0, 4.0])})
 budgets = problem.solve_batched(max_iters=jnp.array([5, 10, 20]))  # per-element caps
 ```
 
 The batch runs until its slowest element converges or exhausts its own cap;
 finished elements are frozen, not re-iterated, so each element matches the
 corresponding single `solve_jax` run.
+
+**New autotuners batch for free.** An autotuner's tunable knobs follow the
+same derivation: declare them as fields on a `HyperParams` subclass — bare
+annotations, no decorator; subclassing applies the frozen-dataclass transform
+and the JAX pytree registration, and the annotation picks the dtype (`int`
+gets the iteration counter's, `float` the problem's) — assign an instance to
+`self.hyper`, and read `state.hyper.<field>` inside `update_weights` (see the
+`AutotuningBase` docstring). The declaration is the registration — each field
+immediately works as a `solve_jax` override, a `solve_batched` sweep target,
+and a runtime input of the exported artifact, with zero edits anywhere else:
+
+```python
+from openscvx.algorithms import AutotuningBase, HyperParams
+
+class MyHyper(HyperParams):
+    ramp: float = 2.0
+
+class MyAutotuner(AutotuningBase):
+    def __init__(self, ramp: float = 2.0):
+        self.hyper = MyHyper(ramp=ramp)
+
+    def update_weights(self, state, ...):
+        ...state.hyper.ramp...
+
+results = problem.solve_batched(overrides={"ramp": jnp.linspace(1.5, 3.0, B)})
+```
 
 Pick `solve_batched` when **cross-process cold-start dominates** — short-lived
 processes (CI sweeps, notebook restarts, deployed workers) that otherwise pay
@@ -176,9 +212,10 @@ layer uses):
 
 Change any of these — backend, a penalty weight, a state bound, which
 parameters are batched — and you get a different cache path, so a stale
-artifact is never reused. The convergence thresholds and `max_iters` are
-deliberately *not* in the key: they are runtime inputs on the state pytree, so
-one artifact serves every tolerance and iteration-cap setting.
+artifact is never reused. Everything `overrides` can reach — convergence
+thresholds, `max_iters`, weights, autotuner hyperparameters — is deliberately
+*not* in the key: those are runtime inputs on the state pytree, so one
+artifact serves every setting of them.
 
 `examples/abstract/brachistochrone_batched.py` shows both paths side by side;
 re-running it is itself the cross-process demo.
@@ -219,14 +256,12 @@ problem.solve_jax(
     *,
     x_guess=None,        # (N, n_x) state trajectory warm-start
     u_guess=None,        # (N, n_u) control trajectory warm-start
-    ep_tr=None,          # convergence threshold on J_tr; falls back to
-                         #     ``algorithm.ep_tr``
-    ep_vb=None,          # convergence threshold on J_vb
-    ep_vc=None,          # convergence threshold on J_vc
-    lam_cost_drop=None,  # iteration after which lam_cost relaxes (-1 = never)
-    max_iters=None,      # SCP iteration cap; falls back to ``algorithm.k_max``.
-                         #     A runtime input on the state pytree — no value
-                         #     forces a retrace
+    max_iters=None,      # SCP iteration cap; sugar for overrides={"k_max": ...};
+                         #     falls back to ``algorithm.k_max``
+    overrides=None,      # any AlgorithmState field by name (ep_tr, lam_prox,
+                         #     ...); values match the field shape or fill it
+                         #     from a scalar. Runtime inputs on the state
+                         #     pytree — no value forces a retrace
 )
 ```
 

--- a/docs/UnderTheHood/batching_jit_grad.md
+++ b/docs/UnderTheHood/batching_jit_grad.md
@@ -150,8 +150,8 @@ kwarg's field. Construction-only keys of the constructor dict — `autotuner`,
   forces the per-element reading. All against one cached artifact:
 
 ```python
-B = 8  # batch size — an ordinary int used to build the arrays; the solver
-       # never receives it, it reads B off the leading axes
+B = 8  # batch size. Just an int for building the arrays below — there is no
+       # B argument; solve_batched infers it from the leading-axis lengths.
 sweep = problem.solve_batched(algorithm={"ep_tr": jnp.logspace(-6, -3, B)})
 weights = problem.solve_batched(algorithm={"lam_prox": jnp.array([0.5, 1.0, 4.0])})
 budgets = problem.solve_batched(max_iters=jnp.array([5, 10, 20]))  # per-element caps

--- a/docs/UnderTheHood/batching_jit_grad.md
+++ b/docs/UnderTheHood/batching_jit_grad.md
@@ -78,6 +78,60 @@ batched = problem.solve_batched(x_initial=x0_batch, parameters=params)
 # batched.x.shape == (B, N, n_states) — same pytree jax.vmap(solve_jax) returns.
 ```
 
+### One rule: add a leading batch axis to whatever varies
+
+`solve_batched` takes exactly `solve_jax`'s arguments. Every batchable input
+has a *declared* (unbatched) shape the library knows — `(n_x,)` for the
+boundary pins, `(N, n_x)` / `(N, n_u)` for the trajectory guesses, the
+parameter's stored shape for each parameter, and `()` for the SCP
+hyperparameters. An argument that matches its declared shape is **shared** by
+every batch element; one with exactly one extra leading axis is **batched**
+along it. Rank against the declared shape decides — never the leading-axis
+value — so a shared `(B, n)` matrix parameter is never misread as batched:
+
+```python
+results = problem.solve_batched(
+    x_initial=x0_batch,                  # (B, n_x): rank = declared+1 -> batched
+    parameters={
+        "gate_center": centers,          # (B, 3) vs declared (3,)  -> batched
+        "gate_radius": 0.5,              # declared shape           -> shared
+    },
+)
+```
+
+For the rare entry the rank rule cannot express — e.g. batching a declared
+rank-1 parameter element-wise — pass an explicit `in_axes` in `jax.vmap`'s
+vocabulary (`0` = batched along the leading axis, `None` = shared; partial
+specs fall back to the rank rule):
+
+```python
+results = problem.solve_batched(
+    parameters={"weights": w},           # (B,) is also w's declared shape...
+    in_axes={"parameters": {"weights": 0}},  # ...so say "batched" explicitly
+)
+```
+
+### Hyperparameter sweeps
+
+The SCP loop constants — `ep_tr` / `ep_vb` / `ep_vc` / `lam_cost_drop` /
+`max_iters` — ride the `AlgorithmState` pytree as runtime inputs rather than
+closure constants. Two consequences:
+
+* On `solve_jax`, each is a per-solve keyword: `solve_jax(ep_tr=1e-6,
+  max_iters=50)` retraces nothing.
+* On `solve_batched`, each follows the same rank rule (declared `()`): a
+  `(B,)` vector sweeps it per element, batched alongside (or instead of) any
+  other input, against one cached artifact:
+
+```python
+sweep = problem.solve_batched(ep_tr=jnp.logspace(-6, -3, B))   # tolerance sweep
+budgets = problem.solve_batched(max_iters=jnp.array([5, 10, 20]))  # per-element caps
+```
+
+The batch runs until its slowest element converges or exhausts its own cap;
+finished elements are frozen, not re-iterated, so each element matches the
+corresponding single `solve_jax` run.
+
 Pick `solve_batched` when **cross-process cold-start dominates** — short-lived
 processes (CI sweeps, notebook restarts, deployed workers) that otherwise pay
 the compile every launch. Pick `jax.vmap(solve_jax)` for everything in-program,
@@ -111,15 +165,20 @@ object contributing through its own `_hash_into` (the same protocol the symbolic
 layer uses):
 
 * the convex backend class + its `solver_args`,
-* the algorithm + autotuner + convergence thresholds + initial weights,
+* the algorithm + autotuner + initial weights,
 * the discretizer scheme (class + hold type + ODE solver),
 * the state/control scaling matrices `inv_S_x` / `inv_S_u`,
-* the fixed batch size `B` (the artifact is exported at one `B`), and
+* the fixed batch size `B` (the artifact is exported at one `B`),
+* the per-parameter shared/batched split (baked into the `jax.vmap` program),
+  and
 * the JAX version (exported artifacts are not guaranteed to survive an
   incompatible jax bump).
 
-Change any of these — backend, a tolerance, `k_max`, a state bound — and you get
-a different cache path, so a stale artifact is never reused.
+Change any of these — backend, a penalty weight, a state bound, which
+parameters are batched — and you get a different cache path, so a stale
+artifact is never reused. The convergence thresholds and `max_iters` are
+deliberately *not* in the key: they are runtime inputs on the state pytree, so
+one artifact serves every tolerance and iteration-cap setting.
 
 `examples/abstract/brachistochrone_batched.py` shows both paths side by side;
 re-running it is itself the cross-process demo.
@@ -158,10 +217,16 @@ problem.solve_jax(
     parameters=None,     # parameters dict for this solve; falls back to
                          #     ``self._parameters``
     *,
-    max_iters=None,      # SCP iteration cap; non-default rebuilds the
-                         #     cached ``lax.while_loop`` closure (one extra
-                         #     trace; subsequent calls at the same cap hit
-                         #     the cache)
+    x_guess=None,        # (N, n_x) state trajectory warm-start
+    u_guess=None,        # (N, n_u) control trajectory warm-start
+    ep_tr=None,          # convergence threshold on J_tr; falls back to
+                         #     ``algorithm.ep_tr``
+    ep_vb=None,          # convergence threshold on J_vb
+    ep_vc=None,          # convergence threshold on J_vc
+    lam_cost_drop=None,  # iteration after which lam_cost relaxes (-1 = never)
+    max_iters=None,      # SCP iteration cap; falls back to ``algorithm.k_max``.
+                         #     A runtime input on the state pytree — no value
+                         #     forces a retrace
 )
 ```
 

--- a/docs/UnderTheHood/batching_jit_grad.md
+++ b/docs/UnderTheHood/batching_jit_grad.md
@@ -60,7 +60,7 @@ that one difference is the whole point.
   no outer `vmap` rule (`call_exported` cannot be batched), so an exported
   artifact can never be re-vmapped, and every fresh process re-traces and
   re-compiles the entire loop.
-* `solve_batched(x0_stack, xf_stack)` — *the library* owns the axis. The vmap
+* `solve_batched(x_initial=x0_batch)` — *the library* owns the axis. The vmap
   is applied **inside** the method, before any export, so the whole loop lowers
   to ordinary batched XLA ops and serializes cleanly. Under
   `save_compiled=True` it is written to the solver cache on the first run and
@@ -74,7 +74,7 @@ problem.initialize()
 
 # First process: traces, exports, writes <cache>/compiled_solve_batched_<hash>.jax
 # Later processes: deserialize-and-.call, no compile.
-batched = problem.solve_batched(x0_stack, xf_stack, params)
+batched = problem.solve_batched(x_initial=x0_batch, parameters=params)
 # batched.x.shape == (B, N, n_states) — same pytree jax.vmap(solve_jax) returns.
 ```
 

--- a/docs/UnderTheHood/batching_jit_grad.md
+++ b/docs/UnderTheHood/batching_jit_grad.md
@@ -87,7 +87,11 @@ parameter's stored shape for each parameter, and `()` for the SCP
 hyperparameters. An argument that matches its declared shape is **shared** by
 every batch element; one with exactly one extra leading axis is **batched**
 along it. Rank against the declared shape decides — never the leading-axis
-value — so a shared `(B, n)` matrix parameter is never misread as batched:
+value — so a shared `(B, n)` matrix parameter is never misread as batched.
+(`B` in these shape patterns is plain notation for the batch size, not
+syntax: it is never passed anywhere — like `jax.vmap`, the library reads it
+off the leading axis of whatever you batched and cross-checks that all
+batched inputs agree.)
 
 ```python
 results = problem.solve_batched(
@@ -146,6 +150,8 @@ kwarg's field. Construction-only keys of the constructor dict — `autotuner`,
   forces the per-element reading. All against one cached artifact:
 
 ```python
+B = 8  # batch size — an ordinary int used to build the arrays; the solver
+       # never receives it, it reads B off the leading axes
 sweep = problem.solve_batched(algorithm={"ep_tr": jnp.logspace(-6, -3, B)})
 weights = problem.solve_batched(algorithm={"lam_prox": jnp.array([0.5, 1.0, 4.0])})
 budgets = problem.solve_batched(max_iters=jnp.array([5, 10, 20]))  # per-element caps

--- a/docs/UnderTheHood/batching_jit_grad.md
+++ b/docs/UnderTheHood/batching_jit_grad.md
@@ -120,30 +120,34 @@ One deliberate divergence from `jax.vmap`: the *default* is "infer by rank",
 not `0`-everything — an all-shared batched solve has no batch axis to find,
 and inference is what makes mixed shared/batched dicts ergonomic.
 
-### Hyperparameter sweeps: the `overrides` dict
+### Hyperparameter sweeps: the `algorithm` dict
 
-Every `AlgorithmState` field is a runtime input riding the state pytree, and
-one `overrides` dict reaches any of them by name — convergence thresholds
-(`ep_tr` / `ep_vb` / `ep_vc`), penalty weights (`lam_prox` / `lam_vc` /
-`lam_cost`), the seed iterate, autotuner hyperparameters. There is no
-whitelist: the field declaration is the registration, and the
-`AlgorithmState` attribute docs are the override reference. (`max_iters`
-survives as a named kwarg — sugar for `overrides={"k_max": ...}`; passing
-both raises, as does an override that shadows any other named kwarg's
-field.)
+Solve-time mirrors construction-time: the `Problem` constructor configures
+the SCP algorithm with a dict (`algorithm={"ep_tr": 1e-5, "lam_prox": 1.0}`),
+and the solve methods take the same box with the same names as per-solve,
+batchable inputs. Every `AlgorithmState` field is a runtime input riding the
+state pytree, and the `algorithm` dict reaches any of them by name —
+convergence thresholds (`ep_tr` / `ep_vb` / `ep_vc`), penalty weights
+(`lam_prox` / `lam_vc` / `lam_cost`), the seed iterate, autotuner
+hyperparameters. There is no whitelist: the field declaration is the
+registration, and the `AlgorithmState` attribute docs are the reference.
+(`max_iters` survives as a named kwarg — sugar for `algorithm={"k_max":
+...}`; passing both raises, as does an entry that shadows any other named
+kwarg's field. Construction-only keys of the constructor dict — `autotuner`,
+`t_max` — raise pointing back at the constructor.)
 
 * On `solve_jax`, each value matches the field's shape, or is a scalar
-  broadcast to it: `solve_jax(overrides={"ep_tr": 1e-6, "lam_prox": 2.0})`
+  broadcast to it: `solve_jax(algorithm={"ep_tr": 1e-6, "lam_prox": 2.0})`
   retraces nothing.
 * On `solve_batched`, each value follows the rank rule against the field's
   shape, plus two **fill** forms for array-shaped fields: a scalar (shared)
   or a `(B,)` vector (one scalar per element, broadcast to the field shape).
-  Exact shapes win when both parse; `in_axes={"overrides": {name: 0}}`
+  Exact shapes win when both parse; `in_axes={"algorithm": {name: 0}}`
   forces the per-element reading. All against one cached artifact:
 
 ```python
-sweep = problem.solve_batched(overrides={"ep_tr": jnp.logspace(-6, -3, B)})
-weights = problem.solve_batched(overrides={"lam_prox": jnp.array([0.5, 1.0, 4.0])})
+sweep = problem.solve_batched(algorithm={"ep_tr": jnp.logspace(-6, -3, B)})
+weights = problem.solve_batched(algorithm={"lam_prox": jnp.array([0.5, 1.0, 4.0])})
 budgets = problem.solve_batched(max_iters=jnp.array([5, 10, 20]))  # per-element caps
 ```
 
@@ -174,7 +178,7 @@ class MyAutotuner(AutotuningBase):
     def update_weights(self, state, ...):
         ...state.hyper.ramp...
 
-results = problem.solve_batched(overrides={"ramp": jnp.linspace(1.5, 3.0, B)})
+results = problem.solve_batched(algorithm={"ramp": jnp.linspace(1.5, 3.0, B)})
 ```
 
 Pick `solve_batched` when **cross-process cold-start dominates** — short-lived
@@ -221,7 +225,7 @@ layer uses):
 
 Change any of these — backend, a penalty weight, a state bound, which
 parameters are batched — and you get a different cache path, so a stale
-artifact is never reused. Everything `overrides` can reach — convergence
+artifact is never reused. Everything the `algorithm` dict can reach — convergence
 thresholds, `max_iters`, weights, autotuner hyperparameters — is deliberately
 *not* in the key: those are runtime inputs on the state pytree, so one
 artifact serves every setting of them.
@@ -265,12 +269,13 @@ problem.solve_jax(
     *,
     x_guess=None,        # (N, n_x) state trajectory warm-start
     u_guess=None,        # (N, n_u) control trajectory warm-start
-    max_iters=None,      # SCP iteration cap; sugar for overrides={"k_max": ...};
-                         #     falls back to ``algorithm.k_max``
-    overrides=None,      # any AlgorithmState field by name (ep_tr, lam_prox,
-                         #     ...); values match the field shape or fill it
-                         #     from a scalar. Runtime inputs on the state
-                         #     pytree — no value forces a retrace
+    max_iters=None,      # SCP iteration cap; sugar for algorithm={"k_max": ...};
+                         #     falls back to the configured k_max
+    algorithm=None,      # any AlgorithmState field by name (ep_tr, lam_prox,
+                         #     ...) — the constructor's algorithm-dict names;
+                         #     values match the field shape or fill it from a
+                         #     scalar. Runtime inputs on the state pytree — no
+                         #     value forces a retrace
 )
 ```
 

--- a/docs/UnderTheHood/batching_jit_grad.md
+++ b/docs/UnderTheHood/batching_jit_grad.md
@@ -101,15 +101,24 @@ results = problem.solve_batched(
 
 For the rare entry the rank rule cannot express — e.g. batching a declared
 rank-1 parameter element-wise — pass an explicit `in_axes` in `jax.vmap`'s
-vocabulary (`0` = batched along the leading axis, `None` = shared; partial
-specs fall back to the rank rule):
+vocabulary, including its prefix semantics (`0` = batched along the leading
+axis, `None` = shared; a prefix applies to everything below it; partial specs
+fall back to the rank rule):
 
 ```python
 results = problem.solve_batched(
     parameters={"weights": w},           # (B,) is also w's declared shape...
     in_axes={"parameters": {"weights": 0}},  # ...so say "batched" explicitly
 )
+
+results = problem.solve_batched(parameters=params, in_axes={"parameters": 0})
+# prefix: every passed parameter is batched, exactly like jax.vmap's
+# pytree-prefix in_axes; a bare in_axes=0 batches every passed input.
 ```
+
+One deliberate divergence from `jax.vmap`: the *default* is "infer by rank",
+not `0`-everything — an all-shared batched solve has no batch axis to find,
+and inference is what makes mixed shared/batched dicts ergonomic.
 
 ### Hyperparameter sweeps: the `overrides` dict
 

--- a/examples/abstract/brachistochrone_batched.py
+++ b/examples/abstract/brachistochrone_batched.py
@@ -153,3 +153,10 @@ if __name__ == "__main__":
     print(f"  result.x.shape:   {batched.x.shape}")
     print(f"  result.t_final:   {np.asarray(batched.t_final).reshape(-1)}")
     print(f"  result.converged: {np.asarray(batched.converged)}")
+
+    # Hyperparameters batch by the same rule: ep_tr is declared (), so a (B,)
+    # vector sweeps the convergence tolerance per element — same artifact, no
+    # recompile, since the thresholds are runtime inputs on the state pytree.
+    sweep = export_problem.solve_batched(ep_tr=jnp.logspace(-4, -1, 4), ep_vc=1e-7)
+    print(f"  ep_tr sweep t_final:   {np.asarray(sweep.t_final).reshape(-1)}")
+    print(f"  ep_tr sweep converged: {np.asarray(sweep.converged)}")

--- a/examples/abstract/brachistochrone_batched.py
+++ b/examples/abstract/brachistochrone_batched.py
@@ -158,7 +158,8 @@ if __name__ == "__main__":
     # the same names as the Problem constructor's algorithm config. ep_tr is
     # a scalar field, so a (B,) vector sweeps the convergence tolerance per
     # element — same artifact, no recompile, since the knobs are runtime
-    # inputs on the state pytree.
+    # inputs on the state pytree. The batch size is never passed: it is read
+    # off the array's leading axis (4 tolerances -> B = 4).
     sweep = export_problem.solve_batched(
         algorithm={"ep_tr": jnp.logspace(-4, -1, 4), "ep_vc": 1e-7}
     )

--- a/examples/abstract/brachistochrone_batched.py
+++ b/examples/abstract/brachistochrone_batched.py
@@ -154,12 +154,13 @@ if __name__ == "__main__":
     print(f"  result.t_final:   {np.asarray(batched.t_final).reshape(-1)}")
     print(f"  result.converged: {np.asarray(batched.converged)}")
 
-    # Hyperparameters batch by the same rule, through the `overrides` dict:
-    # any AlgorithmState field by name. ep_tr is a scalar field, so a (B,)
-    # vector sweeps the convergence tolerance per element — same artifact, no
-    # recompile, since the fields are runtime inputs on the state pytree.
+    # Algorithm knobs batch by the same rule, through the `algorithm` dict —
+    # the same names as the Problem constructor's algorithm config. ep_tr is
+    # a scalar field, so a (B,) vector sweeps the convergence tolerance per
+    # element — same artifact, no recompile, since the knobs are runtime
+    # inputs on the state pytree.
     sweep = export_problem.solve_batched(
-        overrides={"ep_tr": jnp.logspace(-4, -1, 4), "ep_vc": 1e-7}
+        algorithm={"ep_tr": jnp.logspace(-4, -1, 4), "ep_vc": 1e-7}
     )
     print(f"  ep_tr sweep t_final:   {np.asarray(sweep.t_final).reshape(-1)}")
     print(f"  ep_tr sweep converged: {np.asarray(sweep.converged)}")

--- a/examples/abstract/brachistochrone_batched.py
+++ b/examples/abstract/brachistochrone_batched.py
@@ -6,7 +6,7 @@ starting x-coordinate — and contrasts the two batching entry points:
 * ``jax.vmap(problem.solve_jax)`` — the caller owns the batch axis. Maximally
   idiomatic, composes with ``grad`` / ``scan``, but in-process JIT only: every
   fresh process re-traces and re-compiles the whole SCP loop.
-* ``problem.solve_batched(x0_stack, xf_stack)`` — the library owns the batch
+* ``problem.solve_batched(x_initial=...)`` — the library owns the batch
   axis, so the whole vmapped loop is a single function that ``jax.export`` can
   serialize. Under ``save_compiled=True`` it is written to the solver cache on
   the first run and deserialized on later runs, skipping that compile. Reach
@@ -140,14 +140,14 @@ if __name__ == "__main__":
     # The same batched solve, but ``solve_batched`` owns the vmap so the whole
     # loop is one exportable artifact. Under ``save_compiled=True`` it lands in
     # the solver cache on the first run; re-run this script (a fresh process) to
-    # see it deserialized instead of recompiled. ``xf`` is shared across the
-    # batch, so broadcast the default terminal pin to the same leading axis.
+    # see it deserialized instead of recompiled. One rule: ``x_initial`` is
+    # ``(B, n_x)`` — one extra leading axis — so it is batched; the terminal
+    # pin is omitted, so every element shares the default.
     export_problem = build_problem()
     export_problem.settings.sim.save_compiled = True
     export_problem.initialize()
 
-    x_term_stack = jnp.broadcast_to(export_problem.state.x_term_pin, x_initial_stack.shape)
-    batched = export_problem.solve_batched(x_initial_stack, x_term_stack)
+    batched = export_problem.solve_batched(x_initial=x_initial_stack)
 
     print(f"\nsolve_batched (save_compiled=True) over {x_initial_stack.shape[0]} ICs:")
     print(f"  result.x.shape:   {batched.x.shape}")

--- a/examples/abstract/brachistochrone_batched.py
+++ b/examples/abstract/brachistochrone_batched.py
@@ -154,9 +154,12 @@ if __name__ == "__main__":
     print(f"  result.t_final:   {np.asarray(batched.t_final).reshape(-1)}")
     print(f"  result.converged: {np.asarray(batched.converged)}")
 
-    # Hyperparameters batch by the same rule: ep_tr is declared (), so a (B,)
+    # Hyperparameters batch by the same rule, through the `overrides` dict:
+    # any AlgorithmState field by name. ep_tr is a scalar field, so a (B,)
     # vector sweeps the convergence tolerance per element — same artifact, no
-    # recompile, since the thresholds are runtime inputs on the state pytree.
-    sweep = export_problem.solve_batched(ep_tr=jnp.logspace(-4, -1, 4), ep_vc=1e-7)
+    # recompile, since the fields are runtime inputs on the state pytree.
+    sweep = export_problem.solve_batched(
+        overrides={"ep_tr": jnp.logspace(-4, -1, 4), "ep_vc": 1e-7}
+    )
     print(f"  ep_tr sweep t_final:   {np.asarray(sweep.t_final).reshape(-1)}")
     print(f"  ep_tr sweep converged: {np.asarray(sweep.converged)}")

--- a/examples/rocket/6DoF_pdg_batched_ic.py
+++ b/examples/rocket/6DoF_pdg_batched_ic.py
@@ -2,7 +2,7 @@
 
 Runs ``N_BATCH`` SCP solves in parallel, each starting from a different random
 initial position drawn uniformly within the position bounds.  Per-batch ICs are
-passed through ``x0_stack``: position is declared ``Fix`` at the symbolic level
+passed through ``x_initial``: position is declared ``Fix`` at the symbolic level
 (so the solver consumes ``x_init_pin``), then each batch row overwrites the
 position slice with the sampled values.  This avoids the per-iteration
 ``(position == parameter).convex()`` constraint while still enforcing the full
@@ -110,7 +110,7 @@ mass.final = [ox.Maximize(1.5)]
 position = ox.State("position", shape=(3,))
 position.max = [10.0, 10.0, 10.0]
 position.min = [-10.0, -10.0, -10.0]
-# Fix so x0_stack pins are consumed; per-batch values overwrite these defaults.
+# Fix so x_initial pins are consumed; per-batch values overwrite these defaults.
 position.initial = [7.5, 4.5, 2.5]
 position.final = [0.0, ox.Free(0.0), ox.Free(0.0)]
 
@@ -193,7 +193,7 @@ constraint_exprs = []
 for st in states:
     constraint_exprs.extend([ox.ctcs(st <= st.max), ox.ctcs(st.min <= st)])
 
-# Initial position via x0_stack (Fix BC); terminal lateral via convex constraint.
+# Initial position via x_initial pins (Fix BC); terminal lateral via convex constraint.
 constraint_exprs.append((position[1:3] == final_position).convex().at([N - 1]))
 
 constraint_exprs.append(ox.ctcs(1.0 * (mass - m_dry) >= 0))
@@ -414,15 +414,14 @@ if __name__ == "__main__":
     print(f"Sampled {N_BATCH} initial positions  (alt ∈ [3, 9] m, lat ∈ [-7, 7] m)")
 
     # ── Compile + solve ───────────────────────────────────────────────────────
+    # x_initial is (B, n_x) — one extra leading axis — so it is batched; the
+    # terminal pin is omitted, so every element shares the default.
     default_init = np.asarray(problem.state.x_init_pin)
-    x0_stack = np.broadcast_to(default_init, (N_BATCH, default_init.shape[0])).copy()
-    x0_stack[:, POSITION_SLICE] = ic_batch
-    x0_stack = jnp.asarray(x0_stack)
-    xf_pin = np.asarray(problem.state.x_term_pin)
-    xf_stack = jnp.broadcast_to(xf_pin, (N_BATCH, xf_pin.shape[0]))
+    x_initial = np.broadcast_to(default_init, (N_BATCH, default_init.shape[0])).copy()
+    x_initial[:, POSITION_SLICE] = ic_batch
 
     print("Compiling and running solve_batched …")
-    results = problem.solve_batched(x0_stack=x0_stack, xf_stack=xf_stack)
+    results = problem.solve_batched(x_initial=jnp.asarray(x_initial))
 
     # ── Post-process: propagate all B solutions through nonlinear dynamics ────
     print("Post-processing (nonlinear propagation) …")

--- a/openscvx/algorithms/__init__.py
+++ b/openscvx/algorithms/__init__.py
@@ -53,6 +53,7 @@ from .base import (
     AlgorithmState,
     AutotuningBase,
     DiscretizationResult,
+    HyperParams,
     adaptive_state_code_to_str,
 )
 from .optimization_results import OptimizationResults
@@ -145,6 +146,7 @@ __all__ = [
     # PTR algorithm
     "PenalizedTrustRegion",
     "AutotuningBase",
+    "HyperParams",
     "AugmentedLagrangian",
     "AdaptiveProximalWeight",
     "ConstantProximalWeight",

--- a/openscvx/algorithms/autotuner/adaptive_proximal_weight.py
+++ b/openscvx/algorithms/autotuner/adaptive_proximal_weight.py
@@ -13,13 +13,19 @@ from pydantic import BaseModel, ConfigDict
 
 from openscvx.config import Config
 
-from ..base import AdaptiveStateCode, AutotuningBase
+from ..base import AdaptiveStateCode, AutotuningBase, HyperParams
 from .augmented_lagrangian import AugmentedLagrangian
 
 if TYPE_CHECKING:
     from openscvx.lowered import LoweredJaxConstraints
 
     from ..base import AlgorithmState, CandidateIterate
+
+
+class AdaptiveProximalWeightHyper(HyperParams):
+    """Declared hyperparameters for :class:`AdaptiveProximalWeight`."""
+
+    lam_cost_drop: int = -1
 
 
 class AdaptiveProximalWeight(AutotuningBase):
@@ -54,7 +60,7 @@ class AdaptiveProximalWeight(AutotuningBase):
         self.eta_2 = eta_2
         self.lam_prox_min = lam_prox_min
         self.lam_prox_max = lam_prox_max
-        self.lam_cost_drop = lam_cost_drop
+        self.hyper = AdaptiveProximalWeightHyper(lam_cost_drop=lam_cost_drop)
         self.lam_cost_relax = lam_cost_relax
 
     def update_weights(
@@ -85,7 +91,7 @@ class AdaptiveProximalWeight(AutotuningBase):
         J_nonlin = nonlin_cost + nonlin_pen + nodal_pen
 
         lam_cost_next = jnp.where(
-            state.k > state.lam_cost_drop,
+            state.k > state.hyper.lam_cost_drop,
             state.lam_cost * self.lam_cost_relax,
             state.lam_cost_init,
         )

--- a/openscvx/algorithms/autotuner/adaptive_proximal_weight.py
+++ b/openscvx/algorithms/autotuner/adaptive_proximal_weight.py
@@ -85,7 +85,7 @@ class AdaptiveProximalWeight(AutotuningBase):
         J_nonlin = nonlin_cost + nonlin_pen + nodal_pen
 
         lam_cost_next = jnp.where(
-            state.k > self.lam_cost_drop,
+            state.k > state.lam_cost_drop,
             state.lam_cost * self.lam_cost_relax,
             state.lam_cost_init,
         )

--- a/openscvx/algorithms/autotuner/augmented_lagrangian.py
+++ b/openscvx/algorithms/autotuner/augmented_lagrangian.py
@@ -244,12 +244,14 @@ class AugmentedLagrangian(AutotuningBase):
         )
         J_nonlin = nonlin_cost + nonlin_pen + nodal_pen
 
-        # Cost relaxation: when state.k > lam_cost_drop, scale state.lam_cost;
-        # otherwise reset to the algorithm's initial weight (carried on the
-        # pytree as state.lam_cost_init, broadcast at from_settings()). Scalar
+        # Cost relaxation: when state.k > state.lam_cost_drop, scale
+        # state.lam_cost; otherwise reset to the algorithm's initial weight
+        # (carried on the pytree as state.lam_cost_init, broadcast at
+        # from_settings()). Both constants ride the pytree so per-solve
+        # overrides and vmap sweeps reach the traced body. Scalar
         # lam_cost_relax preserves the user-specified per-state weight ratios.
         lam_cost_next = jnp.where(
-            state.k > self.lam_cost_drop,
+            state.k > state.lam_cost_drop,
             state.lam_cost * self.lam_cost_relax,
             state.lam_cost_init,
         )

--- a/openscvx/algorithms/autotuner/augmented_lagrangian.py
+++ b/openscvx/algorithms/autotuner/augmented_lagrangian.py
@@ -19,12 +19,20 @@ from openscvx.utils.printing import (
     color_adaptive_state,
 )
 
-from ..base import AdaptiveStateCode, AutotuningBase
+from ..base import AdaptiveStateCode, AutotuningBase, HyperParams
 
 if TYPE_CHECKING:
     from openscvx.lowered import LoweredJaxConstraints
 
     from ..base import AlgorithmState, CandidateIterate
+
+
+class AugmentedLagrangianHyper(HyperParams):
+    """Declared hyperparameters for :class:`AugmentedLagrangian`."""
+
+    rho_init: float = 1.0
+    rho_max: float = 1e2
+    lam_cost_drop: int = -1
 
 
 class AugmentedLagrangian(AutotuningBase):
@@ -80,7 +88,12 @@ class AugmentedLagrangian(AutotuningBase):
         """Initialize Augmented Lagrangian autotuning parameters.
 
         All parameters have defaults and can be modified after instantiation
-        via attribute access (e.g., ``autotuner.rho_max = 1e7``).
+        via attribute access (e.g., ``autotuner.lam_prox_max = 1e6``); the
+        declared hyperparameters (``rho_init`` / ``rho_max`` /
+        ``lam_cost_drop``) live on the frozen ``hyper`` container instead
+        (``autotuner.hyper = dataclasses.replace(autotuner.hyper,
+        rho_max=1e7)``) and are also per-solve overrides — see
+        :class:`AutotuningBase`.
 
         Args:
             rho_init: Initial penalty parameter for constraints. Defaults to 1.0.
@@ -106,8 +119,11 @@ class AugmentedLagrangian(AutotuningBase):
             lam_cost_relax: Factor applied to lam_cost after lam_cost_drop.
                 Defaults to 1.0.
         """
-        self.rho_init = rho_init
-        self.rho_max = rho_max
+        self.hyper = AugmentedLagrangianHyper(
+            rho_init=rho_init,
+            rho_max=rho_max,
+            lam_cost_drop=lam_cost_drop,
+        )
         self.gamma_1 = gamma_1
         self.gamma_2 = gamma_2
         self.eta_0 = eta_0
@@ -118,7 +134,6 @@ class AugmentedLagrangian(AutotuningBase):
         self.lam_vc_max = lam_vc_max
         self.lam_prox_min = lam_prox_min
         self.lam_prox_max = lam_prox_max
-        self.lam_cost_drop = lam_cost_drop
         self.lam_cost_relax = lam_cost_relax
 
     # -----------------------------------------------------------------------
@@ -244,14 +259,14 @@ class AugmentedLagrangian(AutotuningBase):
         )
         J_nonlin = nonlin_cost + nonlin_pen + nodal_pen
 
-        # Cost relaxation: when state.k > state.lam_cost_drop, scale
+        # Cost relaxation: when state.k > hyper.lam_cost_drop, scale
         # state.lam_cost; otherwise reset to the algorithm's initial weight
         # (carried on the pytree as state.lam_cost_init, broadcast at
         # from_settings()). Both constants ride the pytree so per-solve
         # overrides and vmap sweeps reach the traced body. Scalar
         # lam_cost_relax preserves the user-specified per-state weight ratios.
         lam_cost_next = jnp.where(
-            state.k > state.lam_cost_drop,
+            state.k > state.hyper.lam_cost_drop,
             state.lam_cost * self.lam_cost_relax,
             state.lam_cost_init,
         )

--- a/openscvx/algorithms/autotuner/constant_proximal_weight.py
+++ b/openscvx/algorithms/autotuner/constant_proximal_weight.py
@@ -11,12 +11,18 @@ from pydantic import BaseModel, ConfigDict
 
 from openscvx.config import Config
 
-from ..base import AdaptiveStateCode, AutotuningBase
+from ..base import AdaptiveStateCode, AutotuningBase, HyperParams
 
 if TYPE_CHECKING:
     from openscvx.lowered import LoweredJaxConstraints
 
     from ..base import AlgorithmState, CandidateIterate
+
+
+class ConstantProximalWeightHyper(HyperParams):
+    """Declared hyperparameters for :class:`ConstantProximalWeight`."""
+
+    lam_cost_drop: int = -1
 
 
 class ConstantProximalWeight(AutotuningBase):
@@ -38,7 +44,7 @@ class ConstantProximalWeight(AutotuningBase):
         lam_cost_drop: int = -1,
         lam_cost_relax: float = 1.0,
     ):
-        self.lam_cost_drop = lam_cost_drop
+        self.hyper = ConstantProximalWeightHyper(lam_cost_drop=lam_cost_drop)
         self.lam_cost_relax = lam_cost_relax
 
     def update_weights(
@@ -54,7 +60,7 @@ class ConstantProximalWeight(AutotuningBase):
         Pure functional update — see class docstring.
         """
         lam_cost_next = jnp.where(
-            state.k > state.lam_cost_drop,
+            state.k > state.hyper.lam_cost_drop,
             state.lam_cost * self.lam_cost_relax,
             state.lam_cost_init,
         )

--- a/openscvx/algorithms/autotuner/constant_proximal_weight.py
+++ b/openscvx/algorithms/autotuner/constant_proximal_weight.py
@@ -54,7 +54,7 @@ class ConstantProximalWeight(AutotuningBase):
         Pure functional update — see class docstring.
         """
         lam_cost_next = jnp.where(
-            state.k > self.lam_cost_drop,
+            state.k > state.lam_cost_drop,
             state.lam_cost * self.lam_cost_relax,
             state.lam_cost_init,
         )

--- a/openscvx/algorithms/autotuner/ramp_proximal_weight.py
+++ b/openscvx/algorithms/autotuner/ramp_proximal_weight.py
@@ -11,12 +11,18 @@ from pydantic import BaseModel, ConfigDict
 
 from openscvx.config import Config
 
-from ..base import AdaptiveStateCode, AutotuningBase
+from ..base import AdaptiveStateCode, AutotuningBase, HyperParams
 
 if TYPE_CHECKING:
     from openscvx.lowered import LoweredJaxConstraints
 
     from ..base import AlgorithmState, CandidateIterate
+
+
+class RampProximalWeightHyper(HyperParams):
+    """Declared hyperparameters for :class:`RampProximalWeight`."""
+
+    lam_cost_drop: int = -1
 
 
 class RampProximalWeight(AutotuningBase):
@@ -40,7 +46,7 @@ class RampProximalWeight(AutotuningBase):
     ):
         self.ramp_factor = ramp_factor
         self.lam_prox_max = lam_prox_max
-        self.lam_cost_drop = lam_cost_drop
+        self.hyper = RampProximalWeightHyper(lam_cost_drop=lam_cost_drop)
         self.lam_cost_relax = lam_cost_relax
 
     def update_weights(
@@ -56,7 +62,7 @@ class RampProximalWeight(AutotuningBase):
         Pure functional update — see class docstring.
         """
         lam_cost_next = jnp.where(
-            state.k > state.lam_cost_drop,
+            state.k > state.hyper.lam_cost_drop,
             state.lam_cost * self.lam_cost_relax,
             state.lam_cost_init,
         )

--- a/openscvx/algorithms/autotuner/ramp_proximal_weight.py
+++ b/openscvx/algorithms/autotuner/ramp_proximal_weight.py
@@ -56,7 +56,7 @@ class RampProximalWeight(AutotuningBase):
         Pure functional update — see class docstring.
         """
         lam_cost_next = jnp.where(
-            state.k > self.lam_cost_drop,
+            state.k > state.lam_cost_drop,
             state.lam_cost * self.lam_cost_relax,
             state.lam_cost_init,
         )

--- a/openscvx/algorithms/base.py
+++ b/openscvx/algorithms/base.py
@@ -281,8 +281,8 @@ class AutotuningBase(ABC):
                 ...state.hyper.ramp...
 
     The declaration is the registration: the field becomes a per-solve
-    override (``solve_jax(overrides={"ramp": ...})``), a batchable sweep
-    target (``solve_batched(overrides={"ramp": jnp.linspace(...)})``), and a
+    override (``solve_jax(algorithm={"ramp": ...})``), a batchable sweep
+    target (``solve_batched(algorithm={"ramp": jnp.linspace(...)})``), and a
     runtime input of the exported batched artifact — with zero core edits.
     Structural choices that select code paths (flags, enums) stay ordinary
     attributes; they are part of the traced program, not data.

--- a/openscvx/algorithms/base.py
+++ b/openscvx/algorithms/base.py
@@ -199,9 +199,16 @@ class AutotuningBase(ABC):
             bodies (a handful of XLA ops) override to ``False`` so the SCP loop
             calls ``update_weights`` directly — JAX's eager dispatch is cheaper
             than the JIT'd closure's pytree-flatten overhead for those cases.
+        lam_cost_drop: Default iteration after which ``lam_cost`` relaxation
+            applies (``-1`` = never). Subclasses with the relaxation override
+            this in ``__init__``; the value is snapshotted onto
+            ``AlgorithmState.lam_cost_drop`` (see
+            :meth:`AlgorithmState.from_settings`), which is what
+            ``update_weights`` reads at trace time.
     """
 
     COLUMNS: List[Column] = []
+    lam_cost_drop: int = -1
     # Governs only the Python-loop ``Problem.solve()`` path. Once the SCP body
     # lives inside ``lax.while_loop`` (see ``plans/batchable-problem.md``),
     # ``update_weights`` is one node in the outer compiled graph and the inner
@@ -219,12 +226,12 @@ class AutotuningBase(ABC):
         :meth:`~openscvx.algorithms.scvx.penalized_trust_region.PenalizedTrustRegion._hash_into`);
         mirrors the symbolic ``_hash_into`` protocol.
 
-        Caveat: the ``vars(self)`` sweep hashes *every* instance attribute, so a
-        subclass that stashes an iteration-count- or ``k_max``-derived field
-        would silently re-introduce the double-count that the algorithm's own
-        ``_hash_into`` deliberately avoids (the loop bound is keyed once, on the
-        assembler's resolved ``k_max``). Keep such fields out of the autotuner,
-        or override this method to exclude them.
+        Caveat: the ``vars(self)`` sweep hashes *every* instance attribute,
+        including ones that are runtime state inputs rather than baked
+        constants (e.g. ``lam_cost_drop``, which rides
+        ``AlgorithmState.lam_cost_drop``). For those the hash is merely
+        conservative — changing them re-exports an artifact that would have
+        been reusable — never incorrect.
         """
         from openscvx.utils.caching import hash_value_into
 
@@ -410,6 +417,18 @@ class AlgorithmState:
         x_term_pin: Terminal-state boundary condition, shape ``(n_states,)``.
             ``jnp.nan`` where the state is not pinned at tf (``final_type`` is
             not ``"Fix"``).
+        ep_tr: Convergence threshold on ``J_tr`` (scalar). Carried on the
+            pytree — like ``x_init_pin`` / ``lam_cost_init`` — so the SCP loop
+            reads it as a runtime input: per-solve overrides and ``jax.vmap``
+            sweeps need no retrace, and one exported ``solve_batched`` artifact
+            serves every tolerance setting.
+        ep_vb: Convergence threshold on ``J_vb`` (scalar).
+        ep_vc: Convergence threshold on ``J_vc`` (scalar).
+        k_max: SCP iteration cap (scalar, ``k``'s integer dtype). The loop
+            runs while ``k <= k_max``; a traced bound is valid inside
+            ``lax.while_loop``, so the cap is per-solve and batchable too.
+        lam_cost_drop: Iteration after which autotuners relax ``lam_cost``
+            (scalar, ``k``'s integer dtype; ``-1`` = never).
     """
 
     x: jnp.ndarray
@@ -433,6 +452,11 @@ class AlgorithmState:
     adaptive_state_code: jnp.ndarray
     x_init_pin: jnp.ndarray
     x_term_pin: jnp.ndarray
+    ep_tr: jnp.ndarray
+    ep_vb: jnp.ndarray
+    ep_vc: jnp.ndarray
+    k_max: jnp.ndarray
+    lam_cost_drop: jnp.ndarray
 
     # Field order is the source of truth for tree_flatten / tree_unflatten;
     # keep _FIELDS in sync with the dataclass field declarations above.
@@ -458,6 +482,11 @@ class AlgorithmState:
         "adaptive_state_code",
         "x_init_pin",
         "x_term_pin",
+        "ep_tr",
+        "ep_vb",
+        "ep_vc",
+        "k_max",
+        "lam_cost_drop",
     )
 
     def replace(self, **changes) -> "AlgorithmState":
@@ -477,6 +506,12 @@ class AlgorithmState:
         cls,
         settings: "Config",
         weights: "Weights",
+        *,
+        ep_tr: float,
+        ep_vb: float,
+        ep_vc: float,
+        k_max: int,
+        lam_cost_drop: int,
     ) -> "AlgorithmState":
         """Construct the initial iterate from configuration.
 
@@ -484,6 +519,12 @@ class AlgorithmState:
         the diagnostic scalars to zero / :py:attr:`AdaptiveStateCode.INITIAL`.
         ``x_prop`` and ``x_prop_plus`` are zero-initialized; the SCP algorithm
         fills them at the first discretization step.
+
+        The SCP loop constants (``ep_tr`` / ``ep_vb`` / ``ep_vc`` / ``k_max`` /
+        ``lam_cost_drop``) are snapshotted onto the pytree here — the caller
+        passes them off the algorithm and its autotuner (see
+        ``Problem._default_state``), and per-solve overrides land via
+        ``state.replace``.
         """
         n = settings.sim.n
         n_states = settings.sim.n_states
@@ -549,6 +590,13 @@ class AlgorithmState:
             adaptive_state_code=put(jnp.asarray(int(AdaptiveStateCode.INITIAL), dtype=i)),
             x_init_pin=put(jnp.asarray(x_init_pin, dtype=f)),
             x_term_pin=put(jnp.asarray(x_term_pin, dtype=f)),
+            ep_tr=put(jnp.asarray(ep_tr, dtype=f)),
+            ep_vb=put(jnp.asarray(ep_vb, dtype=f)),
+            ep_vc=put(jnp.asarray(ep_vc, dtype=f)),
+            # Integer constants share k's dtype so `k <= k_max` (and the
+            # autotuners' `k > lam_cost_drop`) compare without promotion.
+            k_max=put(jnp.asarray(k_max, dtype=i)),
+            lam_cost_drop=put(jnp.asarray(lam_cost_drop, dtype=i)),
         )
 
 

--- a/openscvx/algorithms/base.py
+++ b/openscvx/algorithms/base.py
@@ -16,6 +16,7 @@ follow, along with two state containers used during the SCP iteration:
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
+from dataclasses import fields as dc_fields
 from dataclasses import replace as dc_replace
 from enum import IntEnum
 from typing import TYPE_CHECKING, Callable, List, Optional, Tuple, Union
@@ -167,6 +168,79 @@ def adaptive_state_code_to_str(code: Union[int, jnp.ndarray, np.ndarray]) -> str
 
 
 # ---------------------------------------------------------------------------
+# HyperParams — typed autotuner hyperparameter container
+# ---------------------------------------------------------------------------
+
+
+class HyperParams:
+    """Base for autotuner hyperparameter containers.
+
+    Subclassing is the entire integration. Declare each tunable knob as an
+    annotated field with its default — bare annotations, no ``@dataclass``
+    decorator — and the base class does the rest:
+
+    * applies the frozen-dataclass transform, so instances are immutable
+      value objects updated with :func:`dataclasses.replace`;
+    * registers the subclass as a JAX pytree (and for ``jax.export`` treedef
+      serialization), so instances ride :attr:`AlgorithmState.hyper` through
+      ``jit`` / ``vmap`` / the exported batched ``solve_batched`` artifact;
+    * wires dtype handling off the field annotations when
+      :meth:`AlgorithmState.from_settings` snapshots the instance onto the
+      state — ``int`` fields get the iteration counter's dtype, ``float``
+      fields the problem float dtype. Any other annotation is rejected at
+      class definition.
+
+    Example::
+
+        class MyHyper(HyperParams):
+            ramp: float = 2.0
+            drop: int = -1
+
+    The empty base is the "no declared hyperparameters" container: it
+    flattens to zero pytree leaves.
+    """
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        # ``__init_subclass__`` runs before any decorator on the subclass
+        # could, so the transform must happen here — which is exactly what
+        # lets authors skip the dataclass and pytree mechanics entirely.
+        dataclass(frozen=True)(cls)
+        for fld in dc_fields(cls):
+            # fld.type is a string under postponed annotation evaluation
+            # (``from __future__ import annotations``); accept both forms.
+            if fld.type not in (int, float, "int", "float"):
+                raise TypeError(
+                    f"{cls.__name__}.{fld.name}: HyperParams fields must be "
+                    f"annotated int or float (got {fld.type!r}) — the "
+                    f"annotation decides the dtype the knob gets on "
+                    f"AlgorithmState.hyper."
+                )
+        jax.tree_util.register_dataclass(cls)
+        export.register_pytree_node_serialization(
+            cls,
+            serialized_name=f"{cls.__module__}.{cls.__qualname__}",
+            serialize_auxdata=lambda aux: b"",
+            deserialize_auxdata=lambda data: (),
+        )
+
+
+# The base itself is a zero-field frozen dataclass and a zero-leaf pytree, so
+# the shared ``HyperParams()`` default on ``AutotuningBase`` is a valid value
+# for ``AlgorithmState.hyper``. Auxdata of a ``register_dataclass`` node is
+# the (empty) tuple of meta-field values, hence ``()`` — not ``None`` — on
+# deserialize; same for the subclasses registered above.
+dataclass(frozen=True)(HyperParams)
+jax.tree_util.register_dataclass(HyperParams)
+export.register_pytree_node_serialization(
+    HyperParams,
+    serialized_name="openscvx.algorithms.base.HyperParams",
+    serialize_auxdata=lambda aux: b"",
+    deserialize_auxdata=lambda data: (),
+)
+
+
+# ---------------------------------------------------------------------------
 # Autotuning base class
 # ---------------------------------------------------------------------------
 
@@ -189,6 +263,30 @@ class AutotuningBase(ABC):
     converts that back to a human-readable label only on the Python-loop
     printing path.
 
+    **Declaring tunable hyperparameters.** A numeric knob a user might sweep
+    (a penalty ramp, a relaxation iteration) must not be read off ``self``
+    inside ``update_weights`` — a Python attribute is baked into the trace
+    and invisible to every override channel. Instead, declare it on a
+    :class:`HyperParams` subclass, assign an instance to ``self.hyper``, and
+    read it from ``state.hyper``::
+
+        class MyHyper(HyperParams):
+            ramp: float = 2.0
+
+        class MyAutotuner(AutotuningBase):
+            def __init__(self, ramp: float = 2.0):
+                self.hyper = MyHyper(ramp=ramp)
+
+            def update_weights(self, state, ...):
+                ...state.hyper.ramp...
+
+    The declaration is the registration: the field becomes a per-solve
+    override (``solve_jax(overrides={"ramp": ...})``), a batchable sweep
+    target (``solve_batched(overrides={"ramp": jnp.linspace(...)})``), and a
+    runtime input of the exported batched artifact — with zero core edits.
+    Structural choices that select code paths (flags, enums) stay ordinary
+    attributes; they are part of the traced program, not data.
+
     Class Attributes:
         COLUMNS: List of Column specs for autotuner-specific metrics to display.
             Subclasses override this to add their own columns.
@@ -199,16 +297,17 @@ class AutotuningBase(ABC):
             bodies (a handful of XLA ops) override to ``False`` so the SCP loop
             calls ``update_weights`` directly — JAX's eager dispatch is cheaper
             than the JIT'd closure's pytree-flatten overhead for those cases.
-        lam_cost_drop: Default iteration after which ``lam_cost`` relaxation
-            applies (``-1`` = never). Subclasses with the relaxation override
-            this in ``__init__``; the value is snapshotted onto
-            ``AlgorithmState.lam_cost_drop`` (see
-            :meth:`AlgorithmState.from_settings`), which is what
+        hyper: The autotuner's declared hyperparameters — a
+            :class:`HyperParams` instance carrying plain-Python defaults
+            (the empty base when it declares none). Snapshotted onto
+            ``AlgorithmState.hyper`` with array leaves (see
+            :meth:`AlgorithmState.from_settings`; ``int`` fields get ``k``'s
+            integer dtype, ``float`` fields the float dtype), which is what
             ``update_weights`` reads at trace time.
     """
 
     COLUMNS: List[Column] = []
-    lam_cost_drop: int = -1
+    hyper: HyperParams = HyperParams()
     # Governs only the Python-loop ``Problem.solve()`` path. Once the SCP body
     # lives inside ``lax.while_loop`` (see ``plans/batchable-problem.md``),
     # ``update_weights`` is one node in the outer compiled graph and the inner
@@ -221,22 +320,21 @@ class AutotuningBase(ABC):
         The exported batched loop bakes in ``update_weights`` and every numeric
         parameter that steers it (penalty ramps, acceptance thresholds, weight
         clips). The default hashes the concrete class plus all instance
-        attributes — sufficient because autotuner parameters are plain scalars.
-        Folded in by the algorithm's ``_hash_into`` (e.g.
+        attributes — sufficient because autotuner parameters are plain
+        scalars. ``hyper`` is excluded: declared hyperparameters ride
+        ``AlgorithmState.hyper`` as runtime inputs, so one artifact serves
+        every setting of them (the same reasoning that keeps the ``ep_*``
+        thresholds out of the algorithm's hash). Folded in by the algorithm's
+        ``_hash_into`` (e.g.
         :meth:`~openscvx.algorithms.scvx.penalized_trust_region.PenalizedTrustRegion._hash_into`);
         mirrors the symbolic ``_hash_into`` protocol.
-
-        Caveat: the ``vars(self)`` sweep hashes *every* instance attribute,
-        including ones that are runtime state inputs rather than baked
-        constants (e.g. ``lam_cost_drop``, which rides
-        ``AlgorithmState.lam_cost_drop``). For those the hash is merely
-        conservative — changing them re-exports an artifact that would have
-        been reusable — never incorrect.
         """
         from openscvx.utils.caching import hash_value_into
 
         hasher.update(type(self).__name__.encode())
         for name in sorted(vars(self)):
+            if name == "hyper":
+                continue
             hasher.update(name.encode())
             hash_value_into(hasher, getattr(self, name))
 
@@ -393,9 +491,10 @@ class AlgorithmState:
         lam_cost: Cost weight, shape ``(n_states,)``.
         lam_cost_init: Initial cost weight (``weights.lam_cost`` broadcast to
             ``(n_states,)``). Used by autotuners as the "reset" value during
-            early iterations and on the ``state.k <= lam_cost_drop`` branch.
-            Lives on the pytree (not closure-captured) so weight mutations
-            between solves propagate through the JIT'd update_weights.
+            early iterations and on the ``state.k <= hyper.lam_cost_drop``
+            branch. Lives on the pytree (not closure-captured) so weight
+            mutations between solves propagate through the JIT'd
+            update_weights.
         lam_vb_nodal: Nodal virtual-buffer weights, shape ``(N, n_nodal)``.
         lam_vb_cross: Cross-node virtual-buffer weights, shape ``(n_cross,)``.
         k: Iteration counter (starts at 1).
@@ -427,8 +526,13 @@ class AlgorithmState:
         k_max: SCP iteration cap (scalar, ``k``'s integer dtype). The loop
             runs while ``k <= k_max``; a traced bound is valid inside
             ``lax.while_loop``, so the cap is per-solve and batchable too.
-        lam_cost_drop: Iteration after which autotuners relax ``lam_cost``
-            (scalar, ``k``'s integer dtype; ``-1`` = never).
+        hyper: Autotuner-declared hyperparameters — an instance of the
+            autotuner's :class:`HyperParams` subclass with scalar array
+            leaves (the empty ``HyperParams()`` when it declares none).
+            Seeded from :attr:`AutotuningBase.hyper`; ``update_weights``
+            reads its knobs here (e.g. ``state.hyper.lam_cost_drop``) so
+            each is a per-solve override and a batchable sweep target like
+            any other field.
     """
 
     x: jnp.ndarray
@@ -456,7 +560,7 @@ class AlgorithmState:
     ep_vb: jnp.ndarray
     ep_vc: jnp.ndarray
     k_max: jnp.ndarray
-    lam_cost_drop: jnp.ndarray
+    hyper: HyperParams
 
     # Field order is the source of truth for tree_flatten / tree_unflatten;
     # keep _FIELDS in sync with the dataclass field declarations above.
@@ -486,7 +590,7 @@ class AlgorithmState:
         "ep_vb",
         "ep_vc",
         "k_max",
-        "lam_cost_drop",
+        "hyper",
     )
 
     def replace(self, **changes) -> "AlgorithmState":
@@ -511,7 +615,7 @@ class AlgorithmState:
         ep_vb: float,
         ep_vc: float,
         k_max: int,
-        lam_cost_drop: int,
+        hyper: HyperParams,
     ) -> "AlgorithmState":
         """Construct the initial iterate from configuration.
 
@@ -520,12 +624,20 @@ class AlgorithmState:
         ``x_prop`` and ``x_prop_plus`` are zero-initialized; the SCP algorithm
         fills them at the first discretization step.
 
-        The SCP loop constants (``ep_tr`` / ``ep_vb`` / ``ep_vc`` / ``k_max`` /
-        ``lam_cost_drop``) are snapshotted onto the pytree here — the caller
-        passes them off the algorithm and its autotuner (see
+        The SCP loop constants (``ep_tr`` / ``ep_vb`` / ``ep_vc`` / ``k_max``)
+        and the autotuner's declared hyperparameters (*hyper*, from
+        :attr:`AutotuningBase.hyper`) are snapshotted onto the pytree here —
+        the caller passes them off the algorithm and its autotuner (see
         ``Problem._default_state``), and per-solve overrides land via
         ``state.replace``.
         """
+        shadowed = sorted({fld.name for fld in dc_fields(hyper)} & set(cls._FIELDS))
+        if shadowed:
+            raise ValueError(
+                f"Autotuner hyperparameter(s) {shadowed} shadow AlgorithmState "
+                f"fields; rename the HyperParams fields so overrides stay "
+                f"unambiguous."
+            )
         n = settings.sim.n
         n_states = settings.sim.n_states
         n_controls = settings.sim.n_controls
@@ -548,6 +660,14 @@ class AlgorithmState:
 
         def put(arr):
             return jax.device_put(arr, device)
+
+        def hyper_leaf(fld):
+            # int knobs (e.g. lam_cost_drop) share k's dtype so comparisons
+            # against the iteration counter don't promote; floats follow the
+            # problem's float dtype. The annotation is the rule — validated
+            # when the HyperParams subclass is defined.
+            dtype = i if fld.type in (int, "int") else f
+            return put(jnp.asarray(getattr(hyper, fld.name), dtype=dtype))
 
         lam_vc_array = np.ones((n - 1, n_states)) * weights.lam_vc
         lam_prox_array = np.ones((n, n_total)) * weights.lam_prox
@@ -593,10 +713,9 @@ class AlgorithmState:
             ep_tr=put(jnp.asarray(ep_tr, dtype=f)),
             ep_vb=put(jnp.asarray(ep_vb, dtype=f)),
             ep_vc=put(jnp.asarray(ep_vc, dtype=f)),
-            # Integer constants share k's dtype so `k <= k_max` (and the
-            # autotuners' `k > lam_cost_drop`) compare without promotion.
+            # k_max shares k's dtype so `k <= k_max` compares without promotion.
             k_max=put(jnp.asarray(k_max, dtype=i)),
-            lam_cost_drop=put(jnp.asarray(lam_cost_drop, dtype=i)),
+            hyper=dc_replace(hyper, **{fld.name: hyper_leaf(fld) for fld in dc_fields(hyper)}),
         )
 
 

--- a/openscvx/algorithms/optimization_results.py
+++ b/openscvx/algorithms/optimization_results.py
@@ -6,6 +6,8 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
+from .scvx.iteration import _converged
+
 if TYPE_CHECKING:
     from openscvx.algorithms.base import AlgorithmHistory, AlgorithmState
     from openscvx.problem import Problem
@@ -266,7 +268,6 @@ class OptimizationResults:
         """
         settings = problem.settings
         symbolic = problem.symbolic
-        algorithm = problem._algorithm
 
         has_impulsive_controls = any(
             control.parameterization == "impulsive" for control in symbolic.controls
@@ -287,11 +288,10 @@ class OptimizationResults:
         # slice of the last node (vmap'd to ``(B, 1)``).
         t_final = state.x[..., -1, :][..., settings.sim.time_slice]
 
-        converged = (
-            (state.J_tr < algorithm.ep_tr)
-            & (state.J_vb < algorithm.ep_vb)
-            & (state.J_vc < algorithm.ep_vc)
-        )
+        # Per-element thresholds ride the state pytree, so a batched solve
+        # with a tolerance sweep reports convergence against each element's
+        # own ep_* values.
+        converged = _converged(state)
 
         return cls(
             converged=converged,

--- a/openscvx/algorithms/scvx/iteration.py
+++ b/openscvx/algorithms/scvx/iteration.py
@@ -323,35 +323,30 @@ def make_scp_iteration(
     return iteration_fn
 
 
-def _converged(state: AlgorithmState, ep_tr: float, ep_vb: float, ep_vc: float) -> jnp.ndarray:
-    """Boolean SCP convergence test from the metrics on ``state``."""
-    return (state.J_tr < ep_tr) & (state.J_vb < ep_vb) & (state.J_vc < ep_vc)
+def _converged(state: AlgorithmState) -> jnp.ndarray:
+    """Boolean SCP convergence test from the metrics and thresholds on ``state``."""
+    return (state.J_tr < state.ep_tr) & (state.J_vb < state.ep_vb) & (state.J_vc < state.ep_vc)
 
 
 def make_solve_loop(
     iteration_fn: Callable[[AlgorithmState, dict], Tuple[AlgorithmState, IterationDiagnostics]],
-    ep_tr: float,
-    ep_vb: float,
-    ep_vc: float,
-    k_max: int,
 ) -> Callable[[AlgorithmState, dict], AlgorithmState]:
     """Wrap ``iteration_fn`` in a ``lax.while_loop`` keyed on convergence.
 
     The loop runs ``iteration_fn`` until either the SCP metrics fall below the
-    ``ep_*`` thresholds or the iteration counter ``state.k`` exceeds ``k_max`` —
-    matching the Python ``while`` loop in ``Problem.solve()``. The per-iteration
-    :class:`IterationDiagnostics` are projected away so the loop carry stays
-    ``state -> state`` (XLA dead-code-eliminates their host-only pieces). It
-    exists as a primitive for tests and the future JAX-pure ``.solve()`` path;
-    the public ``Problem.solve()`` continues to drive ``iteration_fn`` from
-    Python.
+    ``ep_*`` thresholds on ``state`` or the iteration counter ``state.k``
+    exceeds ``state.k_max`` — matching the Python ``while`` loop in
+    ``Problem.solve()``. Thresholds and cap are :class:`AlgorithmState` fields
+    (runtime inputs, not closure constants), so one built loop serves every
+    tolerance / ``max_iters`` setting and ``jax.vmap`` batches them per
+    element. The per-iteration :class:`IterationDiagnostics` are projected
+    away so the loop carry stays ``state -> state`` (XLA dead-code-eliminates
+    their host-only pieces). It exists as a primitive for tests and the future
+    JAX-pure ``.solve()`` path; the public ``Problem.solve()`` continues to
+    drive ``iteration_fn`` from Python.
 
     Args:
         iteration_fn: A body built by :func:`make_scp_iteration`.
-        ep_tr: Convergence threshold on ``J_tr`` (trust-region step).
-        ep_vb: Convergence threshold on ``J_vb`` (virtual buffer).
-        ep_vc: Convergence threshold on ``J_vc`` (virtual control).
-        k_max: Maximum number of SCP iterations.
 
     Returns:
         ``solve_loop(state, params) -> final_state``.
@@ -359,7 +354,7 @@ def make_solve_loop(
 
     def solve_loop(state: AlgorithmState, params: dict) -> AlgorithmState:
         def cond(state: AlgorithmState) -> jnp.ndarray:
-            return (state.k <= k_max) & jnp.logical_not(_converged(state, ep_tr, ep_vb, ep_vc))
+            return (state.k <= state.k_max) & jnp.logical_not(_converged(state))
 
         def body(state: AlgorithmState) -> AlgorithmState:
             # Under ``jax.vmap`` the ``lax.while_loop`` keeps running until
@@ -370,7 +365,7 @@ def make_solve_loop(
             # ``state`` for converged elements pins them to their first
             # post-convergence iterate, so a batched solve agrees with the
             # single-problem ``solve_jax`` on each element.
-            is_converged = _converged(state, ep_tr, ep_vb, ep_vc)
+            is_converged = _converged(state)
             next_state, _ = iteration_fn(state, params)
 
             def freeze(nxt, prev):

--- a/openscvx/algorithms/scvx/penalized_trust_region.py
+++ b/openscvx/algorithms/scvx/penalized_trust_region.py
@@ -33,6 +33,7 @@ from ..base import (
     adaptive_state_code_to_str,
 )
 from ..weights import Weights
+from .iteration import _converged
 
 if TYPE_CHECKING:
     import hashlib
@@ -175,24 +176,22 @@ class PenalizedTrustRegion(Algorithm):
     def _hash_into(self, hasher: "hashlib._Hash") -> None:
         """Contribute this algorithm's identity to the ``solve_batched`` cache key.
 
-        The exported batched loop bakes in the convergence thresholds, the
-        initial penalty weights, and the autotuner's update rule — none of which
-        the symbolic problem hash covers. Each piece is folded in next to where
-        it lives (weights via their fields, the autotuner via its own
-        ``_hash_into``), mirroring the symbolic ``_hash_into`` protocol so a new
-        field is hashed where it is added.
+        The exported batched loop bakes in the initial penalty weights and the
+        autotuner's update rule — none of which the symbolic problem hash
+        covers. Each piece is folded in next to where it lives (weights via
+        their fields, the autotuner via its own ``_hash_into``), mirroring the
+        symbolic ``_hash_into`` protocol so a new field is hashed where it is
+        added.
 
-        The iteration cap ``k_max`` is deliberately *not* folded in here: the
-        loop is built at a *resolved* bound (a ``solve_batched(max_iters=...)``
-        override supersedes ``self.k_max``), so the assembler stamps that
-        resolved value to avoid both a stale read and spurious invalidation when
-        ``self.k_max`` changes but the caller always overrides it.
+        The convergence thresholds and the iteration cap ``k_max`` are
+        deliberately *not* folded in here: they ride the
+        :class:`AlgorithmState` pytree as runtime inputs (``state.ep_tr`` /
+        ``state.k_max``), so one exported artifact serves every tolerance and
+        ``max_iters`` setting.
         """
         from openscvx.utils.caching import hash_value_into
 
         hasher.update(type(self).__name__.encode())
-        for value in (self.ep_tr, self.ep_vb, self.ep_vc):
-            hash_value_into(hasher, value)
         w = self.weights
         for value in (
             w.lam_prox,
@@ -320,12 +319,10 @@ class PenalizedTrustRegion(Algorithm):
 
         self._emitter(emission_data)
 
-        converged = (
-            (scalars["J_tr"] < self.ep_tr)
-            and (scalars["J_vb"] < self.ep_vb)
-            and (scalars["J_vc"] < self.ep_vc)
-        )
-        return next_state, converged
+        # Same convergence test the lax.while_loop path uses, reading the
+        # thresholds off the state pytree (synced from this algorithm's
+        # ep_* attributes by Problem._sync_scp_constants at solve() time).
+        return next_state, bool(_converged(next_state))
 
     def citation(self) -> List[str]:
         """Return BibTeX citations for the PTR algorithm."""

--- a/openscvx/problem.py
+++ b/openscvx/problem.py
@@ -23,6 +23,8 @@ import os
 import queue
 import threading
 import time
+from dataclasses import fields as dc_fields
+from dataclasses import replace as dc_replace
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import jax
@@ -83,7 +85,8 @@ from openscvx.utils.caching import (
 def _resolve_batch_spec(
     entries: Dict[str, Tuple[Any, Tuple[int, ...]]],
     in_axes: Optional[Dict[str, Optional[int]]] = None,
-) -> Tuple[int, Dict[str, Optional[int]]]:
+    fill: Optional[set] = None,
+) -> Tuple[int, Dict[str, Optional[int]], set]:
     """Decide which entries of a batched solve carry a batch axis.
 
     The one rule behind :meth:`Problem.solve_batched`: a value whose shape
@@ -92,6 +95,13 @@ def _resolve_batch_spec(
     declared shape decides — never the leading-axis value — so a shared entry
     whose leading axis happens to equal ``B`` is never misread as batched.
 
+    Entries named in *fill* additionally accept two **fill** forms for array
+    declared shapes: a scalar ``()`` (one value broadcast to the declared
+    shape, shared) or a ``(B,)`` vector (one scalar per batch element, each
+    broadcast to the declared shape). Exact shapes win when both parse — a
+    rank-1 declared shape of length exactly ``B`` reads as shared-exact, and
+    ``in_axes={name: 0}`` forces the per-element fill reading.
+
     Args:
         entries: ``{name: (value, declared_shape)}`` over every batchable
             input. ``None`` values are skipped (the caller substitutes
@@ -99,19 +109,23 @@ def _resolve_batch_spec(
         in_axes: Optional ``{name: 0 | None}`` overriding inference for the
             named entries (``0`` = batched along the leading axis, ``None`` =
             shared); unlisted entries fall back to the rank rule.
+        fill: Optional set of entry names that accept the scalar / ``(B,)``
+            fill forms (the state-field overrides).
 
     Returns:
-        ``(B, axes)`` — the common batch size and a ``{name: 0 | None}`` dict
-        over the non-``None`` entries, ready to use as a ``jax.vmap``
-        ``in_axes`` pytree.
+        ``(B, axes, fills)`` — the common batch size, a ``{name: 0 | None}``
+        dict over the non-``None`` entries ready to use as a ``jax.vmap``
+        ``in_axes`` pytree, and the subset of names parsed as fills (their
+        values still need broadcasting to the declared shape).
 
     Raises:
-        ValueError: If a value matches neither accepted shape, if batched
-            entries disagree on the leading axis, if no entry is batched, or
-            if *in_axes* names an unknown or absent entry or uses an axis
-            other than ``0`` / ``None``.
+        ValueError: If a value matches none of its accepted shapes, if
+            batched entries disagree on the leading axis, if no entry is
+            batched, or if *in_axes* names an unknown or absent entry or uses
+            an axis other than ``0`` / ``None``.
     """
     in_axes = in_axes or {}
+    fill = fill or set()
     unknown = set(in_axes) - set(entries)
     if unknown:
         raise ValueError(
@@ -129,13 +143,27 @@ def _resolve_batch_spec(
                 f"solve_batched: in_axes marks '{name}' as batched, but no value was passed for it."
             )
 
+    def _shape_error(name, shape, declared):
+        forms = f"pass {declared} to share it across the batch, or (B,) + {declared} to batch it"
+        if name in fill:
+            forms += (
+                ", a scalar () to fill the shared value, or (B,) to fill one "
+                "scalar per batch element"
+            )
+        return ValueError(
+            f"solve_batched: '{name}' has shape {shape}, but its unbatched "
+            f"shape is {declared}; {forms}."
+        )
+
     axes: Dict[str, Optional[int]] = {}
+    fills: set = set()
     batched: List[Tuple[str, int]] = []  # (name, leading axis)
     for name, (value, declared) in entries.items():
         if value is None:
             continue
         shape = tuple(jnp.shape(value))
         declared = tuple(declared)
+        exact_batched = len(shape) == len(declared) + 1 and shape[1:] == declared
         if name in in_axes:
             axes[name] = in_axes[name]
             if in_axes[name] == 0:
@@ -144,18 +172,29 @@ def _resolve_batch_spec(
                         f"solve_batched: in_axes marks '{name}' as batched, but it "
                         f"is a scalar with no leading axis to batch over."
                     )
+                if name in fill and not exact_batched:
+                    if len(shape) != 1:
+                        raise _shape_error(name, shape, declared)
+                    fills.add(name)
                 batched.append((name, shape[0]))
+            elif name in fill and shape != declared:
+                if shape != ():
+                    raise _shape_error(name, shape, declared)
+                fills.add(name)
         elif shape == declared:
             axes[name] = None
-        elif len(shape) == len(declared) + 1 and shape[1:] == declared:
+        elif exact_batched:
             axes[name] = 0
             batched.append((name, shape[0]))
+        elif name in fill and shape == ():
+            axes[name] = None
+            fills.add(name)
+        elif name in fill and len(shape) == 1:
+            axes[name] = 0
+            fills.add(name)
+            batched.append((name, shape[0]))
         else:
-            raise ValueError(
-                f"solve_batched: '{name}' has shape {shape}, but its unbatched "
-                f"shape is {declared}; pass {declared} to share it across the "
-                f"batch, or (B,) + {declared} to batch it."
-            )
+            raise _shape_error(name, shape, declared)
 
     if not batched:
         raise ValueError(
@@ -170,7 +209,33 @@ def _resolve_batch_spec(
                 f"solve_batched: batch sizes disagree: '{ref_name}' has leading "
                 f"axis {B} but '{name}' has leading axis {b}."
             )
-    return B, axes
+    return B, axes, fills
+
+
+# Named solve kwargs and the AlgorithmState field each one targets. The
+# ``overrides`` dict reaches the same fields by name, so passing both for one
+# field is ambiguous — the solve methods raise, pointing at the kwarg.
+_OVERRIDE_KWARG_FIELDS = {
+    "x_initial": "x_init_pin",
+    "x_final": "x_term_pin",
+    "x_guess": "x",
+    "u_guess": "u",
+    "max_iters": "k_max",
+}
+
+
+def _override_target(state: "AlgorithmState", name: str) -> jnp.ndarray:
+    """The state leaf a (validated) override name targets.
+
+    Override names are :class:`AlgorithmState` field names or fields of its
+    autotuner-declared ``hyper`` container (the two never collide —
+    ``AlgorithmState.from_settings`` rejects shadowing fields); the leaf
+    supplies the declared shape and dtype the override value is checked and
+    cast against.
+    """
+    if name in {fld.name for fld in dc_fields(state.hyper)}:
+        return getattr(state.hyper, name)
+    return getattr(state, name)
 
 
 def _make_single_result(
@@ -685,10 +750,11 @@ class Problem:
     def _sync_scp_constants(self):
         """Sync the SCP loop constants from the algorithm config onto the state.
 
-        ``ep_tr`` / ``ep_vb`` / ``ep_vc`` / ``k_max`` / ``lam_cost_drop`` are
-        snapshotted onto :class:`AlgorithmState` when it is created, so a
-        mutation like ``problem.algorithm.ep_tr = 1e-6`` between ``solve()``
-        calls would otherwise go stale. Re-read them here, alongside
+        ``ep_tr`` / ``ep_vb`` / ``ep_vc`` / ``k_max`` and the autotuner's
+        declared hyperparameters (``hyper``) are snapshotted onto
+        :class:`AlgorithmState` when it is created, so a mutation like
+        ``problem.algorithm.ep_tr = 1e-6`` between ``solve()`` calls would
+        otherwise go stale. Re-read them here, alongside
         :meth:`_sync_parameters` / :meth:`_sync_boundary_conditions`.
 
         Note:
@@ -707,12 +773,19 @@ class Problem:
         def put(value, like):
             return jax.device_put(jnp.asarray(value, dtype=like.dtype), device)
 
+        hyper = algo.autotuner.hyper
         self._state = state.replace(
             ep_tr=put(algo.ep_tr, state.ep_tr),
             ep_vb=put(algo.ep_vb, state.ep_vb),
             ep_vc=put(algo.ep_vc, state.ep_vc),
             k_max=put(algo.k_max, state.k_max),
-            lam_cost_drop=put(algo.autotuner.lam_cost_drop, state.lam_cost_drop),
+            hyper=dc_replace(
+                state.hyper,
+                **{
+                    fld.name: put(getattr(hyper, fld.name), getattr(state.hyper, fld.name))
+                    for fld in dc_fields(state.hyper)
+                },
+            ),
         )
 
     def _sync_guesses(self):
@@ -1302,7 +1375,8 @@ class Problem:
 
         The single assembly point for :meth:`AlgorithmState.from_settings`'
         keyword constants: convergence thresholds and the iteration cap come
-        off the algorithm, ``lam_cost_drop`` off its autotuner.
+        off the algorithm, the declared hyperparameters off its autotuner's
+        ``hyper`` container.
         """
         algo = self._algorithm
         return AlgorithmState.from_settings(
@@ -1312,8 +1386,35 @@ class Problem:
             ep_vb=algo.ep_vb,
             ep_vc=algo.ep_vc,
             k_max=algo.k_max,
-            lam_cost_drop=algo.autotuner.lam_cost_drop,
+            hyper=algo.autotuner.hyper,
         )
+
+    def _validate_overrides(self, where: str, overrides: dict, kwargs: Dict[str, Any]) -> None:
+        """Reject unknown override names and overrides that shadow a named kwarg.
+
+        The set of valid names is *derived*, never listed: every
+        :class:`AlgorithmState` field (``_FIELDS``) plus every field of the
+        autotuner's declared ``hyper`` container. Adding a state field — or
+        declaring an autotuner knob — is thereby the registration. *kwargs*
+        maps each named solve kwarg to the value the caller received; an
+        override targeting the same field as a kwarg that was actually passed
+        is ambiguous and raises.
+        """
+        fields = [name for name in AlgorithmState._FIELDS if name != "hyper"]
+        hyper_keys = sorted(fld.name for fld in dc_fields(self._algorithm.autotuner.hyper))
+        unknown = sorted(set(overrides) - set(fields) - set(hyper_keys))
+        if unknown:
+            raise ValueError(
+                f"{where}: unknown override name(s) {unknown}; overridable names "
+                f"are the AlgorithmState fields {sorted(fields)} and the "
+                f"autotuner's declared hyperparameters {hyper_keys}."
+            )
+        for kwarg, field in _OVERRIDE_KWARG_FIELDS.items():
+            if field in overrides and kwargs.get(kwarg) is not None:
+                raise ValueError(
+                    f"{where}: overrides['{field}'] and the {kwarg} kwarg target the "
+                    f"same state field; pass the {kwarg} kwarg only."
+                )
 
     def _resolve_initial_state(
         self,
@@ -1321,21 +1422,19 @@ class Problem:
         x_final: Optional[jnp.ndarray],
         x_guess: Optional[jnp.ndarray] = None,
         u_guess: Optional[jnp.ndarray] = None,
-        ep_tr: Optional[jnp.ndarray] = None,
-        ep_vb: Optional[jnp.ndarray] = None,
-        ep_vc: Optional[jnp.ndarray] = None,
-        lam_cost_drop: Optional[jnp.ndarray] = None,
         max_iters: Optional[jnp.ndarray] = None,
+        overrides: Optional[dict] = None,
     ) -> AlgorithmState:
         """Build a fresh :class:`AlgorithmState` with per-solve overrides applied.
 
         This is the single place per-solve inputs land on the state pytree:
         boundary pins (``x_init_pin`` / ``x_term_pin``), trajectory
-        warm-starts (``x`` / ``u``), and the SCP loop constants
-        (``ep_tr`` / ``ep_vb`` / ``ep_vc`` / ``lam_cost_drop`` /
-        ``max_iters`` → ``k_max``). Because every override is a pytree field,
-        ``jax.vmap`` over any subset gives each batch slot its own boundary
-        condition, seed iterate, and hyperparameters without recompilation.
+        warm-starts (``x`` / ``u``), ``max_iters`` → ``k_max``, and the
+        generic *overrides* dict (validated field names; values broadcast to
+        the field shape, so a scalar fills an array-shaped field). Because
+        every override is a pytree field, ``jax.vmap`` over any subset gives
+        each batch slot its own boundary condition, seed iterate, and
+        hyperparameters without recompilation.
 
         ``None`` falls back to the defaults from :meth:`_default_state`. A
         user-supplied pin replaces the corresponding field in full; pass
@@ -1344,24 +1443,32 @@ class Problem:
         consumes the pin where the boundary type is ``"Fix"``).
         """
         state = self._default_state()
-        overrides = {
-            "x_init_pin": x_initial,
-            "x_term_pin": x_final,
-            "x": x_guess,
-            "u": u_guess,
-            "ep_tr": ep_tr,
-            "ep_vb": ep_vb,
-            "ep_vc": ep_vc,
-            "lam_cost_drop": lam_cost_drop,
-            "k_max": max_iters,
-        }
-        return state.replace(
-            **{
-                name: jnp.asarray(value, dtype=getattr(state, name).dtype)
-                for name, value in overrides.items()
-                if value is not None
-            }
-        )
+        # Named kwargs first, overrides on top: ``solve_batched`` always
+        # materializes the kwarg defaults (broadcast stacks), and an override
+        # must beat a default. A genuine user-passed duplicate never reaches
+        # here — ``_validate_overrides`` rejects it.
+        updates = {}
+        for kwarg, value in (
+            ("x_initial", x_initial),
+            ("x_final", x_final),
+            ("x_guess", x_guess),
+            ("u_guess", u_guess),
+            ("max_iters", max_iters),
+        ):
+            if value is not None:
+                updates[_OVERRIDE_KWARG_FIELDS[kwarg]] = value
+        updates.update(overrides or {})
+
+        def cast(name, value):
+            target = _override_target(state, name)
+            return jnp.broadcast_to(jnp.asarray(value, dtype=target.dtype), target.shape)
+
+        updates = {name: cast(name, value) for name, value in updates.items()}
+        hyper_names = {fld.name for fld in dc_fields(state.hyper)}
+        hyper = {name: updates.pop(name) for name in list(updates) if name in hyper_names}
+        if hyper:
+            updates["hyper"] = dc_replace(state.hyper, **hyper)
+        return state.replace(**updates)
 
     def _get_or_build_solve_loop(self) -> callable:
         """Return the cached ``jax.jit``'d ``lax.while_loop`` wrapper.
@@ -1467,11 +1574,8 @@ class Problem:
         *,
         x_guess: Optional[jnp.ndarray] = None,
         u_guess: Optional[jnp.ndarray] = None,
-        ep_tr: Optional[jnp.ndarray] = None,
-        ep_vb: Optional[jnp.ndarray] = None,
-        ep_vc: Optional[jnp.ndarray] = None,
-        lam_cost_drop: Optional[jnp.ndarray] = None,
         max_iters: Optional[int] = None,
+        overrides: Optional[dict] = None,
     ) -> OptimizationResults:
         """Run the SCP algorithm — JAX-pure.
 
@@ -1505,18 +1609,20 @@ class Problem:
                 settings (``State.guess`` at ``initialize()``).
             u_guess: Initial control trajectory guess, shape ``(N, n_controls)``.
                 Replaces ``state.u``; ``None`` uses the default from settings.
-            ep_tr: Convergence threshold on ``J_tr`` (scalar). Replaces
-                ``state.ep_tr``; ``None`` uses ``algorithm.ep_tr``.
-            ep_vb: Convergence threshold on ``J_vb`` (scalar). ``None`` uses
-                ``algorithm.ep_vb``.
-            ep_vc: Convergence threshold on ``J_vc`` (scalar). ``None`` uses
-                ``algorithm.ep_vc``.
-            lam_cost_drop: Iteration after which autotuners relax
-                ``lam_cost`` (scalar; ``-1`` = never). ``None`` uses the
-                autotuner's configured value.
-            max_iters: SCP iteration cap (scalar). ``None`` uses
-                ``algorithm.k_max``. A runtime input like the tolerances —
-                no value forces a retrace.
+            max_iters: SCP iteration cap (scalar). Sugar for
+                ``overrides={"k_max": ...}``; passing both raises. ``None``
+                uses ``algorithm.k_max``. A runtime input on the state
+                pytree — no value forces a retrace.
+            overrides: Per-solve values for any :class:`AlgorithmState`
+                field by name — convergence thresholds (``ep_tr`` /
+                ``ep_vb`` / ``ep_vc``), weights (``lam_prox`` / ``lam_vc`` /
+                ``lam_cost``), autotuner hyperparameters, and so on; the
+                ``AlgorithmState`` attribute docs are the reference. Each
+                value either matches the field's shape or is a scalar
+                (broadcast to it). All are runtime inputs: no value forces a
+                retrace. Fields with a dedicated kwarg (``x_guess`` →
+                ``x``, ``x_initial`` → ``x_init_pin``, ...) raise here when
+                both are passed.
 
         Returns:
             :class:`OptimizationResults` pytree with the final iterate and
@@ -1529,16 +1635,36 @@ class Problem:
 
         params = parameters if parameters is not None else self._parameters
 
+        overrides = dict(overrides or {})
+        self._validate_overrides(
+            "solve_jax",
+            overrides,
+            {
+                "x_initial": x_initial,
+                "x_final": x_final,
+                "x_guess": x_guess,
+                "u_guess": u_guess,
+                "max_iters": max_iters,
+            },
+        )
+        default_state = self._default_state()
+        for name, value in overrides.items():
+            declared = tuple(jnp.shape(_override_target(default_state, name)))
+            shape = tuple(jnp.shape(value))
+            if shape not in (declared, ()):
+                raise ValueError(
+                    f"solve_jax: overrides['{name}'] has shape {shape}, but the "
+                    f"field has shape {declared}; pass {declared}, or a scalar to "
+                    f"fill it. For a per-element sweep, use solve_batched()."
+                )
+
         initial_state = self._resolve_initial_state(
             x_initial,
             x_final,
             x_guess=x_guess,
             u_guess=u_guess,
-            ep_tr=ep_tr,
-            ep_vb=ep_vb,
-            ep_vc=ep_vc,
-            lam_cost_drop=lam_cost_drop,
             max_iters=max_iters,
+            overrides=overrides,
         )
         solve_fn = self._get_or_build_solve_loop()
         final_state = solve_fn(initial_state, params)
@@ -1552,11 +1678,8 @@ class Problem:
         *,
         x_guess: Optional[jnp.ndarray] = None,
         u_guess: Optional[jnp.ndarray] = None,
-        ep_tr: Optional[jnp.ndarray] = None,
-        ep_vb: Optional[jnp.ndarray] = None,
-        ep_vc: Optional[jnp.ndarray] = None,
-        lam_cost_drop: Optional[jnp.ndarray] = None,
         max_iters: Optional[jnp.ndarray] = None,
+        overrides: Optional[dict] = None,
         in_axes: Optional[dict] = None,
     ) -> OptimizationResults:
         """Run ``B`` SCP solves in parallel as one batched XLA program.
@@ -1571,12 +1694,15 @@ class Problem:
         (B, N, n_x)``)::
 
             results = problem.solve_batched(
-                x_initial=x0_batch,              # (B, n_x): batched pins
+                x_initial=x0_batch,                       # (B, n_x): batched pins
                 parameters={
-                    "gate_center": centers,      # (B, 3) vs declared (3,) -> batched
-                    "gate_radius": 0.5,          # declared shape -> shared
+                    "gate_center": centers,               # (B, 3) vs declared (3,) -> batched
+                    "gate_radius": 0.5,                   # declared shape -> shared
                 },
-                ep_tr=jnp.logspace(-5, -3, B),   # (B,) vs declared () -> tolerance sweep
+                overrides={
+                    "ep_tr": jnp.logspace(-5, -3, B),     # (B,) vs field () -> tolerance sweep
+                    "lam_prox": jnp.linspace(1.0, 4.0, B),  # (B,) fill: one scalar per element
+                },
             )
 
         Rank against the declared shape decides — never the leading-axis
@@ -1625,26 +1751,27 @@ class Problem:
                 settings.
             u_guess: Control trajectory guess — ``(N, n_u)`` or
                 ``(B, N, n_u)``. ``None`` uses the default from settings.
-            ep_tr: Convergence threshold on ``J_tr`` — ``()`` shared or
-                ``(B,)`` for a per-element tolerance sweep. ``None`` uses
-                ``algorithm.ep_tr``.
-            ep_vb: Convergence threshold on ``J_vb`` — ``()`` or ``(B,)``.
-                ``None`` uses ``algorithm.ep_vb``.
-            ep_vc: Convergence threshold on ``J_vc`` — ``()`` or ``(B,)``.
-                ``None`` uses ``algorithm.ep_vc``.
-            lam_cost_drop: Iteration after which autotuners relax
-                ``lam_cost`` (``-1`` = never) — ``()`` or ``(B,)``. ``None``
-                uses the autotuner's configured value.
             max_iters: SCP iteration cap — ``()`` shared or ``(B,)``
-                per-element budgets. ``None`` uses ``algorithm.k_max``. A
+                per-element budgets. Sugar for ``overrides={"k_max": ...}``;
+                passing both raises. ``None`` uses ``algorithm.k_max``. A
                 runtime input: changing it reuses the cached (or exported)
                 batched closure. The batch runs until its slowest element
                 converges or exhausts its own cap; finished elements are
                 frozen, not re-iterated.
+            overrides: Per-solve values for any :class:`AlgorithmState`
+                field by name (see :meth:`solve_jax`); all runtime inputs
+                against one cached artifact. Each value takes the rank rule's
+                two shapes — the field's shape (shared) or ``(B,) +`` it
+                (batched) — plus two **fill** forms for array-shaped fields:
+                a scalar (shared) or ``(B,)`` (one scalar per element, each
+                broadcast to the field shape). Exact shapes win when both
+                parse; ``in_axes={"overrides": {name: 0}}`` forces the
+                per-element fill reading.
             in_axes: Explicit batching override in ``jax.vmap``'s vocabulary:
                 a dict keyed by argument name with leaves ``0`` (batched) or
-                ``None`` (shared); ``"parameters"`` maps to a per-key dict,
-                e.g. ``in_axes={"parameters": {"gate_center": 0}}``. Partial
+                ``None`` (shared); ``"parameters"`` and ``"overrides"`` map
+                to per-key dicts, e.g.
+                ``in_axes={"parameters": {"gate_center": 0}}``. Partial
                 specs are fine — unlisted entries use the rank rule.
 
         Returns:
@@ -1664,6 +1791,20 @@ class Problem:
                 f"declared parameters are {sorted(self._parameters)}."
             )
 
+        overrides = dict(overrides or {})
+        self._validate_overrides(
+            "solve_batched",
+            overrides,
+            {
+                "x_initial": x_initial,
+                "x_final": x_final,
+                "x_guess": x_guess,
+                "u_guess": u_guess,
+                "max_iters": max_iters,
+            },
+        )
+        _default = self._default_state()
+
         N = self.settings.sim.n
         n_x = self.settings.sim.n_states
         n_u = self.settings.sim.n_controls
@@ -1672,43 +1813,41 @@ class Problem:
             "x_final": (x_final, (n_x,)),
             "x_guess": (x_guess, (N, n_x)),
             "u_guess": (u_guess, (N, n_u)),
-            "ep_tr": (ep_tr, ()),
-            "ep_vb": (ep_vb, ()),
-            "ep_vc": (ep_vc, ()),
-            "lam_cost_drop": (lam_cost_drop, ()),
             "max_iters": (max_iters, ()),
         }
         for key, value in user_params.items():
             entries[f"parameters.{key}"] = (value, tuple(np.shape(self._parameters[key])))
+        for name, value in overrides.items():
+            declared = tuple(jnp.shape(_override_target(_default, name)))
+            entries[f"overrides.{name}"] = (value, declared)
 
         # Flatten the user-facing in_axes ({"parameters": {key: ax}}) to the
         # per-entry names the resolver (and its error messages) uses.
         flat_in_axes = {}
         for name, ax in (in_axes or {}).items():
-            if name == "parameters":
+            if name in ("parameters", "overrides"):
                 if not isinstance(ax, dict):
                     raise ValueError(
-                        f"solve_batched: in_axes['parameters'] must be a per-key "
+                        f"solve_batched: in_axes['{name}'] must be a per-key "
                         f"dict, e.g. {{'gate_center': 0}}; got {ax!r}."
                     )
-                flat_in_axes.update({f"parameters.{key}": v for key, v in ax.items()})
+                flat_in_axes.update({f"{name}.{key}": v for key, v in ax.items()})
             else:
                 flat_in_axes[name] = ax
 
-        B, axes = _resolve_batch_spec(entries, flat_in_axes)
+        B, axes, fills = _resolve_batch_spec(
+            entries,
+            flat_in_axes,
+            fill={f"overrides.{name}" for name in overrides},
+        )
 
         # Shared state-side inputs — and the defaults for omitted ones —
         # broadcast to a leading B axis; batched ones pass through.
-        _default = self._default_state()
         defaults = {
             "x_initial": _default.x_init_pin,
             "x_final": _default.x_term_pin,
             "x_guess": _default.x,
             "u_guess": _default.u,
-            "ep_tr": _default.ep_tr,
-            "ep_vb": _default.ep_vb,
-            "ep_vc": _default.ep_vc,
-            "lam_cost_drop": _default.lam_cost_drop,
             "max_iters": _default.k_max,
         }
         stacks = {}
@@ -1719,16 +1858,31 @@ class Problem:
                 arr = jnp.broadcast_to(arr, (B,) + arr.shape)
             stacks[name] = arr
 
+        # Overrides normalize to (B,) + field shape: fills first broadcast
+        # their scalars up to the field shape, shared entries then gain the
+        # leading batch axis.
+        override_stacks = {}
+        for name, value in overrides.items():
+            entry = f"overrides.{name}"
+            field_shape = entries[entry][1]
+            arr = jnp.asarray(value)
+            if entry in fills and axes[entry] == 0:
+                arr = jnp.broadcast_to(
+                    arr.reshape(arr.shape + (1,) * len(field_shape)), (B,) + field_shape
+                )
+            elif entry in fills:
+                arr = jnp.broadcast_to(arr, field_shape)
+            if axes[entry] is None:
+                arr = jnp.broadcast_to(arr, (B,) + arr.shape)
+            override_stacks[name] = arr
+
         states = jax.vmap(self._resolve_initial_state)(
             stacks["x_initial"],
             stacks["x_final"],
             stacks["x_guess"],
             stacks["u_guess"],
-            stacks["ep_tr"],
-            stacks["ep_vb"],
-            stacks["ep_vc"],
-            stacks["lam_cost_drop"],
             stacks["max_iters"],
+            override_stacks,
         )
 
         params_for_solve = dict(self._parameters, **user_params)

--- a/openscvx/problem.py
+++ b/openscvx/problem.py
@@ -507,15 +507,15 @@ class Problem:
         self._iteration_fn_jit_inner: callable = None
 
         # Closure cache for the ``lax.while_loop`` wrapper that backs
-        # :meth:`solve_jax`. Keyed on ``k_max`` — rebuilt only when the caller
-        # supplies a non-default ``max_iters``.
+        # :meth:`solve_jax`. Built once per ``initialize()`` — convergence
+        # thresholds and the iteration cap ride the state pytree, so they
+        # never force a rebuild.
         self._solve_loop_fn: Optional[callable] = None
-        self._solve_loop_k_max: Optional[int] = None
 
         # Closure cache for the batched ``vmap``'d loop that backs
-        # :meth:`solve_batched`. Keyed on ``(B, k_max, param_axes)`` — batch
-        # size and per-parameter batching are baked into the artifact, so
-        # changing either rebuilds.
+        # :meth:`solve_batched`. Keyed on ``(B, param_axes)`` — batch size and
+        # per-parameter batching are baked into the artifact, so changing
+        # either rebuilds.
         self._solve_batched_fn: Optional[callable] = None
         self._solve_batched_key: Optional[tuple] = None
 
@@ -681,6 +681,39 @@ class Problem:
         self._solver.update_boundary_conditions(
             x_init=self._lowered.x_unified.initial,
             x_term=self._lowered.x_unified.final,
+        )
+
+    def _sync_scp_constants(self):
+        """Sync the SCP loop constants from the algorithm config onto the state.
+
+        ``ep_tr`` / ``ep_vb`` / ``ep_vc`` / ``k_max`` / ``lam_cost_drop`` are
+        snapshotted onto :class:`AlgorithmState` when it is created, so a
+        mutation like ``problem.algorithm.ep_tr = 1e-6`` between ``solve()``
+        calls would otherwise go stale. Re-read them here, alongside
+        :meth:`_sync_parameters` / :meth:`_sync_boundary_conditions`.
+
+        Note:
+            Safe to call before initialize() - it will simply do nothing.
+        """
+        if self._state is None:
+            return
+
+        algo = self._algorithm
+        state = self._state
+        # Commit each leaf to the device exactly as ``from_settings`` does:
+        # ``iteration_fn``'s jit cache keys on committed sharding, so an
+        # uncommitted leaf here would trigger a recompile on the next step.
+        device = jax.devices()[0]
+
+        def put(value, like):
+            return jax.device_put(jnp.asarray(value, dtype=like.dtype), device)
+
+        self._state = state.replace(
+            ep_tr=put(algo.ep_tr, state.ep_tr),
+            ep_vb=put(algo.ep_vb, state.ep_vb),
+            ep_vc=put(algo.ep_vc, state.ep_vc),
+            k_max=put(algo.k_max, state.k_max),
+            lam_cost_drop=put(algo.autotuner.lam_cost_drop, state.lam_cost_drop),
         )
 
     def _sync_guesses(self):
@@ -1006,7 +1039,6 @@ class Problem:
         # capture the previous ``iteration_fn`` and would re-use stale traces
         # if ``initialize()`` is invoked twice.
         self._solve_loop_fn = None
-        self._solve_loop_k_max = None
         self._solve_batched_fn = None
         self._solve_batched_key = None
         self._solve_batched_is_exported = False
@@ -1054,7 +1086,7 @@ class Problem:
         # first call (see :meth:`_get_or_build_solve_loop`) — pre-warming it
         # here would tax ``.solve()``-only users with ~1-3s of XLA compile work
         # they never benefit from.
-        warmup_state = AlgorithmState.from_settings(self.settings, self._algorithm.weights)
+        warmup_state = self._default_state()
         jax.block_until_ready(self._iteration_fn(warmup_state, self._parameters))
         print("✓ SCvx Subproblem Solver initialized")
 
@@ -1072,7 +1104,7 @@ class Problem:
             self.emitter_function = lambda data: None
 
         # Create fresh solver state + history pair.
-        self._state = AlgorithmState.from_settings(self.settings, self._algorithm.weights)
+        self._state = self._default_state()
         self._history = AlgorithmHistory.from_settings(self.settings)
 
         t_f_while = time.time()
@@ -1128,7 +1160,7 @@ class Problem:
         self._sync_boundary_conditions()
 
         # Create fresh solver state + history from settings
-        self._state = AlgorithmState.from_settings(self.settings, self._algorithm.weights)
+        self._state = self._default_state()
         self._history = AlgorithmHistory.from_settings(self.settings)
 
         # Reset solution
@@ -1204,9 +1236,10 @@ class Problem:
             OptimizationResults with trajectory and convergence info
                 (call post_process() for full propagation)
         """
-        # Sync parameters and boundary conditions before solving
+        # Sync parameters, boundary conditions, and SCP constants before solving
         self._sync_parameters()
         self._sync_boundary_conditions()
+        self._sync_scp_constants()
 
         required = [
             self._compiled_dynamics_prop,
@@ -1265,48 +1298,78 @@ class Problem:
             int(self._state.k) <= k_max and not timed_out,
         )
 
+    def _default_state(self) -> AlgorithmState:
+        """Fresh :class:`AlgorithmState` from settings and the algorithm's SCP constants.
+
+        The single assembly point for :meth:`AlgorithmState.from_settings`'
+        keyword constants: convergence thresholds and the iteration cap come
+        off the algorithm, ``lam_cost_drop`` off its autotuner.
+        """
+        algo = self._algorithm
+        return AlgorithmState.from_settings(
+            self.settings,
+            algo.weights,
+            ep_tr=algo.ep_tr,
+            ep_vb=algo.ep_vb,
+            ep_vc=algo.ep_vc,
+            k_max=algo.k_max,
+            lam_cost_drop=algo.autotuner.lam_cost_drop,
+        )
+
     def _resolve_initial_state(
         self,
         x_initial: Optional[jnp.ndarray],
         x_final: Optional[jnp.ndarray],
         x_guess: Optional[jnp.ndarray] = None,
         u_guess: Optional[jnp.ndarray] = None,
+        ep_tr: Optional[jnp.ndarray] = None,
+        ep_vb: Optional[jnp.ndarray] = None,
+        ep_vc: Optional[jnp.ndarray] = None,
+        lam_cost_drop: Optional[jnp.ndarray] = None,
+        max_iters: Optional[jnp.ndarray] = None,
     ) -> AlgorithmState:
-        """Build a fresh :class:`AlgorithmState` with user-supplied boundary pins.
+        """Build a fresh :class:`AlgorithmState` with per-solve overrides applied.
 
-        The pins live on the pytree (``x_init_pin`` / ``x_term_pin``) so the
-        fused iteration body assembles the subproblem's initial / terminal
-        rows as a pure function of state. Under ``jax.vmap`` over
-        ``x_initial`` / ``x_final`` / ``x_guess`` / ``u_guess``, each batch
-        slot gets its own boundary condition and SCP seed iterate without
-        recompilation.
+        This is the single place per-solve inputs land on the state pytree:
+        boundary pins (``x_init_pin`` / ``x_term_pin``), trajectory
+        warm-starts (``x`` / ``u``), and the SCP loop constants
+        (``ep_tr`` / ``ep_vb`` / ``ep_vc`` / ``lam_cost_drop`` /
+        ``max_iters`` → ``k_max``). Because every override is a pytree field,
+        ``jax.vmap`` over any subset gives each batch slot its own boundary
+        condition, seed iterate, and hyperparameters without recompilation.
 
-        ``None`` falls back to the defaults from
-        :meth:`AlgorithmState.from_settings`. A user-supplied vector replaces
-        the corresponding pin in full; pass ``jnp.nan`` at non-pinned
-        entries to match the convention :meth:`from_settings` uses (the
-        subproblem only consumes the pin where the boundary type is
-        ``"Fix"``).  Optional ``x_guess`` / ``u_guess`` replace
-        ``state.x`` / ``state.u`` (the trajectory warm-start).
+        ``None`` falls back to the defaults from :meth:`_default_state`. A
+        user-supplied pin replaces the corresponding field in full; pass
+        ``jnp.nan`` at non-pinned entries to match the convention
+        :meth:`AlgorithmState.from_settings` uses (the subproblem only
+        consumes the pin where the boundary type is ``"Fix"``).
         """
-        state = AlgorithmState.from_settings(self.settings, self._algorithm.weights)
-        if x_initial is not None:
-            state = state.replace(x_init_pin=jnp.asarray(x_initial, dtype=state.x_init_pin.dtype))
-        if x_final is not None:
-            state = state.replace(x_term_pin=jnp.asarray(x_final, dtype=state.x_term_pin.dtype))
-        if x_guess is not None:
-            state = state.replace(x=jnp.asarray(x_guess, dtype=state.x.dtype))
-        if u_guess is not None:
-            state = state.replace(u=jnp.asarray(u_guess, dtype=state.u.dtype))
-        return state
+        state = self._default_state()
+        overrides = {
+            "x_init_pin": x_initial,
+            "x_term_pin": x_final,
+            "x": x_guess,
+            "u": u_guess,
+            "ep_tr": ep_tr,
+            "ep_vb": ep_vb,
+            "ep_vc": ep_vc,
+            "lam_cost_drop": lam_cost_drop,
+            "k_max": max_iters,
+        }
+        return state.replace(
+            **{
+                name: jnp.asarray(value, dtype=getattr(state, name).dtype)
+                for name, value in overrides.items()
+                if value is not None
+            }
+        )
 
-    def _get_or_build_solve_loop(self, max_iters: Optional[int]) -> callable:
+    def _get_or_build_solve_loop(self) -> callable:
         """Return the cached ``jax.jit``'d ``lax.while_loop`` wrapper.
 
-        :func:`make_solve_loop` is hashable on ``k_max`` (the convergence
-        thresholds are problem constants). Cache the closure on
-        ``self._solve_loop_fn`` keyed on ``k_max`` and rebuild only when the
-        caller supplies a non-default ``max_iters``. The closure is wrapped
+        Built once per ``initialize()`` — the convergence thresholds and the
+        iteration cap are :class:`AlgorithmState` fields, i.e. runtime inputs,
+        so no per-solve setting forces a rebuild. The closure is wrapped
         in :func:`jax.jit`, so the first :meth:`solve_jax` call pays the XLA
         compile cost (~1-3s for brachistochrone-sized problems) and
         subsequent calls hit ``jax.jit``'s shape-keyed cache. Users with a
@@ -1317,24 +1380,13 @@ class Problem:
         real-call warmup populates ``jax.jit``'s standard cache which vmap
         retraces from on first use.
         """
-        k_max = max_iters if max_iters is not None else self._algorithm.k_max
-        if self._solve_loop_fn is None or self._solve_loop_k_max != k_max:
-            self._solve_loop_fn = jax.jit(
-                make_solve_loop(
-                    self._iteration_fn,
-                    self._algorithm.ep_tr,
-                    self._algorithm.ep_vb,
-                    self._algorithm.ep_vc,
-                    k_max,
-                )
-            )
-            self._solve_loop_k_max = k_max
+        if self._solve_loop_fn is None:
+            self._solve_loop_fn = jax.jit(make_solve_loop(self._iteration_fn))
         return self._solve_loop_fn
 
     def _get_or_build_solve_batched(
         self,
         B: int,
-        max_iters: Optional[int],
         params: dict,
         param_axes: Dict[str, Optional[int]],
     ) -> callable:
@@ -1349,8 +1401,10 @@ class Problem:
         discretization solvers are plain ``jax.jit``, hence ``vmap``-safe — not
         :attr:`_iteration_fn`, which under ``save_compiled`` wraps
         ``call_exported`` solvers that have no ``vmap`` rule (§3). The closure
-        is cached on ``(B, k_max, param_axes)``: batch size and per-parameter
+        is cached on ``(B, param_axes)``: batch size and per-parameter
         batching are baked into the program, so changing either retraces.
+        Tolerances and the iteration cap ride the state pytree, so they never
+        retrace or re-export.
 
         Under ``save_compiled`` the whole vmapped loop is exported once to the
         solver cache and deserialized on later processes (the single artifact
@@ -1359,16 +1413,9 @@ class Problem:
         exportable backend — CVXPy raises a teaching error here rather than
         silently degrading to an in-process solve.
         """
-        k_max = max_iters if max_iters is not None else self._algorithm.k_max
-        key = (B, k_max, tuple(sorted(param_axes.items())))
+        key = (B, tuple(sorted(param_axes.items())))
         if self._solve_batched_fn is None or self._solve_batched_key != key:
-            loop = make_solve_loop(
-                self._iteration_fn_jit_inner,
-                self._algorithm.ep_tr,
-                self._algorithm.ep_vb,
-                self._algorithm.ep_vc,
-                k_max,
-            )
+            loop = make_solve_loop(self._iteration_fn_jit_inner)
             batched = jax.vmap(loop, in_axes=(0, param_axes))
             if self.settings.sim.save_compiled and not self.settings.dev.debug:
                 if not self._solver.exportable:
@@ -1386,11 +1433,11 @@ class Problem:
                     self._solver,
                     self._discretizer,
                     B,
-                    k_max,
+                    param_axes,
                 )
                 sample_state = jax.tree_util.tree_map(
                     lambda a: jnp.broadcast_to(a, (B,) + jnp.shape(a)),
-                    AlgorithmState.from_settings(self.settings, self._algorithm.weights),
+                    self._default_state(),
                 )
                 # Trace the export against the same ``params`` the call will use,
                 # not ``self._parameters`` — under an export the input avals are
@@ -1403,7 +1450,7 @@ class Problem:
                 # artifact accepts any inputs with those same shapes/dtypes.
                 sample_state = jax.tree_util.tree_map(
                     lambda a: jnp.broadcast_to(a, (B,) + jnp.shape(a)),
-                    AlgorithmState.from_settings(self.settings, self._algorithm.weights),
+                    self._default_state(),
                 )
                 t_0_compile = time.time()
                 batched = jax.jit(batched).lower(sample_state, params).compile()
@@ -1421,6 +1468,10 @@ class Problem:
         *,
         x_guess: Optional[jnp.ndarray] = None,
         u_guess: Optional[jnp.ndarray] = None,
+        ep_tr: Optional[jnp.ndarray] = None,
+        ep_vb: Optional[jnp.ndarray] = None,
+        ep_vc: Optional[jnp.ndarray] = None,
+        lam_cost_drop: Optional[jnp.ndarray] = None,
         max_iters: Optional[int] = None,
     ) -> OptimizationResults:
         """Run the SCP algorithm — JAX-pure.
@@ -1455,10 +1506,18 @@ class Problem:
                 settings (``State.guess`` at ``initialize()``).
             u_guess: Initial control trajectory guess, shape ``(N, n_controls)``.
                 Replaces ``state.u``; ``None`` uses the default from settings.
-            max_iters: SCP iteration cap. ``None`` uses ``algorithm.k_max``;
-                a different value rebuilds the cached ``lax.while_loop``
-                closure (one extra trace; subsequent calls at the same
-                ``max_iters`` hit the cache).
+            ep_tr: Convergence threshold on ``J_tr`` (scalar). Replaces
+                ``state.ep_tr``; ``None`` uses ``algorithm.ep_tr``.
+            ep_vb: Convergence threshold on ``J_vb`` (scalar). ``None`` uses
+                ``algorithm.ep_vb``.
+            ep_vc: Convergence threshold on ``J_vc`` (scalar). ``None`` uses
+                ``algorithm.ep_vc``.
+            lam_cost_drop: Iteration after which autotuners relax
+                ``lam_cost`` (scalar; ``-1`` = never). ``None`` uses the
+                autotuner's configured value.
+            max_iters: SCP iteration cap (scalar). ``None`` uses
+                ``algorithm.k_max``. A runtime input like the tolerances —
+                no value forces a retrace.
 
         Returns:
             :class:`OptimizationResults` pytree with the final iterate and
@@ -1472,9 +1531,17 @@ class Problem:
         params = parameters if parameters is not None else self._parameters
 
         initial_state = self._resolve_initial_state(
-            x_initial, x_final, x_guess=x_guess, u_guess=u_guess
+            x_initial,
+            x_final,
+            x_guess=x_guess,
+            u_guess=u_guess,
+            ep_tr=ep_tr,
+            ep_vb=ep_vb,
+            ep_vc=ep_vc,
+            lam_cost_drop=lam_cost_drop,
+            max_iters=max_iters,
         )
-        solve_fn = self._get_or_build_solve_loop(max_iters)
+        solve_fn = self._get_or_build_solve_loop()
         final_state = solve_fn(initial_state, params)
         return OptimizationResults.from_final_state(final_state, problem=self)
 
@@ -1486,7 +1553,11 @@ class Problem:
         *,
         x_guess: Optional[jnp.ndarray] = None,
         u_guess: Optional[jnp.ndarray] = None,
-        max_iters: Optional[int] = None,
+        ep_tr: Optional[jnp.ndarray] = None,
+        ep_vb: Optional[jnp.ndarray] = None,
+        ep_vc: Optional[jnp.ndarray] = None,
+        lam_cost_drop: Optional[jnp.ndarray] = None,
+        max_iters: Optional[jnp.ndarray] = None,
         in_axes: Optional[dict] = None,
     ) -> OptimizationResults:
         """Run ``B`` SCP solves in parallel as one batched XLA program.
@@ -1506,6 +1577,7 @@ class Problem:
                     "gate_center": centers,      # (B, 3) vs declared (3,) -> batched
                     "gate_radius": 0.5,          # declared shape -> shared
                 },
+                ep_tr=jnp.logspace(-5, -3, B),   # (B,) vs declared () -> tolerance sweep
             )
 
         Rank against the declared shape decides — never the leading-axis
@@ -1526,8 +1598,10 @@ class Problem:
         Export requires a pure-JAX backend: under ``save_compiled=True`` the
         CVXPy backend raises.  The cache key invalidates on any change that
         alters the exported loop — backend, algorithm, discretizer, scaling,
-        ``B``, and the JAX version — so a stale artifact is never silently
-        reused.
+        ``B``, the shared/batched parameter split, and the JAX version — so a
+        stale artifact is never silently reused.  Tolerances and ``max_iters``
+        are runtime inputs on the state pytree, so one artifact serves every
+        setting of them.
 
         **What cannot be batched**: ``N``, the solver backend, the
         discretizer/integrator, the autotuner type, and ``float_dtype``
@@ -1552,9 +1626,22 @@ class Problem:
                 settings.
             u_guess: Control trajectory guess — ``(N, n_u)`` or
                 ``(B, N, n_u)``. ``None`` uses the default from settings.
-            max_iters: SCP iteration cap. ``None`` uses ``algorithm.k_max``;
-                a different value (or a different ``B``) rebuilds the cached
-                batched closure.
+            ep_tr: Convergence threshold on ``J_tr`` — ``()`` shared or
+                ``(B,)`` for a per-element tolerance sweep. ``None`` uses
+                ``algorithm.ep_tr``.
+            ep_vb: Convergence threshold on ``J_vb`` — ``()`` or ``(B,)``.
+                ``None`` uses ``algorithm.ep_vb``.
+            ep_vc: Convergence threshold on ``J_vc`` — ``()`` or ``(B,)``.
+                ``None`` uses ``algorithm.ep_vc``.
+            lam_cost_drop: Iteration after which autotuners relax
+                ``lam_cost`` (``-1`` = never) — ``()`` or ``(B,)``. ``None``
+                uses the autotuner's configured value.
+            max_iters: SCP iteration cap — ``()`` shared or ``(B,)``
+                per-element budgets. ``None`` uses ``algorithm.k_max``. A
+                runtime input: changing it reuses the cached (or exported)
+                batched closure. The batch runs until its slowest element
+                converges or exhausts its own cap; finished elements are
+                frozen, not re-iterated.
             in_axes: Explicit batching override in ``jax.vmap``'s vocabulary:
                 a dict keyed by argument name with leaves ``0`` (batched) or
                 ``None`` (shared); ``"parameters"`` maps to a per-key dict,
@@ -1586,6 +1673,11 @@ class Problem:
             "x_final": (x_final, (n_x,)),
             "x_guess": (x_guess, (N, n_x)),
             "u_guess": (u_guess, (N, n_u)),
+            "ep_tr": (ep_tr, ()),
+            "ep_vb": (ep_vb, ()),
+            "ep_vc": (ep_vc, ()),
+            "lam_cost_drop": (lam_cost_drop, ()),
+            "max_iters": (max_iters, ()),
         }
         for key, value in user_params.items():
             entries[f"parameters.{key}"] = (value, tuple(np.shape(self._parameters[key])))
@@ -1608,12 +1700,17 @@ class Problem:
 
         # Shared state-side inputs — and the defaults for omitted ones —
         # broadcast to a leading B axis; batched ones pass through.
-        _default = AlgorithmState.from_settings(self.settings, self._algorithm.weights)
+        _default = self._default_state()
         defaults = {
             "x_initial": _default.x_init_pin,
             "x_final": _default.x_term_pin,
             "x_guess": _default.x,
             "u_guess": _default.u,
+            "ep_tr": _default.ep_tr,
+            "ep_vb": _default.ep_vb,
+            "ep_vc": _default.ep_vc,
+            "lam_cost_drop": _default.lam_cost_drop,
+            "max_iters": _default.k_max,
         }
         stacks = {}
         for name, default in defaults.items():
@@ -1624,14 +1721,20 @@ class Problem:
             stacks[name] = arr
 
         states = jax.vmap(self._resolve_initial_state)(
-            stacks["x_initial"], stacks["x_final"], stacks["x_guess"], stacks["u_guess"]
+            stacks["x_initial"],
+            stacks["x_final"],
+            stacks["x_guess"],
+            stacks["u_guess"],
+            stacks["ep_tr"],
+            stacks["ep_vb"],
+            stacks["ep_vc"],
+            stacks["lam_cost_drop"],
+            stacks["max_iters"],
         )
 
         params_for_solve = dict(self._parameters, **user_params)
         param_axes = {key: axes.get(f"parameters.{key}") for key in params_for_solve}
-        batched_solve = self._get_or_build_solve_batched(
-            B, max_iters, params_for_solve, param_axes
-        )
+        batched_solve = self._get_or_build_solve_batched(B, params_for_solve, param_axes)
         t_0_solve = time.time()
         if getattr(self, "_solve_batched_is_exported", False):
             final_states = batched_solve.call(states, params_for_solve)

--- a/openscvx/problem.py
+++ b/openscvx/problem.py
@@ -212,6 +212,54 @@ def _resolve_batch_spec(
     return B, axes, fills
 
 
+def _flatten_in_axes(in_axes, entries: Dict[str, Tuple[Any, Tuple[int, ...]]]) -> dict:
+    """Flatten the user-facing ``in_axes`` to the resolver's per-entry names.
+
+    Mirrors ``jax.vmap``'s prefix semantics: a bare ``0`` batches every
+    passed input, and ``0`` / ``None`` at ``"parameters"`` / ``"overrides"``
+    applies to every key passed in that dict; per-key dicts pick out
+    individual entries. One deliberate divergence from ``vmap``: a bare
+    ``None`` keeps its default meaning — infer by rank — because vmap's
+    all-broadcast reading would leave a batched solve with no batch axis.
+
+    Args:
+        in_axes: ``None`` (infer), ``0`` (batch everything passed), or a dict
+            keyed by argument name with leaves ``0`` / ``None`` — where
+            ``"parameters"`` and ``"overrides"`` take either a prefix
+            (``0`` / ``None``) or a per-key dict.
+        entries: The resolver's ``{name: (value, declared_shape)}`` map;
+            supplies the passed-entry names a prefix expands over.
+
+    Returns:
+        ``{entry_name: 0 | None}`` for :func:`_resolve_batch_spec`.
+    """
+    if in_axes is None:
+        return {}
+    if in_axes == 0:
+        return {name: 0 for name, (value, _) in entries.items() if value is not None}
+    if not isinstance(in_axes, dict):
+        raise ValueError(
+            f"solve_batched: in_axes must be 0 (batch every input), a dict "
+            f"keyed by argument name, or None (infer by rank); got {in_axes!r}."
+        )
+    flat = {}
+    for name, ax in in_axes.items():
+        if name in ("parameters", "overrides"):
+            if isinstance(ax, dict):
+                flat.update({f"{name}.{key}": v for key, v in ax.items()})
+            elif ax in (0, None):
+                flat.update({entry: ax for entry in entries if entry.startswith(f"{name}.")})
+            else:
+                raise ValueError(
+                    f"solve_batched: in_axes['{name}'] must be 0 or None (a "
+                    f"prefix applied to every passed key) or a per-key dict, "
+                    f"e.g. {{'gate_center': 0}}; got {ax!r}."
+                )
+        else:
+            flat[name] = ax
+    return flat
+
+
 # Named solve kwargs and the AlgorithmState field each one targets. The
 # ``overrides`` dict reaches the same fields by name, so passing both for one
 # field is ambiguous — the solve methods raise, pointing at the kwarg.
@@ -1767,12 +1815,17 @@ class Problem:
                 broadcast to the field shape). Exact shapes win when both
                 parse; ``in_axes={"overrides": {name: 0}}`` forces the
                 per-element fill reading.
-            in_axes: Explicit batching override in ``jax.vmap``'s vocabulary:
-                a dict keyed by argument name with leaves ``0`` (batched) or
-                ``None`` (shared); ``"parameters"`` and ``"overrides"`` map
-                to per-key dicts, e.g.
+            in_axes: Explicit batching override in ``jax.vmap``'s vocabulary,
+                including its prefix semantics: a bare ``0`` batches every
+                passed input; a dict keyed by argument name takes leaves
+                ``0`` (batched) or ``None`` (shared), where ``"parameters"``
+                and ``"overrides"`` accept either a prefix (``0`` / ``None``,
+                applied to every passed key) or a per-key dict, e.g.
                 ``in_axes={"parameters": {"gate_center": 0}}``. Partial
-                specs are fine — unlisted entries use the rank rule.
+                specs are fine — unlisted entries use the rank rule. Unlike
+                ``vmap``, the default (``None``) means *infer by rank*, not
+                broadcast-everything — an all-shared batched solve has no
+                batch axis to find.
 
         Returns:
             :class:`OptimizationResults` pytree with a leading ``B`` axis on
@@ -1821,19 +1874,7 @@ class Problem:
             declared = tuple(jnp.shape(_override_target(_default, name)))
             entries[f"overrides.{name}"] = (value, declared)
 
-        # Flatten the user-facing in_axes ({"parameters": {key: ax}}) to the
-        # per-entry names the resolver (and its error messages) uses.
-        flat_in_axes = {}
-        for name, ax in (in_axes or {}).items():
-            if name in ("parameters", "overrides"):
-                if not isinstance(ax, dict):
-                    raise ValueError(
-                        f"solve_batched: in_axes['{name}'] must be a per-key "
-                        f"dict, e.g. {{'gate_center': 0}}; got {ax!r}."
-                    )
-                flat_in_axes.update({f"{name}.{key}": v for key, v in ax.items()})
-            else:
-                flat_in_axes[name] = ax
+        flat_in_axes = _flatten_in_axes(in_axes, entries)
 
         B, axes, fills = _resolve_batch_spec(
             entries,

--- a/openscvx/problem.py
+++ b/openscvx/problem.py
@@ -23,7 +23,7 @@ import os
 import queue
 import threading
 import time
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import jax
 import numpy as np
@@ -80,81 +80,98 @@ from openscvx.utils.caching import (
 )
 
 
-def _infer_batch_size(
-    user_params: Optional[dict],
-    *,
-    x0_stack=None,
-    xf_stack=None,
-    x_guess=None,
-    u_guess=None,
-) -> int:
-    """Infer the batch size B for :meth:`Problem.solve_batched`.
+def _resolve_batch_spec(
+    entries: Dict[str, Tuple[Any, Tuple[int, ...]]],
+    in_axes: Optional[Dict[str, Optional[int]]] = None,
+) -> Tuple[int, Dict[str, Optional[int]]]:
+    """Decide which entries of a batched solve carry a batch axis.
 
-    Returns the leading axis of the first batched entry among *x0_stack*,
-    *xf_stack*, *x_guess*, *u_guess*, or a non-scalar value in *user_params*.
-    Raises ``ValueError`` when no batched entry is found.
+    The one rule behind :meth:`Problem.solve_batched`: a value whose shape
+    equals its declared (unbatched) shape is shared across the batch; a value
+    with exactly one extra leading axis is batched along it. Rank against the
+    declared shape decides — never the leading-axis value — so a shared entry
+    whose leading axis happens to equal ``B`` is never misread as batched.
+
+    Args:
+        entries: ``{name: (value, declared_shape)}`` over every batchable
+            input. ``None`` values are skipped (the caller substitutes
+            defaults for them).
+        in_axes: Optional ``{name: 0 | None}`` overriding inference for the
+            named entries (``0`` = batched along the leading axis, ``None`` =
+            shared); unlisted entries fall back to the rank rule.
+
+    Returns:
+        ``(B, axes)`` — the common batch size and a ``{name: 0 | None}`` dict
+        over the non-``None`` entries, ready to use as a ``jax.vmap``
+        ``in_axes`` pytree.
+
+    Raises:
+        ValueError: If a value matches neither accepted shape, if batched
+            entries disagree on the leading axis, if no entry is batched, or
+            if *in_axes* names an unknown or absent entry or uses an axis
+            other than ``0`` / ``None``.
     """
-    for value in (x0_stack, xf_stack):
-        if value is not None:
-            arr = jnp.asarray(value)
-            if arr.ndim >= 2:
-                return int(arr.shape[0])
-    for value in (x_guess, u_guess):
-        if value is not None:
-            arr = jnp.asarray(value)
-            if arr.ndim >= 3:
-                return int(arr.shape[0])
-    if user_params:
-        for value in user_params.values():
-            arr = jnp.asarray(value)
-            if arr.ndim > 0:
-                return int(arr.shape[0])
-    raise ValueError(
-        "solve_batched: cannot infer batch size B. "
-        "Pass at least one batched entry in parameters "
-        "(e.g. parameters={'initial_position': array_of_shape_B_x_n}), "
-        "or batched x_guess/u_guess arrays of shape (B, N, n)."
-    )
-
-
-def _expand_batched_trajectory_guess(
-    arr,
-    *,
-    B: int,
-    N: int,
-    n: int,
-    name: str,
-    default: jnp.ndarray,
-) -> jnp.ndarray:
-    """Broadcast or validate a trajectory guess for :meth:`Problem.solve_batched`.
-
-    Accepts ``None`` (use *default*), a shared ``(N, n)`` array, or a
-    per-batch ``(B, N, n)`` stack.
-    """
-    if arr is None:
-        return jnp.asarray(np.broadcast_to(np.asarray(default), (B, N, n)).copy())
-    arr = jnp.asarray(arr)
-    if arr.ndim == 2:
-        if tuple(arr.shape) != (N, n):
+    in_axes = in_axes or {}
+    unknown = set(in_axes) - set(entries)
+    if unknown:
+        raise ValueError(
+            f"solve_batched: in_axes names unknown entr{'y' if len(unknown) == 1 else 'ies'} "
+            f"{sorted(unknown)}; batchable entries are {sorted(entries)}."
+        )
+    for name, ax in in_axes.items():
+        if ax not in (0, None):
             raise ValueError(
-                f"solve_batched: shared {name} must have shape (N, n)=({N}, {n}), got {arr.shape}."
+                f"solve_batched: in_axes['{name}'] must be 0 (batched along the "
+                f"leading axis) or None (shared); got {ax!r}."
             )
-        return jnp.asarray(np.broadcast_to(np.asarray(arr), (B, N, n)).copy())
-    if arr.ndim == 3:
-        if int(arr.shape[0]) != B:
+        if ax == 0 and entries[name][0] is None:
             raise ValueError(
-                f"solve_batched: batched {name} leading axis must equal B={B}, "
-                f"got shape {arr.shape}."
+                f"solve_batched: in_axes marks '{name}' as batched, but no value "
+                f"was passed for it."
             )
-        if tuple(arr.shape[1:]) != (N, n):
+
+    axes: Dict[str, Optional[int]] = {}
+    batched: List[Tuple[str, int]] = []  # (name, leading axis)
+    for name, (value, declared) in entries.items():
+        if value is None:
+            continue
+        shape = tuple(jnp.shape(value))
+        declared = tuple(declared)
+        if name in in_axes:
+            axes[name] = in_axes[name]
+            if in_axes[name] == 0:
+                if not shape:
+                    raise ValueError(
+                        f"solve_batched: in_axes marks '{name}' as batched, but it "
+                        f"is a scalar with no leading axis to batch over."
+                    )
+                batched.append((name, shape[0]))
+        elif shape == declared:
+            axes[name] = None
+        elif len(shape) == len(declared) + 1 and shape[1:] == declared:
+            axes[name] = 0
+            batched.append((name, shape[0]))
+        else:
             raise ValueError(
-                f"solve_batched: batched {name} must have shape (B, N, n)=({B}, {N}, {n}), "
-                f"got {arr.shape}."
+                f"solve_batched: '{name}' has shape {shape}, but its unbatched "
+                f"shape is {declared}; pass {declared} to share it across the "
+                f"batch, or (B,) + {declared} to batch it."
             )
-        return arr
-    raise ValueError(
-        f"solve_batched: {name} must be None, shape (N, n), or (B, N, n); got {arr.shape}."
-    )
+
+    if not batched:
+        raise ValueError(
+            "solve_batched: every argument matches its unbatched shape, so there "
+            "is no batch axis. Use solve_jax() for a single solve, or mark an "
+            "entry as batched explicitly via in_axes (e.g. in_axes={'x_initial': 0})."
+        )
+    ref_name, B = batched[0]
+    for name, b in batched[1:]:
+        if b != B:
+            raise ValueError(
+                f"solve_batched: batch sizes disagree: '{ref_name}' has leading "
+                f"axis {B} but '{name}' has leading axis {b}."
+            )
+    return B, axes
 
 
 def _make_single_result(
@@ -182,29 +199,6 @@ def _make_single_result(
         _states=results._states,
         _controls=results._controls,
     )
-
-
-def _solve_batched_param_in_axes(params: dict, B: int):
-    """Per-parameter vmap ``in_axes`` spec for the parameters pytree.
-
-    Returns ``0`` when every parameter carries a leading batch axis of size ``B``,
-    ``None`` when none do (all shared), or a per-key ``dict`` when the dict is
-    mixed — JAX ``vmap`` accepts any pytree-shaped ``in_axes`` value, so a dict
-    of ``{key: 0 | None}`` correctly batches only the parameters that carry the
-    batch dimension while broadcasting the rest.
-    """
-    if not params:
-        return None
-    axes = {
-        key: (0 if (jnp.asarray(v).ndim > 0 and int(jnp.asarray(v).shape[0]) == B) else None)
-        for key, v in params.items()
-    }
-    vals = list(axes.values())
-    if all(ax == 0 for ax in vals):
-        return 0
-    if all(ax is None for ax in vals):
-        return None
-    return axes  # mixed: return per-key spec; JAX vmap handles it
 
 
 class Problem:
@@ -519,10 +513,11 @@ class Problem:
         self._solve_loop_k_max: Optional[int] = None
 
         # Closure cache for the batched ``vmap``'d loop that backs
-        # :meth:`solve_batched`. Keyed on ``(B, k_max)`` — the fixed batch
-        # size is baked into the artifact, so a different ``B`` rebuilds.
+        # :meth:`solve_batched`. Keyed on ``(B, k_max, param_axes)`` — batch
+        # size and per-parameter batching are baked into the artifact, so
+        # changing either rebuilds.
         self._solve_batched_fn: Optional[callable] = None
-        self._solve_batched_key: Optional[Tuple[int, int]] = None
+        self._solve_batched_key: Optional[tuple] = None
 
         # Set up emitter & queue (thread started in initialize() after columns are known)
         if self.settings.dev.printing:
@@ -1337,21 +1332,25 @@ class Problem:
         return self._solve_loop_fn
 
     def _get_or_build_solve_batched(
-        self, B: int, max_iters: Optional[int], params: dict
+        self,
+        B: int,
+        max_iters: Optional[int],
+        params: dict,
+        param_axes: Dict[str, Optional[int]],
     ) -> callable:
         """Return the cached ``jax.jit``'d batched ``lax.while_loop`` wrapper.
 
         Mirrors :meth:`_get_or_build_solve_loop` but the loop body is
-        ``jax.vmap``'d over the leading batch axis of the ``AlgorithmState`` and,
-        when every parameter array carries that same axis, over parameters too;
-        otherwise parameters are shared across the batch. A single XLA program
-        runs all ``B`` SCP solves.
+        ``jax.vmap``'d over the leading batch axis of the ``AlgorithmState``
+        and over each parameter whose entry in *param_axes* is ``0``;
+        parameters at ``None`` are shared across the batch. A single XLA
+        program runs all ``B`` SCP solves.
         It is built over :attr:`_iteration_fn_jit_inner` — the body whose inner
         discretization solvers are plain ``jax.jit``, hence ``vmap``-safe — not
         :attr:`_iteration_fn`, which under ``save_compiled`` wraps
         ``call_exported`` solvers that have no ``vmap`` rule (§3). The closure
-        is cached on ``(B, k_max)``: the batch size is baked into the program,
-        so a different ``B`` retraces.
+        is cached on ``(B, k_max, param_axes)``: batch size and per-parameter
+        batching are baked into the program, so changing either retraces.
 
         Under ``save_compiled`` the whole vmapped loop is exported once to the
         solver cache and deserialized on later processes (the single artifact
@@ -1361,7 +1360,7 @@ class Problem:
         silently degrading to an in-process solve.
         """
         k_max = max_iters if max_iters is not None else self._algorithm.k_max
-        key = (B, k_max)
+        key = (B, k_max, tuple(sorted(param_axes.items())))
         if self._solve_batched_fn is None or self._solve_batched_key != key:
             loop = make_solve_loop(
                 self._iteration_fn_jit_inner,
@@ -1370,7 +1369,6 @@ class Problem:
                 self._algorithm.ep_vc,
                 k_max,
             )
-            param_axes = _solve_batched_param_in_axes(params, B)
             batched = jax.vmap(loop, in_axes=(0, param_axes))
             if self.settings.sim.save_compiled and not self.settings.dev.debug:
                 if not self._solver.exportable:
@@ -1482,51 +1480,39 @@ class Problem:
 
     def solve_batched(
         self,
+        x_initial: Optional[jnp.ndarray] = None,
+        x_final: Optional[jnp.ndarray] = None,
         parameters: Optional[dict] = None,
         *,
-        x0_stack: Optional[jnp.ndarray] = None,
-        xf_stack: Optional[jnp.ndarray] = None,
         x_guess: Optional[jnp.ndarray] = None,
         u_guess: Optional[jnp.ndarray] = None,
         max_iters: Optional[int] = None,
+        in_axes: Optional[dict] = None,
     ) -> OptimizationResults:
-        """Run ``B`` SCP solves in parallel, batching over parameters.
+        """Run ``B`` SCP solves in parallel as one batched XLA program.
 
-        Applies ``jax.vmap`` *internally* and drives the same fused
-        ``iteration_fn`` core as :meth:`solve_jax` inside one
-        ``lax.while_loop``.  The result is a batched
-        :class:`OptimizationResults` pytree: every array leaf carries the
-        leading batch axis ``B`` (e.g. ``result.x.shape == (B, N, n_x)``).
-
-        **Batching over parameters**: declare any state or constraint whose
-        value changes across solves as an ``ox.Parameter``, then pass an
-        ``(B, ...)``-shaped array for it in *parameters*::
-
-            ic_param = ox.Parameter("ic", shape=(3,), value=default_ic)
-            constraints += [(state == ic_param).convex().at([0])]
-            ...
-            results = problem.solve_batched(parameters={"ic": ic_batch})
-
-        Parameters whose leading axis equals ``B`` are vmapped over; all others
-        are broadcast across the batch.  ``B`` is inferred from the first
-        batched entry in *parameters*, *x_guess*, or *u_guess*.
-
-        **Boundary pins**: pass ``x0_stack`` / ``xf_stack`` as ``(B, n_x)``
-        arrays to batch initial and terminal Fix boundary conditions without
-        declaring a runtime ``.convex()`` constraint (cheaper than parameter
-        pins evaluated every SCP iteration)::
-
-            results = problem.solve_batched(x0_stack=x0_stack, xf_stack=xf_stack)
-
-        **Trajectory guesses**: pass ``x_guess`` / ``u_guess`` as shared
-        ``(N, n)`` arrays (broadcast to every batch element) or per-batch
-        ``(B, N, n)`` stacks to seed each solve's SCP iterate independently::
+        Takes the same arguments as :meth:`solve_jax`, with one rule on top:
+        **add a leading batch axis to whatever varies across solves**. An
+        argument whose shape matches its unbatched shape is shared by every
+        batch element; an argument with exactly one extra leading axis is
+        batched along it. The batch size ``B`` is the common leading axis of
+        the batched entries, and every array leaf of the returned
+        :class:`OptimizationResults` carries it (e.g. ``result.x.shape ==
+        (B, N, n_x)``)::
 
             results = problem.solve_batched(
-                x0_stack=x0_stack,
-                xf_stack=xf_stack,
-                x_guess=x_guess_batch,
+                x_initial=x0_batch,              # (B, n_x): batched pins
+                parameters={
+                    "gate_center": centers,      # (B, 3) vs declared (3,) -> batched
+                    "gate_radius": 0.5,          # declared shape -> shared
+                },
             )
+
+        Rank against the declared shape decides — never the leading-axis
+        value — so a shared parameter whose leading axis happens to equal
+        ``B`` stays shared. For the rare entry the rank rule cannot express
+        (e.g. batching a declared rank-1 parameter element-wise), pass an
+        explicit *in_axes*.
 
         Why this exists alongside ``jax.vmap(solve_jax)``: because the batch
         axis is owned here the whole vmapped loop is a single function that
@@ -1543,27 +1529,37 @@ class Problem:
         ``B``, and the JAX version — so a stale artifact is never silently
         reused.
 
+        **What cannot be batched**: ``N``, the solver backend, the
+        discretizer/integrator, the autotuner type, and ``float_dtype``
+        change array shapes or program structure, so ``B`` such solves can
+        never share one XLA program. There is deliberately no slot for them
+        here — sweep them with a Python loop over separately built
+        ``Problem`` instances.
+
         Args:
-            parameters: Problem parameters dict.  ``None`` reuses
-                ``self._parameters``.  Parameters whose leading axis equals
-                ``B`` are vmapped over (each batch element receives its own
-                slice); parameters with a different shape are broadcast.
-                ``B`` is inferred from the first batched entry supplied here,
-                in *x0_stack*, *xf_stack*, *x_guess*, or *u_guess* (raises
-                if none is found).
-            x0_stack: Initial boundary pins, shape ``(B, n_states)``.  ``None``
-                broadcasts the default ``x_init_pin`` from settings.
-            xf_stack: Terminal boundary pins, shape ``(B, n_states)``.  ``None``
-                broadcasts the default ``x_term_pin`` from settings.
-            x_guess: State trajectory guess, shape ``(N, n_states)`` shared
-                across the batch or ``(B, N, n_states)`` per element.
+            x_initial: Initial-state boundary pin — shape ``(n_x,)`` shared
+                across the batch or ``(B, n_x)`` batched. Same
+                ``jnp.nan``-at-non-Fix convention as :meth:`solve_jax`.
                 ``None`` uses the default from settings.
-            u_guess: Control trajectory guess, shape ``(N, n_controls)`` or
-                ``(B, N, n_controls)``.  ``None`` uses the default from
+            x_final: Terminal-state boundary pin — ``(n_x,)`` or
+                ``(B, n_x)``. Same conventions as ``x_initial``.
+            parameters: Problem parameters for this solve, merged over
+                ``self.parameters``. Each value either matches the
+                parameter's declared shape (shared) or carries one extra
+                leading axis, ``(B,) + declared`` (batched).
+            x_guess: State trajectory guess — ``(N, n_x)`` shared or
+                ``(B, N, n_x)`` batched. ``None`` uses the default from
                 settings.
-            max_iters: SCP iteration cap.  ``None`` uses
-                ``algorithm.k_max``; a different value (or a different ``B``)
-                rebuilds the cached batched closure.
+            u_guess: Control trajectory guess — ``(N, n_u)`` or
+                ``(B, N, n_u)``. ``None`` uses the default from settings.
+            max_iters: SCP iteration cap. ``None`` uses ``algorithm.k_max``;
+                a different value (or a different ``B``) rebuilds the cached
+                batched closure.
+            in_axes: Explicit batching override in ``jax.vmap``'s vocabulary:
+                a dict keyed by argument name with leaves ``0`` (batched) or
+                ``None`` (shared); ``"parameters"`` maps to a per-key dict,
+                e.g. ``in_axes={"parameters": {"gate_center": 0}}``. Partial
+                specs are fine — unlisted entries use the rank rule.
 
         Returns:
             :class:`OptimizationResults` pytree with a leading ``B`` axis on
@@ -1574,48 +1570,68 @@ class Problem:
                 "Problem has not been initialized. Call initialize() before solve_batched()"
             )
 
-        params_for_solve = dict(self._parameters, **(parameters or {}))
+        user_params = parameters or {}
+        unknown = set(user_params) - set(self._parameters)
+        if unknown:
+            raise ValueError(
+                f"solve_batched: unknown parameter(s) {sorted(unknown)}; "
+                f"declared parameters are {sorted(self._parameters)}."
+            )
 
-        B = _infer_batch_size(
-            parameters, x0_stack=x0_stack, xf_stack=xf_stack, x_guess=x_guess, u_guess=u_guess
-        )
         N = self.settings.sim.n
         n_x = self.settings.sim.n_states
         n_u = self.settings.sim.n_controls
+        entries = {
+            "x_initial": (x_initial, (n_x,)),
+            "x_final": (x_final, (n_x,)),
+            "x_guess": (x_guess, (N, n_x)),
+            "u_guess": (u_guess, (N, n_u)),
+        }
+        for key, value in user_params.items():
+            entries[f"parameters.{key}"] = (value, tuple(np.shape(self._parameters[key])))
+
+        # Flatten the user-facing in_axes ({"parameters": {key: ax}}) to the
+        # per-entry names the resolver (and its error messages) uses.
+        flat_in_axes = {}
+        for name, ax in (in_axes or {}).items():
+            if name == "parameters":
+                if not isinstance(ax, dict):
+                    raise ValueError(
+                        f"solve_batched: in_axes['parameters'] must be a per-key "
+                        f"dict, e.g. {{'gate_center': 0}}; got {ax!r}."
+                    )
+                flat_in_axes.update({f"parameters.{key}": v for key, v in ax.items()})
+            else:
+                flat_in_axes[name] = ax
+
+        B, axes = _resolve_batch_spec(entries, flat_in_axes)
+
+        # Shared state-side inputs — and the defaults for omitted ones —
+        # broadcast to a leading B axis; batched ones pass through.
         _default = AlgorithmState.from_settings(self.settings, self._algorithm.weights)
-        if x0_stack is None:
-            x0_stack = jnp.asarray(
-                np.broadcast_to(np.asarray(_default.x_init_pin), (B, n_x)).copy()
-            )
-        else:
-            x0_stack = jnp.asarray(x0_stack)
-            if x0_stack.shape != (B, n_x):
-                raise ValueError(
-                    f"solve_batched: x0_stack must have shape (B, n_x)=({B}, {n_x}), "
-                    f"got {x0_stack.shape}."
-                )
-        if xf_stack is None:
-            xf_stack = jnp.asarray(
-                np.broadcast_to(np.asarray(_default.x_term_pin), (B, n_x)).copy()
-            )
-        else:
-            xf_stack = jnp.asarray(xf_stack)
-            if xf_stack.shape != (B, n_x):
-                raise ValueError(
-                    f"solve_batched: xf_stack must have shape (B, n_x)=({B}, {n_x}), "
-                    f"got {xf_stack.shape}."
-                )
-        x_guess_stack = _expand_batched_trajectory_guess(
-            x_guess, B=B, N=N, n=n_x, name="x_guess", default=_default.x
-        )
-        u_guess_stack = _expand_batched_trajectory_guess(
-            u_guess, B=B, N=N, n=n_u, name="u_guess", default=_default.u
-        )
+        defaults = {
+            "x_initial": _default.x_init_pin,
+            "x_final": _default.x_term_pin,
+            "x_guess": _default.x,
+            "u_guess": _default.u,
+        }
+        stacks = {}
+        for name, default in defaults.items():
+            value = entries[name][0]
+            arr = jnp.asarray(default if value is None else value)
+            if axes.get(name) is None:
+                arr = jnp.broadcast_to(arr, (B,) + arr.shape)
+            stacks[name] = arr
 
         states = jax.vmap(self._resolve_initial_state)(
-            x0_stack, xf_stack, x_guess_stack, u_guess_stack
+            stacks["x_initial"], stacks["x_final"], stacks["x_guess"], stacks["u_guess"]
         )
-        batched_solve = self._get_or_build_solve_batched(B, max_iters, params_for_solve)
+
+        params_for_solve = dict(self._parameters, **user_params)
+        param_axes = {key: axes.get(f"parameters.{key}") for key in params_for_solve}
+        batched_solve = self._get_or_build_solve_batched(
+            B, max_iters, params_for_solve, param_axes
+        )
         t_0_solve = time.time()
         if getattr(self, "_solve_batched_is_exported", False):
             final_states = batched_solve.call(states, params_for_solve)

--- a/openscvx/problem.py
+++ b/openscvx/problem.py
@@ -110,7 +110,7 @@ def _resolve_batch_spec(
             named entries (``0`` = batched along the leading axis, ``None`` =
             shared); unlisted entries fall back to the rank rule.
         fill: Optional set of entry names that accept the scalar / ``(B,)``
-            fill forms (the state-field overrides).
+            fill forms (the ``algorithm`` knobs).
 
     Returns:
         ``(B, axes, fills)`` — the common batch size, a ``{name: 0 | None}``
@@ -216,7 +216,7 @@ def _flatten_in_axes(in_axes, entries: Dict[str, Tuple[Any, Tuple[int, ...]]]) -
     """Flatten the user-facing ``in_axes`` to the resolver's per-entry names.
 
     Mirrors ``jax.vmap``'s prefix semantics: a bare ``0`` batches every
-    passed input, and ``0`` / ``None`` at ``"parameters"`` / ``"overrides"``
+    passed input, and ``0`` / ``None`` at ``"parameters"`` / ``"algorithm"``
     applies to every key passed in that dict; per-key dicts pick out
     individual entries. One deliberate divergence from ``vmap``: a bare
     ``None`` keeps its default meaning — infer by rank — because vmap's
@@ -225,7 +225,7 @@ def _flatten_in_axes(in_axes, entries: Dict[str, Tuple[Any, Tuple[int, ...]]]) -
     Args:
         in_axes: ``None`` (infer), ``0`` (batch everything passed), or a dict
             keyed by argument name with leaves ``0`` / ``None`` — where
-            ``"parameters"`` and ``"overrides"`` take either a prefix
+            ``"parameters"`` and ``"algorithm"`` take either a prefix
             (``0`` / ``None``) or a per-key dict.
         entries: The resolver's ``{name: (value, declared_shape)}`` map;
             supplies the passed-entry names a prefix expands over.
@@ -244,7 +244,7 @@ def _flatten_in_axes(in_axes, entries: Dict[str, Tuple[Any, Tuple[int, ...]]]) -
         )
     flat = {}
     for name, ax in in_axes.items():
-        if name in ("parameters", "overrides"):
+        if name in ("parameters", "algorithm"):
             if isinstance(ax, dict):
                 flat.update({f"{name}.{key}": v for key, v in ax.items()})
             elif ax in (0, None):
@@ -261,7 +261,7 @@ def _flatten_in_axes(in_axes, entries: Dict[str, Tuple[Any, Tuple[int, ...]]]) -
 
 
 # Named solve kwargs and the AlgorithmState field each one targets. The
-# ``overrides`` dict reaches the same fields by name, so passing both for one
+# ``algorithm`` dict reaches the same fields by name, so passing both for one
 # field is ambiguous — the solve methods raise, pointing at the kwarg.
 _OVERRIDE_KWARG_FIELDS = {
     "x_initial": "x_init_pin",
@@ -270,6 +270,14 @@ _OVERRIDE_KWARG_FIELDS = {
     "u_guess": "u",
     "max_iters": "k_max",
 }
+
+# Constructor-only keys of the ``algorithm`` config that select program
+# structure or live outside the traced SCP loop: ``autotuner`` picks the
+# weight-update rule, and ``t_max`` is a wall-clock budget only the
+# interactive ``solve()`` honors. Neither can be a per-solve input, so
+# ``algorithm={...}`` at solve time names them with a construction-time
+# error rather than the generic unknown-name one.
+_ALGORITHM_CONSTRUCTION_KEYS = ("autotuner", "t_max")
 
 
 def _override_target(state: "AlgorithmState", name: str) -> jnp.ndarray:
@@ -1437,30 +1445,40 @@ class Problem:
             hyper=algo.autotuner.hyper,
         )
 
-    def _validate_overrides(self, where: str, overrides: dict, kwargs: Dict[str, Any]) -> None:
-        """Reject unknown override names and overrides that shadow a named kwarg.
+    def _validate_overrides(self, where: str, algorithm: dict, kwargs: Dict[str, Any]) -> None:
+        """Reject unknown ``algorithm`` keys and entries that shadow a named kwarg.
 
         The set of valid names is *derived*, never listed: every
         :class:`AlgorithmState` field (``_FIELDS``) plus every field of the
-        autotuner's declared ``hyper`` container. Adding a state field — or
-        declaring an autotuner knob — is thereby the registration. *kwargs*
-        maps each named solve kwarg to the value the caller received; an
-        override targeting the same field as a kwarg that was actually passed
-        is ambiguous and raises.
+        autotuner's declared ``hyper`` container — the same names the user
+        wrote in the ``Problem`` constructor's ``algorithm`` dict. Adding a
+        state field — or declaring an autotuner knob — is thereby the
+        registration. Construction-only keys of that dict
+        (:data:`_ALGORITHM_CONSTRUCTION_KEYS`) get a teaching error of their
+        own. *kwargs* maps each named solve kwarg to the value the caller
+        received; an entry targeting the same field as a kwarg that was
+        actually passed is ambiguous and raises.
         """
         fields = [name for name in AlgorithmState._FIELDS if name != "hyper"]
         hyper_keys = sorted(fld.name for fld in dc_fields(self._algorithm.autotuner.hyper))
-        unknown = sorted(set(overrides) - set(fields) - set(hyper_keys))
+        for name in algorithm:
+            if name in _ALGORITHM_CONSTRUCTION_KEYS:
+                raise ValueError(
+                    f"{where}: algorithm['{name}'] is a construction-time setting, "
+                    f"not a per-solve input; rebuild the Problem with "
+                    f"Problem(..., algorithm={{'{name}': ...}}) to change it."
+                )
+        unknown = sorted(set(algorithm) - set(fields) - set(hyper_keys))
         if unknown:
             raise ValueError(
-                f"{where}: unknown override name(s) {unknown}; overridable names "
+                f"{where}: unknown algorithm key(s) {unknown}; overridable names "
                 f"are the AlgorithmState fields {sorted(fields)} and the "
                 f"autotuner's declared hyperparameters {hyper_keys}."
             )
         for kwarg, field in _OVERRIDE_KWARG_FIELDS.items():
-            if field in overrides and kwargs.get(kwarg) is not None:
+            if field in algorithm and kwargs.get(kwarg) is not None:
                 raise ValueError(
-                    f"{where}: overrides['{field}'] and the {kwarg} kwarg target the "
+                    f"{where}: algorithm['{field}'] and the {kwarg} kwarg target the "
                     f"same state field; pass the {kwarg} kwarg only."
                 )
 
@@ -1471,14 +1489,14 @@ class Problem:
         x_guess: Optional[jnp.ndarray] = None,
         u_guess: Optional[jnp.ndarray] = None,
         max_iters: Optional[jnp.ndarray] = None,
-        overrides: Optional[dict] = None,
+        algorithm: Optional[dict] = None,
     ) -> AlgorithmState:
         """Build a fresh :class:`AlgorithmState` with per-solve overrides applied.
 
         This is the single place per-solve inputs land on the state pytree:
         boundary pins (``x_init_pin`` / ``x_term_pin``), trajectory
         warm-starts (``x`` / ``u``), ``max_iters`` → ``k_max``, and the
-        generic *overrides* dict (validated field names; values broadcast to
+        validated *algorithm* knob dict (field names; values broadcast to
         the field shape, so a scalar fills an array-shaped field). Because
         every override is a pytree field, ``jax.vmap`` over any subset gives
         each batch slot its own boundary condition, seed iterate, and
@@ -1491,7 +1509,7 @@ class Problem:
         consumes the pin where the boundary type is ``"Fix"``).
         """
         state = self._default_state()
-        # Named kwargs first, overrides on top: ``solve_batched`` always
+        # Named kwargs first, algorithm knobs on top: ``solve_batched`` always
         # materializes the kwarg defaults (broadcast stacks), and an override
         # must beat a default. A genuine user-passed duplicate never reaches
         # here — ``_validate_overrides`` rejects it.
@@ -1505,7 +1523,7 @@ class Problem:
         ):
             if value is not None:
                 updates[_OVERRIDE_KWARG_FIELDS[kwarg]] = value
-        updates.update(overrides or {})
+        updates.update(algorithm or {})
 
         def cast(name, value):
             target = _override_target(state, name)
@@ -1623,7 +1641,7 @@ class Problem:
         x_guess: Optional[jnp.ndarray] = None,
         u_guess: Optional[jnp.ndarray] = None,
         max_iters: Optional[int] = None,
-        overrides: Optional[dict] = None,
+        algorithm: Optional[dict] = None,
     ) -> OptimizationResults:
         """Run the SCP algorithm — JAX-pure.
 
@@ -1658,19 +1676,22 @@ class Problem:
             u_guess: Initial control trajectory guess, shape ``(N, n_controls)``.
                 Replaces ``state.u``; ``None`` uses the default from settings.
             max_iters: SCP iteration cap (scalar). Sugar for
-                ``overrides={"k_max": ...}``; passing both raises. ``None``
-                uses ``algorithm.k_max``. A runtime input on the state
+                ``algorithm={"k_max": ...}``; passing both raises. ``None``
+                uses the configured ``k_max``. A runtime input on the state
                 pytree — no value forces a retrace.
-            overrides: Per-solve values for any :class:`AlgorithmState`
-                field by name — convergence thresholds (``ep_tr`` /
-                ``ep_vb`` / ``ep_vc``), weights (``lam_prox`` / ``lam_vc`` /
-                ``lam_cost``), autotuner hyperparameters, and so on; the
-                ``AlgorithmState`` attribute docs are the reference. Each
-                value either matches the field's shape or is a scalar
-                (broadcast to it). All are runtime inputs: no value forces a
-                retrace. Fields with a dedicated kwarg (``x_guess`` →
-                ``x``, ``x_initial`` → ``x_init_pin``, ...) raise here when
-                both are passed.
+            algorithm: Per-solve algorithm knobs, by the same names as the
+                ``Problem`` constructor's ``algorithm`` dict — convergence
+                thresholds (``ep_tr`` / ``ep_vb`` / ``ep_vc``), weights
+                (``lam_prox`` / ``lam_vc`` / ``lam_cost``), autotuner
+                hyperparameters, and any other :class:`AlgorithmState`
+                field; the ``AlgorithmState`` attribute docs are the
+                reference. Each value either matches the field's shape or
+                is a scalar (broadcast to it). All are runtime inputs: no
+                value forces a retrace. Fields with a dedicated kwarg
+                (``x_guess`` → ``x``, ``x_initial`` → ``x_init_pin``, ...)
+                raise here when both are passed; construction-only keys
+                (``autotuner``, ``t_max``) raise pointing at the
+                constructor.
 
         Returns:
             :class:`OptimizationResults` pytree with the final iterate and
@@ -1683,10 +1704,10 @@ class Problem:
 
         params = parameters if parameters is not None else self._parameters
 
-        overrides = dict(overrides or {})
+        algorithm = dict(algorithm or {})
         self._validate_overrides(
             "solve_jax",
-            overrides,
+            algorithm,
             {
                 "x_initial": x_initial,
                 "x_final": x_final,
@@ -1696,12 +1717,12 @@ class Problem:
             },
         )
         default_state = self._default_state()
-        for name, value in overrides.items():
+        for name, value in algorithm.items():
             declared = tuple(jnp.shape(_override_target(default_state, name)))
             shape = tuple(jnp.shape(value))
             if shape not in (declared, ()):
                 raise ValueError(
-                    f"solve_jax: overrides['{name}'] has shape {shape}, but the "
+                    f"solve_jax: algorithm['{name}'] has shape {shape}, but the "
                     f"field has shape {declared}; pass {declared}, or a scalar to "
                     f"fill it. For a per-element sweep, use solve_batched()."
                 )
@@ -1712,7 +1733,7 @@ class Problem:
             x_guess=x_guess,
             u_guess=u_guess,
             max_iters=max_iters,
-            overrides=overrides,
+            algorithm=algorithm,
         )
         solve_fn = self._get_or_build_solve_loop()
         final_state = solve_fn(initial_state, params)
@@ -1727,7 +1748,7 @@ class Problem:
         x_guess: Optional[jnp.ndarray] = None,
         u_guess: Optional[jnp.ndarray] = None,
         max_iters: Optional[jnp.ndarray] = None,
-        overrides: Optional[dict] = None,
+        algorithm: Optional[dict] = None,
         in_axes: Optional[dict] = None,
     ) -> OptimizationResults:
         """Run ``B`` SCP solves in parallel as one batched XLA program.
@@ -1747,7 +1768,7 @@ class Problem:
                     "gate_center": centers,               # (B, 3) vs declared (3,) -> batched
                     "gate_radius": 0.5,                   # declared shape -> shared
                 },
-                overrides={
+                algorithm={
                     "ep_tr": jnp.logspace(-5, -3, B),     # (B,) vs field () -> tolerance sweep
                     "lam_prox": jnp.linspace(1.0, 4.0, B),  # (B,) fill: one scalar per element
                 },
@@ -1800,26 +1821,27 @@ class Problem:
             u_guess: Control trajectory guess — ``(N, n_u)`` or
                 ``(B, N, n_u)``. ``None`` uses the default from settings.
             max_iters: SCP iteration cap — ``()`` shared or ``(B,)``
-                per-element budgets. Sugar for ``overrides={"k_max": ...}``;
-                passing both raises. ``None`` uses ``algorithm.k_max``. A
-                runtime input: changing it reuses the cached (or exported)
+                per-element budgets. Sugar for ``algorithm={"k_max": ...}``;
+                passing both raises. ``None`` uses the configured ``k_max``.
+                A runtime input: changing it reuses the cached (or exported)
                 batched closure. The batch runs until its slowest element
                 converges or exhausts its own cap; finished elements are
                 frozen, not re-iterated.
-            overrides: Per-solve values for any :class:`AlgorithmState`
-                field by name (see :meth:`solve_jax`); all runtime inputs
-                against one cached artifact. Each value takes the rank rule's
-                two shapes — the field's shape (shared) or ``(B,) +`` it
-                (batched) — plus two **fill** forms for array-shaped fields:
-                a scalar (shared) or ``(B,)`` (one scalar per element, each
-                broadcast to the field shape). Exact shapes win when both
-                parse; ``in_axes={"overrides": {name: 0}}`` forces the
-                per-element fill reading.
+            algorithm: Per-solve algorithm knobs, by the same names as the
+                ``Problem`` constructor's ``algorithm`` dict (see
+                :meth:`solve_jax`); all runtime inputs against one cached
+                artifact. Each value takes the rank rule's two shapes — the
+                field's shape (shared) or ``(B,) +`` it (batched) — plus two
+                **fill** forms for array-shaped fields: a scalar (shared) or
+                ``(B,)`` (one scalar per element, each broadcast to the
+                field shape). Exact shapes win when both parse;
+                ``in_axes={"algorithm": {name: 0}}`` forces the per-element
+                fill reading.
             in_axes: Explicit batching override in ``jax.vmap``'s vocabulary,
                 including its prefix semantics: a bare ``0`` batches every
                 passed input; a dict keyed by argument name takes leaves
                 ``0`` (batched) or ``None`` (shared), where ``"parameters"``
-                and ``"overrides"`` accept either a prefix (``0`` / ``None``,
+                and ``"algorithm"`` accept either a prefix (``0`` / ``None``,
                 applied to every passed key) or a per-key dict, e.g.
                 ``in_axes={"parameters": {"gate_center": 0}}``. Partial
                 specs are fine — unlisted entries use the rank rule. Unlike
@@ -1844,10 +1866,10 @@ class Problem:
                 f"declared parameters are {sorted(self._parameters)}."
             )
 
-        overrides = dict(overrides or {})
+        algorithm = dict(algorithm or {})
         self._validate_overrides(
             "solve_batched",
-            overrides,
+            algorithm,
             {
                 "x_initial": x_initial,
                 "x_final": x_final,
@@ -1870,16 +1892,16 @@ class Problem:
         }
         for key, value in user_params.items():
             entries[f"parameters.{key}"] = (value, tuple(np.shape(self._parameters[key])))
-        for name, value in overrides.items():
+        for name, value in algorithm.items():
             declared = tuple(jnp.shape(_override_target(_default, name)))
-            entries[f"overrides.{name}"] = (value, declared)
+            entries[f"algorithm.{name}"] = (value, declared)
 
         flat_in_axes = _flatten_in_axes(in_axes, entries)
 
         B, axes, fills = _resolve_batch_spec(
             entries,
             flat_in_axes,
-            fill={f"overrides.{name}" for name in overrides},
+            fill={f"algorithm.{name}" for name in algorithm},
         )
 
         # Shared state-side inputs — and the defaults for omitted ones —
@@ -1899,12 +1921,12 @@ class Problem:
                 arr = jnp.broadcast_to(arr, (B,) + arr.shape)
             stacks[name] = arr
 
-        # Overrides normalize to (B,) + field shape: fills first broadcast
-        # their scalars up to the field shape, shared entries then gain the
-        # leading batch axis.
-        override_stacks = {}
-        for name, value in overrides.items():
-            entry = f"overrides.{name}"
+        # Algorithm knobs normalize to (B,) + field shape: fills first
+        # broadcast their scalars up to the field shape, shared entries then
+        # gain the leading batch axis.
+        algorithm_stacks = {}
+        for name, value in algorithm.items():
+            entry = f"algorithm.{name}"
             field_shape = entries[entry][1]
             arr = jnp.asarray(value)
             if entry in fills and axes[entry] == 0:
@@ -1915,7 +1937,7 @@ class Problem:
                 arr = jnp.broadcast_to(arr, field_shape)
             if axes[entry] is None:
                 arr = jnp.broadcast_to(arr, (B,) + arr.shape)
-            override_stacks[name] = arr
+            algorithm_stacks[name] = arr
 
         states = jax.vmap(self._resolve_initial_state)(
             stacks["x_initial"],
@@ -1923,7 +1945,7 @@ class Problem:
             stacks["x_guess"],
             stacks["u_guess"],
             stacks["max_iters"],
-            override_stacks,
+            algorithm_stacks,
         )
 
         params_for_solve = dict(self._parameters, **user_params)

--- a/openscvx/problem.py
+++ b/openscvx/problem.py
@@ -126,8 +126,7 @@ def _resolve_batch_spec(
             )
         if ax == 0 and entries[name][0] is None:
             raise ValueError(
-                f"solve_batched: in_axes marks '{name}' as batched, but no value "
-                f"was passed for it."
+                f"solve_batched: in_axes marks '{name}' as batched, but no value was passed for it."
             )
 
     axes: Dict[str, Optional[int]] = {}

--- a/openscvx/utils/caching.py
+++ b/openscvx/utils/caching.py
@@ -123,7 +123,7 @@ def get_solve_batched_cache_path(
     solver: Any,
     discretizer: Any,
     B: int,
-    k_max: int,
+    param_axes: Dict[str, Optional[int]],
     cache_dir: Optional[Path] = None,
 ) -> Path:
     """Cache path for the exported :meth:`Problem.solve_batched` artifact.
@@ -136,17 +136,21 @@ def get_solve_batched_cache_path(
     types, parameter shapes) with everything *additionally* baked into the loop:
 
     * the convex backend class and its ``solver_args`` (via ``solver._hash_into``),
-    * the algorithm + autotuner + convergence thresholds + initial penalty
-      weights (via ``algorithm._hash_into``),
+    * the algorithm + autotuner + initial penalty weights (via
+      ``algorithm._hash_into``),
     * the discretizer scheme (via ``discretizer._hash_into``),
     * the state/control scaling matrices ``inv_S_x`` / ``inv_S_u`` (settings-
       derived, not covered by any subsystem hash),
     * the fixed batch size ``B`` (the artifact is exported at one ``B``),
-    * the resolved iteration cap ``k_max`` — the *actual* loop bound baked into
-      the exported ``lax.while_loop``, which a ``solve_batched(max_iters=...)``
-      override can change independently of ``algorithm.k_max``, and
+    * the per-parameter batch axes ``param_axes`` — the shared/batched split is
+      baked into the ``jax.vmap`` program, so an artifact traced for one split
+      must never be loaded for another, and
     * the JAX version (exported artifacts are not guaranteed to survive an
       incompatible jax bump — the worst failure mode is deserializing one).
+
+    The convergence thresholds and iteration cap are deliberately *absent*:
+    they ride the ``AlgorithmState`` pytree as runtime inputs, so one artifact
+    serves every tolerance and ``max_iters`` setting.
 
     Each runtime object contributes through its own ``_hash_into`` — the same
     two-tier split the symbolic layer uses — so a new field that changes the
@@ -160,8 +164,8 @@ def get_solve_batched_cache_path(
         solver: The convex subproblem backend.
         discretizer: The dynamics discretizer.
         B: Fixed batch size the artifact is exported at.
-        k_max: Resolved SCP iteration cap baked into the exported loop
-            (``max_iters`` if the caller overrode it, else ``algorithm.k_max``).
+        param_axes: Per-parameter ``{name: 0 | None}`` vmap axes the loop was
+            built with (``0`` = batched, ``None`` = shared).
         cache_dir: Override for the cache directory. ``None`` uses
             :func:`openscvx.get_cache_dir`.
 
@@ -178,7 +182,7 @@ def get_solve_batched_cache_path(
     hash_value_into(hasher, settings.sim.inv_S_x)
     hash_value_into(hasher, settings.sim.inv_S_u)
     hasher.update(f"B:{B}".encode())
-    hasher.update(f"k_max:{k_max}".encode())
+    hasher.update(f"param_axes:{tuple(sorted(param_axes.items()))}".encode())
     hasher.update(f"jax:{jax.__version__}".encode())
 
     final_hash = hasher.hexdigest()[:32]

--- a/tests/algorithms/autotuner/test_update_weights_jit.py
+++ b/tests/algorithms/autotuner/test_update_weights_jit.py
@@ -17,12 +17,20 @@ from openscvx.algorithms import (
     AlgorithmState,
     AugmentedLagrangian,
     ConstantProximalWeight,
+    HyperParams,
     RampProximalWeight,
 )
 from openscvx.algorithms.base import CandidateIterate
 from openscvx.algorithms.weights import Weights
 from openscvx.config import Config, DevConfig, PropagationConfig, SimConfig
 from openscvx.lowered.jax_constraints import LoweredJaxConstraints
+
+
+class _Hyper(HyperParams):
+    """The one knob every autotuner under test reads from ``state.hyper``."""
+
+    lam_cost_drop: int = -1
+
 
 # -- Tiny problem fixture ---------------------------------------------------
 
@@ -82,7 +90,7 @@ def state(settings, weights):
         ep_vb=1e-4,
         ep_vc=1e-8,
         k_max=200,
-        lam_cost_drop=-1,
+        hyper=_Hyper(),
     )
     return base.replace(
         x_prop=jnp.asarray(np.array([[0.1, 0.1], [0.9, 0.9]])),
@@ -110,16 +118,19 @@ def empty_constraints():
 
 
 def _states_match(a: AlgorithmState, b: AlgorithmState) -> None:
-    for name in AlgorithmState._FIELDS:
-        if name == "_FIELDS":
-            continue
-        np.testing.assert_allclose(
-            np.asarray(getattr(a, name)),
-            np.asarray(getattr(b, name)),
-            err_msg=f"field {name!r} diverged between jit'd and bare call",
+    # Leaf-wise over the pytree (the HyperParams-valued ``hyper`` field
+    # recurses); tree_map also asserts the two treedefs agree.
+    jax.tree_util.tree_map_with_path(
+        lambda path, leaf_a, leaf_b: np.testing.assert_allclose(
+            np.asarray(leaf_a),
+            np.asarray(leaf_b),
+            err_msg=f"leaf {jax.tree_util.keystr(path)} diverged between jit'd and bare call",
             rtol=1e-7,
             atol=1e-7,
-        )
+        ),
+        a,
+        b,
+    )
 
 
 def _candidate_to_dict(c: CandidateIterate) -> dict:

--- a/tests/algorithms/autotuner/test_update_weights_jit.py
+++ b/tests/algorithms/autotuner/test_update_weights_jit.py
@@ -75,7 +75,15 @@ def state(settings, weights):
     # Pre-populate x_prop / x_prop_plus so the autotuner's "previous iterate"
     # branch (k > 1) has finite values to compare against. The actual numbers
     # are arbitrary — we only check jit vs. bare equivalence.
-    base = AlgorithmState.from_settings(settings, weights)
+    base = AlgorithmState.from_settings(
+        settings,
+        weights,
+        ep_tr=1e-4,
+        ep_vb=1e-4,
+        ep_vc=1e-8,
+        k_max=200,
+        lam_cost_drop=-1,
+    )
     return base.replace(
         x_prop=jnp.asarray(np.array([[0.1, 0.1], [0.9, 0.9]])),
         x_prop_plus=jnp.asarray(np.array([[0.0, 0.0], [0.1, 0.1], [0.9, 0.9]])),

--- a/tests/algorithms/test_algorithm_state_pytree.py
+++ b/tests/algorithms/test_algorithm_state_pytree.py
@@ -52,7 +52,15 @@ def state():
     weights = Weights(lam_prox=1.0, lam_vc=1.0, lam_vb=1.0, lam_cost=1.0)
     weights.lam_vb_nodal = np.ones((3, 1))
     weights.lam_vb_cross = np.ones(1)
-    return AlgorithmState.from_settings(settings, weights)
+    return AlgorithmState.from_settings(
+        settings,
+        weights,
+        ep_tr=1e-4,
+        ep_vb=1e-4,
+        ep_vc=1e-8,
+        k_max=200,
+        lam_cost_drop=-1,
+    )
 
 
 # === pytree registration ===================================================

--- a/tests/algorithms/test_algorithm_state_pytree.py
+++ b/tests/algorithms/test_algorithm_state_pytree.py
@@ -11,9 +11,15 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from openscvx.algorithms import AdaptiveStateCode, AlgorithmState
+from openscvx.algorithms import AdaptiveStateCode, AlgorithmState, HyperParams
 from openscvx.algorithms.weights import Weights
 from openscvx.config import Config, DevConfig, PropagationConfig, SimConfig
+
+
+class _Hyper(HyperParams):
+    """One declared knob so the ``hyper`` field contributes a pytree leaf."""
+
+    lam_cost_drop: int = -1
 
 
 class _DummyState:
@@ -59,7 +65,7 @@ def state():
         ep_vb=1e-4,
         ep_vc=1e-8,
         k_max=200,
-        lam_cost_drop=-1,
+        hyper=_Hyper(),
     )
 
 

--- a/tests/algorithms/test_iteration_fn_jit.py
+++ b/tests/algorithms/test_iteration_fn_jit.py
@@ -30,14 +30,20 @@ def test_jit_matches_bare():
 
     assert isinstance(jit_state, AlgorithmState)
     assert isinstance(jit_diag, IterationDiagnostics)
-    for field in AlgorithmState._FIELDS:
-        np.testing.assert_allclose(
-            np.asarray(getattr(jit_state, field)),
-            np.asarray(getattr(bare_state, field)),
+    # Leaf-wise over the pytree (the HyperParams-valued ``hyper`` field
+    # recurses); tree_map also asserts the two treedefs agree.
+    jax.tree_util.tree_map_with_path(
+        lambda path, jit_leaf, bare_leaf: np.testing.assert_allclose(
+            np.asarray(jit_leaf),
+            np.asarray(bare_leaf),
             atol=1e-8,
             rtol=1e-8,
             equal_nan=True,
-        )
+            err_msg=f"leaf {jax.tree_util.keystr(path)} diverged between jit'd and bare call",
+        ),
+        jit_state,
+        bare_state,
+    )
     for field in ("cost", "J_lin", "V", "W", "TR", "VC"):
         np.testing.assert_allclose(
             np.asarray(getattr(jit_diag, field)),

--- a/tests/algorithms/test_make_solve_loop.py
+++ b/tests/algorithms/test_make_solve_loop.py
@@ -29,11 +29,13 @@ def test_make_solve_loop_matches_python_solve():
     solve_k = int(prob.state.k)
 
     # lax.while_loop over the fused body, from the same fresh initial iterate.
+    # The convergence thresholds and iteration cap ride the state pytree
+    # (snapshotted from the algorithm at reset()), so the loop takes no
+    # constants.
     prob.reset()
     state0 = prob.state
     iteration_fn = build_iteration_fn(prob)
-    algo = prob.algorithm
-    solve_loop = make_solve_loop(iteration_fn, algo.ep_tr, algo.ep_vb, algo.ep_vc, algo.k_max)
+    solve_loop = make_solve_loop(iteration_fn)
     loop_state = solve_loop(state0, prob._parameters)
 
     assert int(loop_state.k) == solve_k

--- a/tests/solvers/_iteration_callback_helpers.py
+++ b/tests/solvers/_iteration_callback_helpers.py
@@ -30,6 +30,7 @@ def build_brachistochrone(
     n: int = 4,
     k_max: int = 1,
     constraint_style: str = "ctcs",
+    autotuner="ConstantProximalWeight",
 ):
     """Build the brachistochrone problem at small ``N`` for callback tests.
 
@@ -46,6 +47,8 @@ def build_brachistochrone(
         constraint_style: ``"ctcs"`` (CTCS box rows; the default) or
             ``"nodal"`` (plain nodal inequalities; exercises the
             nodal-constraint assembly block that's dormant under CTCS-only).
+        autotuner: Autotuner name or instance, passed straight through to the
+            algorithm config (instances let tests exercise custom autotuners).
     """
     import openscvx as ox
 
@@ -106,7 +109,7 @@ def build_brachistochrone(
         N=n,
         float_dtype="float64",
         algorithm={
-            "autotuner": "ConstantProximalWeight",
+            "autotuner": autotuner,
             "lam_prox": 1e0,
             "lam_cost": 6e-1,
             "k_max": k_max,

--- a/tests/test_autotuning.py
+++ b/tests/test_autotuning.py
@@ -122,7 +122,15 @@ def weights():
 @pytest.fixture
 def algorithm_state(settings, weights):
     """Initial :class:`AlgorithmState` for the 3-node test problem."""
-    return AlgorithmState.from_settings(settings, weights)
+    return AlgorithmState.from_settings(
+        settings,
+        weights,
+        ep_tr=1e-4,
+        ep_vb=1e-4,
+        ep_vc=1e-8,
+        k_max=200,
+        lam_cost_drop=-1,
+    )
 
 
 def _candidate_x_prop_plus(N: int = 3, n_x: int = 2) -> np.ndarray:

--- a/tests/test_autotuning.py
+++ b/tests/test_autotuning.py
@@ -6,6 +6,9 @@ The autotuners now return a new :class:`AlgorithmState` pytree, so tests here
 assert on the *returned* state rather than mutation of an input.
 """
 
+import dataclasses
+
+import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
@@ -129,7 +132,7 @@ def algorithm_state(settings, weights):
         ep_vb=1e-4,
         ep_vc=1e-8,
         k_max=200,
-        lam_cost_drop=-1,
+        hyper=AugmentedLagrangian().hyper,
     )
 
 
@@ -568,11 +571,16 @@ def test_update_scp_weights_initial_iteration(
 
 
 def test_update_scp_weights_cost_drop(settings, algorithm_state, empty_nodal_constraints, weights):
-    """Cost relaxation kicks in once ``state.k > lam_cost_drop``."""
+    """Cost relaxation kicks in once ``state.k > hyper.lam_cost_drop``."""
     autotuner = AugmentedLagrangian(lam_cost_drop=3, lam_cost_relax=0.8)
 
     # k=4 > lam_cost_drop=3, so lam_cost should be scaled by lam_cost_relax.
-    state = _seeded_state_for_k2(algorithm_state).replace(k=jnp.asarray(4, dtype=jnp.int32))
+    # The declared knob is read from state.hyper, so seed it from the
+    # autotuner's hyper container (in production from_settings does this).
+    state = _seeded_state_for_k2(algorithm_state).replace(
+        k=jnp.asarray(4, dtype=jnp.int32),
+        hyper=jax.tree_util.tree_map(jnp.asarray, autotuner.hyper),
+    )
     lam_cost_prev = np.asarray(state.lam_cost)
 
     candidate = CandidateIterate()
@@ -846,26 +854,30 @@ def test_algorithm_autotuner_configurable():
     algorithm = PenalizedTrustRegion()
     autotuner = algorithm.autotuner
     assert isinstance(autotuner, AugmentedLagrangian)
-    assert hasattr(autotuner, "rho_init")
-    assert hasattr(autotuner, "rho_max")
     assert hasattr(autotuner, "lam_prox_min")
     assert hasattr(autotuner, "lam_prox_max")
     assert hasattr(autotuner, "lam_vc_max")
-    assert hasattr(autotuner, "lam_cost_drop")
     assert hasattr(autotuner, "lam_cost_relax")
-    autotuner.rho_max = 1e7
-    assert autotuner.rho_max == 1e7
+    # Declared hyperparameters live on the frozen HyperParams container (and
+    # ride state.hyper); updates go through dataclasses.replace.
+    assert {f.name for f in dataclasses.fields(autotuner.hyper)} == {
+        "rho_init",
+        "rho_max",
+        "lam_cost_drop",
+    }
+    autotuner.hyper = dataclasses.replace(autotuner.hyper, rho_max=1e7)
+    assert autotuner.hyper.rho_max == 1e7
 
 
 def test_custom_autotuner_instance():
     """Custom autotuner instance can be passed to PenalizedTrustRegion."""
     custom_autotuner = AugmentedLagrangian()
-    custom_autotuner.rho_max = 1e7
+    custom_autotuner.hyper = dataclasses.replace(custom_autotuner.hyper, rho_max=1e7)
     custom_autotuner.lam_prox_max = 1e6
     custom_autotuner.lam_vc_max = 1e6
     algorithm = PenalizedTrustRegion(autotuner=custom_autotuner)
     assert algorithm.autotuner is custom_autotuner
-    assert algorithm.autotuner.rho_max == 1e7
+    assert algorithm.autotuner.hyper.rho_max == 1e7
     assert algorithm.autotuner.lam_prox_max == 1e6
     assert algorithm.autotuner.lam_vc_max == 1e6
 
@@ -876,14 +888,14 @@ def test_augmented_lagrangian_exported():
 
     # Should be able to import directly
     auto_tuner = ox.AugmentedLagrangian()
-    assert hasattr(auto_tuner, "rho_max")
+    assert hasattr(auto_tuner.hyper, "rho_max")
     assert hasattr(auto_tuner, "lam_prox_max")
     assert hasattr(auto_tuner, "lam_vc_max")
 
     # Should be able to modify parameters
-    auto_tuner.rho_max = 1e7
+    auto_tuner.hyper = dataclasses.replace(auto_tuner.hyper, rho_max=1e7)
     auto_tuner.lam_prox_max = 1e6
-    assert auto_tuner.rho_max == 1e7
+    assert auto_tuner.hyper.rho_max == 1e7
     assert auto_tuner.lam_prox_max == 1e6
 
 
@@ -1029,7 +1041,8 @@ def test_constant_proximal_weight_uses_relaxed_cost_after_cost_drop(
     """After cost_drop, ConstantProximalWeight scales lam_cost by lam_cost_relax."""
     autotuner = ConstantProximalWeight(lam_cost_drop=5, lam_cost_relax=0.9)
     state = algorithm_state.replace(
-        k=jnp.asarray(autotuner.lam_cost_drop + 1, dtype=jnp.int32),
+        k=jnp.asarray(autotuner.hyper.lam_cost_drop + 1, dtype=jnp.int32),
+        hyper=jax.tree_util.tree_map(jnp.asarray, autotuner.hyper),
     )
     initial_lam_cost = np.asarray(state.lam_cost)
 

--- a/tests/test_solve_batched_brachistochrone.py
+++ b/tests/test_solve_batched_brachistochrone.py
@@ -15,6 +15,12 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
+from openscvx.algorithms import (
+    AdaptiveStateCode,
+    AugmentedLagrangian,
+    AutotuningBase,
+    HyperParams,
+)
 from tests.solvers._iteration_callback_helpers import build_brachistochrone
 
 # === Boundary-pin batching ===
@@ -187,17 +193,155 @@ def test_solve_batched_ep_tr_sweep_matches_solve_jax():
     prob.initialize()
 
     # Loose-to-tight trust-region tolerances: the loose element converges
-    # iterations earlier, so the per-element final iterates differ.
+    # iterations earlier, so the per-element final iterates differ. ep_tr is
+    # a scalar state field, so (B,) vs () -> batched through `overrides`.
     tolerances = jnp.array([1e-1, 1e-5])
-    batched = prob.solve_batched(ep_tr=tolerances)
+    batched = prob.solve_batched(overrides={"ep_tr": tolerances})
 
     for i, tol in enumerate(np.asarray(tolerances)):
-        ref = prob.solve_jax(ep_tr=float(tol))
+        ref = prob.solve_jax(overrides={"ep_tr": float(tol)})
         np.testing.assert_allclose(
             np.asarray(batched.x[i]), np.asarray(ref.x), atol=1e-5, rtol=1e-5
         )
 
     assert not np.allclose(np.asarray(batched.x[0]), np.asarray(batched.x[1]), atol=1e-8)
+
+    jax.clear_caches()
+
+
+def test_solve_batched_lam_prox_fill_sweep_matches_solve_jax():
+    pytest.importorskip("qpax")
+
+    prob = build_brachistochrone("qpax", n=8, k_max=20)
+    prob.initialize()
+
+    # lam_prox is an (N, n_x + n_u) state field; a (B,) vector is the
+    # batched *fill* form — one scalar per element, each broadcast to the
+    # field shape. Different trust-region weights walk different iterate
+    # paths, so the elements genuinely diverge.
+    weights = jnp.array([0.5, 1.0, 4.0])
+    batched = prob.solve_batched(overrides={"lam_prox": weights})
+    assert batched.x.shape[0] == weights.shape[0]
+
+    for i, w in enumerate(np.asarray(weights)):
+        # solve_jax takes the scalar (shared-fill) form of the same override.
+        ref = prob.solve_jax(overrides={"lam_prox": float(w)})
+        np.testing.assert_allclose(
+            np.asarray(batched.x[i]), np.asarray(ref.x), atol=1e-5, rtol=1e-5
+        )
+        np.testing.assert_allclose(
+            np.asarray(batched.u[i]), np.asarray(ref.u), atol=1e-5, rtol=1e-5
+        )
+
+    assert not np.allclose(np.asarray(batched.x[0]), np.asarray(batched.x[2]), atol=1e-8)
+
+    jax.clear_caches()
+
+
+def test_solve_batched_overrides_k_max_matches_max_iters_kwarg():
+    pytest.importorskip("qpax")
+
+    prob = build_brachistochrone("qpax", n=8, k_max=20)
+    prob.initialize()
+
+    # k_max has a dedicated kwarg (max_iters) whose default stack
+    # solve_batched always materializes; the override spelling must beat
+    # that default, not silently lose to it.
+    budgets = jnp.array([2, 8])
+    via_kwarg = prob.solve_batched(max_iters=budgets)
+    via_override = prob.solve_batched(overrides={"k_max": budgets})
+
+    np.testing.assert_allclose(
+        np.asarray(via_override.x), np.asarray(via_kwarg.x), atol=1e-9, rtol=0
+    )
+    # The budgets actually bind — this is not two default-k_max solves agreeing.
+    assert not np.allclose(np.asarray(via_kwarg.x[0]), np.asarray(via_kwarg.x[1]), atol=1e-8)
+
+    jax.clear_caches()
+
+
+# === Autotuner-declared hyperparameters (state.hyper) ===
+
+
+class _ProxRampHyper(HyperParams):
+    """The toy autotuner's one declared knob."""
+
+    prox_scale: float = 1.0
+
+
+class _ProxRampAutotuner(AutotuningBase):
+    """Toy user autotuner: one declared knob scaling ``lam_prox`` per iteration.
+
+    Defined entirely inside the test — the point is that declaring
+    ``prox_scale`` on a :class:`HyperParams` subclass and reading it from
+    ``state.hyper`` is the *whole* integration: overrides and batched sweeps
+    work with zero library edits.
+    """
+
+    JIT_UPDATE_WEIGHTS = False
+
+    def __init__(self, prox_scale: float = 1.0):
+        self.hyper = _ProxRampHyper(prox_scale=prox_scale)
+
+    def update_weights(self, state, candidate, nodal_constraints, settings, params):
+        return state.replace(
+            x=candidate.x,
+            u=candidate.u,
+            x_prop=candidate.x_prop,
+            x_prop_plus=candidate.x_prop_plus,
+            lam_prox=state.lam_prox * state.hyper.prox_scale,
+            adaptive_state_code=jnp.asarray(
+                int(AdaptiveStateCode.ACCEPT_CONSTANT), dtype=jnp.int32
+            ),
+        )
+
+
+def test_user_autotuner_knob_sweeps_through_solve_batched():
+    pytest.importorskip("qpax")
+
+    prob = build_brachistochrone("qpax", n=8, k_max=10, autotuner=_ProxRampAutotuner())
+    prob.initialize()
+
+    # The declared knob is a valid override name purely by declaration; a
+    # (B,) vector sweeps it per element and each element matches the
+    # corresponding single solve.
+    scales = jnp.array([0.8, 1.0, 1.4])
+    batched = prob.solve_batched(overrides={"prox_scale": scales})
+    assert batched.x.shape[0] == scales.shape[0]
+
+    for i, s in enumerate(np.asarray(scales)):
+        ref = prob.solve_jax(overrides={"prox_scale": float(s)})
+        np.testing.assert_allclose(
+            np.asarray(batched.x[i]), np.asarray(ref.x), atol=1e-5, rtol=1e-5
+        )
+
+    # The knob actually steers the solve: different ramps, different iterates.
+    assert not np.allclose(np.asarray(batched.x[0]), np.asarray(batched.x[2]), atol=1e-8)
+
+    jax.clear_caches()
+
+
+def test_augmented_lagrangian_declared_knobs_are_overridable():
+    pytest.importorskip("qpax")
+
+    # AugmentedLagrangian declares rho_init / rho_max / lam_cost_drop on its
+    # HyperParams container, so the override channel accepts them by name. rho_init
+    # and rho_max currently have no read sites in update_weights (vestigial
+    # knobs), so the sweep exercises the plumbing — accepted name, batched
+    # state, per-element agreement — with results identical to the baseline.
+    prob = build_brachistochrone("qpax", n=8, k_max=6, autotuner=AugmentedLagrangian())
+    prob.initialize()
+
+    base = prob.solve_jax()
+    single = prob.solve_jax(overrides={"rho_init": 5.0, "rho_max": 1e3})
+    np.testing.assert_allclose(np.asarray(single.x), np.asarray(base.x), atol=1e-12)
+
+    batched = prob.solve_batched(overrides={"rho_init": jnp.array([1.0, 5.0])})
+    assert batched.x.shape[0] == 2
+    for i in range(2):
+        np.testing.assert_allclose(
+            np.asarray(batched.x[i]), np.asarray(base.x), atol=1e-5, rtol=1e-5
+        )
 
     jax.clear_caches()
 
@@ -212,6 +356,31 @@ def test_solve_batched_unknown_parameter_key_raises():
         ValueError, match=r"unknown parameter.*'gravty'.*declared parameters.*'gravity'"
     ):
         prob.solve_batched(parameters={"gravty": jnp.zeros((2, 1))})
+
+
+def test_overrides_unknown_name_lists_valid_names():
+    prob = build_brachistochrone("cvxpy", n=4, k_max=1)
+    prob.initialize()
+    with pytest.raises(ValueError, match=r"unknown override name.*'ep_trr'.*'ep_tr'"):
+        prob.solve_batched(overrides={"ep_trr": jnp.zeros(2)})
+    with pytest.raises(ValueError, match=r"solve_jax: unknown override name.*'ep_trr'"):
+        prob.solve_jax(overrides={"ep_trr": 1e-4})
+
+
+def test_overrides_kwarg_collision_names_the_kwarg():
+    prob = build_brachistochrone("cvxpy", n=4, k_max=1)
+    prob.initialize()
+    with pytest.raises(ValueError, match=r"overrides\['k_max'\].*max_iters kwarg"):
+        prob.solve_batched(max_iters=jnp.array([2, 3]), overrides={"k_max": 5})
+    with pytest.raises(ValueError, match=r"overrides\['x'\].*x_guess kwarg"):
+        prob.solve_jax(x_guess=prob.state.x, overrides={"x": prob.state.x})
+
+
+def test_solve_jax_override_shape_mismatch_points_at_solve_batched():
+    prob = build_brachistochrone("cvxpy", n=4, k_max=1)
+    prob.initialize()
+    with pytest.raises(ValueError, match=r"overrides\['ep_tr'\] has shape \(2,\).*solve_batched"):
+        prob.solve_jax(overrides={"ep_tr": jnp.zeros(2)})
 
 
 def test_solve_batched_before_initialize_raises():

--- a/tests/test_solve_batched_brachistochrone.py
+++ b/tests/test_solve_batched_brachistochrone.py
@@ -147,6 +147,59 @@ def test_solve_batched_mixed_shared_and_batched_parameters():
     jax.clear_caches()
 
 
+# === Hyperparameter sweeps ===
+
+
+def test_solve_batched_max_iters_sweep_matches_solve_jax():
+    pytest.importorskip("qpax")
+
+    prob = build_brachistochrone("qpax", n=8, k_max=20)
+    prob.initialize()
+
+    # Per-element iteration budgets, all below the convergence point so the
+    # cap binds and each element stops at a different iterate. (B,) vs
+    # declared () -> batched; everything else is the shared default.
+    budgets = jnp.array([2, 4, 8])
+    batched = prob.solve_batched(max_iters=budgets)
+    assert batched.x.shape[0] == budgets.shape[0]
+
+    for i, budget in enumerate(np.asarray(budgets)):
+        ref = prob.solve_jax(max_iters=int(budget))
+        np.testing.assert_allclose(
+            np.asarray(batched.x[i]), np.asarray(ref.x), atol=1e-5, rtol=1e-5
+        )
+        np.testing.assert_allclose(
+            np.asarray(batched.u[i]), np.asarray(ref.u), atol=1e-5, rtol=1e-5
+        )
+
+    # The budgets actually bind: different caps end at different iterates.
+    assert not np.allclose(np.asarray(batched.x[0]), np.asarray(batched.x[2]), atol=1e-8)
+
+    jax.clear_caches()
+
+
+def test_solve_batched_ep_tr_sweep_matches_solve_jax():
+    pytest.importorskip("qpax")
+
+    prob = build_brachistochrone("qpax", n=8, k_max=20)
+    prob.initialize()
+
+    # Loose-to-tight trust-region tolerances: the loose element converges
+    # iterations earlier, so the per-element final iterates differ.
+    tolerances = jnp.array([1e-1, 1e-5])
+    batched = prob.solve_batched(ep_tr=tolerances)
+
+    for i, tol in enumerate(np.asarray(tolerances)):
+        ref = prob.solve_jax(ep_tr=float(tol))
+        np.testing.assert_allclose(
+            np.asarray(batched.x[i]), np.asarray(ref.x), atol=1e-5, rtol=1e-5
+        )
+
+    assert not np.allclose(np.asarray(batched.x[0]), np.asarray(batched.x[1]), atol=1e-8)
+
+    jax.clear_caches()
+
+
 # === Teaching errors ===
 
 

--- a/tests/test_solve_batched_brachistochrone.py
+++ b/tests/test_solve_batched_brachistochrone.py
@@ -1,12 +1,12 @@
-"""``Problem.solve_batched`` matches ``jax.vmap(solve_jax)`` element-wise.
+"""``Problem.solve_batched`` matches per-element ``solve_jax`` solves.
 
 ``solve_batched`` owns the batch axis internally (``jax.vmap`` applied inside
 the method) where :func:`jax.vmap` over :meth:`Problem.solve_jax` leaves it to
 the caller. With no export wired up (Phase 1) the two are just different
-spellings of the same batched solve, so over a stack of trajectory guesses
-each batch element must agree with the corresponding ``jax.vmap(solve_jax)``
-result. CVXPy runs the ``B`` solves sequentially (host CVXPy isn't
-thread-safe); QPAX runs them in parallel under vmap. Parallels
+spellings of the same batched solve, so over a stack of boundary pins or
+parameter values each batch element must agree with the corresponding
+``solve_jax`` result. CVXPy runs the ``B`` solves sequentially (host CVXPy
+isn't thread-safe); QPAX runs them in parallel under vmap. Parallels
 ``tests/test_solve_jax_vmap_brachistochrone.py``.
 """
 
@@ -17,40 +17,144 @@ import pytest
 
 from tests.solvers._iteration_callback_helpers import build_brachistochrone
 
+# === Boundary-pin batching ===
+
 
 @pytest.mark.parametrize("backend", ["cvxpy", "qpax"])
-def test_solve_batched_matches_vmap_solve_jax(backend):
+def test_solve_batched_matches_solve_jax_over_x_initial(backend):
     if backend == "qpax":
         pytest.importorskip("qpax")
 
     prob = build_brachistochrone(backend, n=8, k_max=20)
     prob.initialize()
 
-    base_x = prob.state.x
-
-    # Stack four guesses by varying the x-coordinate of position (component 0).
+    # Stack four initial pins by varying the starting x-coordinate (component
+    # 0 of the unified state vector).
+    default_pin = prob.state.x_init_pin
     shifts = jnp.array([0.0, 0.3, -0.3, 0.6])
-    x_guess_stack = jnp.stack([base_x.at[0, 0].set(base_x[0, 0] + s) for s in shifts])
+    x_initial_stack = jnp.stack([default_pin.at[0].set(default_pin[0] + s) for s in shifts])
 
     # Per-element reference.
     bare_xs = []
     bare_us = []
-    for i in range(x_guess_stack.shape[0]):
-        res = prob.solve_jax(x_guess=x_guess_stack[i])
+    for i in range(x_initial_stack.shape[0]):
+        res = prob.solve_jax(x_initial=x_initial_stack[i])
         bare_xs.append(np.asarray(res.x))
         bare_us.append(np.asarray(res.u))
     bare_xs = np.stack(bare_xs)
     bare_us = np.stack(bare_us)
 
-    # Internal-vmap batched solve.
-    batched = prob.solve_batched(x_guess=x_guess_stack)
+    # Internal-vmap batched solve: x_initial is (B, n_x) -> batched, the
+    # terminal pin is omitted -> shared default, broadcast automatically.
+    batched = prob.solve_batched(x_initial=x_initial_stack)
 
-    assert batched.x.shape == bare_xs.shape == (x_guess_stack.shape[0], 8, base_x.shape[1])
+    assert batched.x.shape == bare_xs.shape == (x_initial_stack.shape[0], 8, bare_xs.shape[2])
     np.testing.assert_allclose(np.asarray(batched.x), bare_xs, atol=1e-5, rtol=1e-5)
     np.testing.assert_allclose(np.asarray(batched.u), bare_us, atol=1e-5, rtol=1e-5)
-    assert batched.converged.shape == (x_guess_stack.shape[0],)
+    assert batched.converged.shape == (x_initial_stack.shape[0],)
 
     jax.clear_caches()
+
+
+# === Mixed shared/batched parameters ===
+
+
+def _build_brachistochrone_with_params(backend: str, n: int = 8, k_max: int = 20):
+    """Brachistochrone variant whose dynamics read two ``ox.Parameter``s.
+
+    ``gravity`` is the sweep target (batched in the test); ``gain`` scales the
+    position kinematics and stays shared, exercising the mixed per-key vmap
+    axes that ``solve_batched`` resolves from declared parameter shapes.
+    """
+    import openscvx as ox
+    from openscvx import Problem
+
+    position = ox.State("position", shape=(2,))
+    position.max = np.array([10.0, 10.0])
+    position.min = np.array([0.0, 0.0])
+    position.initial = np.array([0.0, 10.0])
+    position.final = [10.0, 5.0]
+
+    velocity = ox.State("velocity", shape=(1,))
+    velocity.max = np.array([10.0])
+    velocity.min = np.array([0.0])
+    velocity.initial = np.array([0.0])
+    velocity.final = [("free", 10.0)]
+
+    theta = ox.Control("theta", shape=(1,))
+    theta.max = np.array([100.5 * jnp.pi / 180])
+    theta.min = np.array([0.0])
+    theta.guess = np.linspace(5 * jnp.pi / 180, 100.5 * jnp.pi / 180, n).reshape(-1, 1)
+
+    gravity = ox.Parameter("gravity", shape=(1,), value=np.array([9.81]))
+    gain = ox.Parameter("gain", shape=(1,), value=np.array([1.0]))
+
+    dynamics = {
+        "position": ox.Concat(
+            gain[0] * velocity[0] * ox.Sin(theta[0]),
+            -gain[0] * velocity[0] * ox.Cos(theta[0]),
+        ),
+        "velocity": gravity[0] * ox.Cos(theta[0]),
+    }
+
+    constraint_exprs = []
+    for state in [position, velocity]:
+        constraint_exprs.extend([ox.ctcs(state <= state.max), ox.ctcs(state.min <= state)])
+
+    time = ox.Time(initial=0.0, final=("minimize", 2.0), min=0.0, max=2.0, uniform_time_grid=True)
+
+    prob = Problem(
+        dynamics=dynamics,
+        states=[position, velocity],
+        controls=[theta],
+        time=time,
+        constraints=constraint_exprs,
+        N=n,
+        float_dtype="float64",
+        algorithm={
+            "autotuner": "ConstantProximalWeight",
+            "lam_prox": 1e0,
+            "lam_cost": 6e-1,
+            "k_max": k_max,
+        },
+        solver={"backend": backend},
+    )
+    prob.settings.dev.printing = False
+    return prob
+
+
+def test_solve_batched_mixed_shared_and_batched_parameters():
+    pytest.importorskip("qpax")
+
+    prob = _build_brachistochrone_with_params("qpax", n=8, k_max=20)
+    prob.initialize()
+
+    gravity_batch = jnp.array([[9.0], [9.81], [10.5]])  # (B, 1) vs declared (1,) -> batched
+    gain_shared = jnp.array([0.9])  # declared shape (1,) -> shared
+
+    batched = prob.solve_batched(
+        parameters={"gravity": gravity_batch, "gain": gain_shared}
+    )
+    assert batched.x.shape[0] == gravity_batch.shape[0]
+
+    for i in range(gravity_batch.shape[0]):
+        ref = prob.solve_jax(
+            parameters=dict(prob.parameters, gravity=gravity_batch[i], gain=gain_shared)
+        )
+        np.testing.assert_allclose(np.asarray(batched.x[i]), np.asarray(ref.x), atol=1e-5, rtol=1e-5)
+        np.testing.assert_allclose(np.asarray(batched.u[i]), np.asarray(ref.u), atol=1e-5, rtol=1e-5)
+
+    jax.clear_caches()
+
+
+# === Teaching errors ===
+
+
+def test_solve_batched_unknown_parameter_key_raises():
+    prob = _build_brachistochrone_with_params("cvxpy", n=4, k_max=1)
+    prob.initialize()
+    with pytest.raises(ValueError, match=r"unknown parameter.*'gravty'.*declared parameters.*'gravity'"):
+        prob.solve_batched(parameters={"gravty": jnp.zeros((2, 1))})
 
 
 def test_solve_batched_before_initialize_raises():

--- a/tests/test_solve_batched_brachistochrone.py
+++ b/tests/test_solve_batched_brachistochrone.py
@@ -132,17 +132,19 @@ def test_solve_batched_mixed_shared_and_batched_parameters():
     gravity_batch = jnp.array([[9.0], [9.81], [10.5]])  # (B, 1) vs declared (1,) -> batched
     gain_shared = jnp.array([0.9])  # declared shape (1,) -> shared
 
-    batched = prob.solve_batched(
-        parameters={"gravity": gravity_batch, "gain": gain_shared}
-    )
+    batched = prob.solve_batched(parameters={"gravity": gravity_batch, "gain": gain_shared})
     assert batched.x.shape[0] == gravity_batch.shape[0]
 
     for i in range(gravity_batch.shape[0]):
         ref = prob.solve_jax(
             parameters=dict(prob.parameters, gravity=gravity_batch[i], gain=gain_shared)
         )
-        np.testing.assert_allclose(np.asarray(batched.x[i]), np.asarray(ref.x), atol=1e-5, rtol=1e-5)
-        np.testing.assert_allclose(np.asarray(batched.u[i]), np.asarray(ref.u), atol=1e-5, rtol=1e-5)
+        np.testing.assert_allclose(
+            np.asarray(batched.x[i]), np.asarray(ref.x), atol=1e-5, rtol=1e-5
+        )
+        np.testing.assert_allclose(
+            np.asarray(batched.u[i]), np.asarray(ref.u), atol=1e-5, rtol=1e-5
+        )
 
     jax.clear_caches()
 
@@ -206,7 +208,9 @@ def test_solve_batched_ep_tr_sweep_matches_solve_jax():
 def test_solve_batched_unknown_parameter_key_raises():
     prob = _build_brachistochrone_with_params("cvxpy", n=4, k_max=1)
     prob.initialize()
-    with pytest.raises(ValueError, match=r"unknown parameter.*'gravty'.*declared parameters.*'gravity'"):
+    with pytest.raises(
+        ValueError, match=r"unknown parameter.*'gravty'.*declared parameters.*'gravity'"
+    ):
         prob.solve_batched(parameters={"gravty": jnp.zeros((2, 1))})
 
 

--- a/tests/test_solve_batched_brachistochrone.py
+++ b/tests/test_solve_batched_brachistochrone.py
@@ -215,12 +215,12 @@ def test_solve_batched_ep_tr_sweep_matches_solve_jax():
 
     # Loose-to-tight trust-region tolerances: the loose element converges
     # iterations earlier, so the per-element final iterates differ. ep_tr is
-    # a scalar state field, so (B,) vs () -> batched through `overrides`.
+    # a scalar state field, so (B,) vs () -> batched through `algorithm`.
     tolerances = jnp.array([1e-1, 1e-5])
-    batched = prob.solve_batched(overrides={"ep_tr": tolerances})
+    batched = prob.solve_batched(algorithm={"ep_tr": tolerances})
 
     for i, tol in enumerate(np.asarray(tolerances)):
-        ref = prob.solve_jax(overrides={"ep_tr": float(tol)})
+        ref = prob.solve_jax(algorithm={"ep_tr": float(tol)})
         np.testing.assert_allclose(
             np.asarray(batched.x[i]), np.asarray(ref.x), atol=1e-5, rtol=1e-5
         )
@@ -241,12 +241,12 @@ def test_solve_batched_lam_prox_fill_sweep_matches_solve_jax():
     # field shape. Different trust-region weights walk different iterate
     # paths, so the elements genuinely diverge.
     weights = jnp.array([0.5, 1.0, 4.0])
-    batched = prob.solve_batched(overrides={"lam_prox": weights})
+    batched = prob.solve_batched(algorithm={"lam_prox": weights})
     assert batched.x.shape[0] == weights.shape[0]
 
     for i, w in enumerate(np.asarray(weights)):
         # solve_jax takes the scalar (shared-fill) form of the same override.
-        ref = prob.solve_jax(overrides={"lam_prox": float(w)})
+        ref = prob.solve_jax(algorithm={"lam_prox": float(w)})
         np.testing.assert_allclose(
             np.asarray(batched.x[i]), np.asarray(ref.x), atol=1e-5, rtol=1e-5
         )
@@ -259,7 +259,7 @@ def test_solve_batched_lam_prox_fill_sweep_matches_solve_jax():
     jax.clear_caches()
 
 
-def test_solve_batched_overrides_k_max_matches_max_iters_kwarg():
+def test_solve_batched_algorithm_k_max_matches_max_iters_kwarg():
     pytest.importorskip("qpax")
 
     prob = build_brachistochrone("qpax", n=8, k_max=20)
@@ -270,7 +270,7 @@ def test_solve_batched_overrides_k_max_matches_max_iters_kwarg():
     # that default, not silently lose to it.
     budgets = jnp.array([2, 8])
     via_kwarg = prob.solve_batched(max_iters=budgets)
-    via_override = prob.solve_batched(overrides={"k_max": budgets})
+    via_override = prob.solve_batched(algorithm={"k_max": budgets})
 
     np.testing.assert_allclose(
         np.asarray(via_override.x), np.asarray(via_kwarg.x), atol=1e-9, rtol=0
@@ -327,11 +327,11 @@ def test_user_autotuner_knob_sweeps_through_solve_batched():
     # (B,) vector sweeps it per element and each element matches the
     # corresponding single solve.
     scales = jnp.array([0.8, 1.0, 1.4])
-    batched = prob.solve_batched(overrides={"prox_scale": scales})
+    batched = prob.solve_batched(algorithm={"prox_scale": scales})
     assert batched.x.shape[0] == scales.shape[0]
 
     for i, s in enumerate(np.asarray(scales)):
-        ref = prob.solve_jax(overrides={"prox_scale": float(s)})
+        ref = prob.solve_jax(algorithm={"prox_scale": float(s)})
         np.testing.assert_allclose(
             np.asarray(batched.x[i]), np.asarray(ref.x), atol=1e-5, rtol=1e-5
         )
@@ -354,10 +354,10 @@ def test_augmented_lagrangian_declared_knobs_are_overridable():
     prob.initialize()
 
     base = prob.solve_jax()
-    single = prob.solve_jax(overrides={"rho_init": 5.0, "rho_max": 1e3})
+    single = prob.solve_jax(algorithm={"rho_init": 5.0, "rho_max": 1e3})
     np.testing.assert_allclose(np.asarray(single.x), np.asarray(base.x), atol=1e-12)
 
-    batched = prob.solve_batched(overrides={"rho_init": jnp.array([1.0, 5.0])})
+    batched = prob.solve_batched(algorithm={"rho_init": jnp.array([1.0, 5.0])})
     assert batched.x.shape[0] == 2
     for i in range(2):
         np.testing.assert_allclose(
@@ -379,29 +379,46 @@ def test_solve_batched_unknown_parameter_key_raises():
         prob.solve_batched(parameters={"gravty": jnp.zeros((2, 1))})
 
 
-def test_overrides_unknown_name_lists_valid_names():
+def test_algorithm_unknown_key_lists_valid_names():
     prob = build_brachistochrone("cvxpy", n=4, k_max=1)
     prob.initialize()
-    with pytest.raises(ValueError, match=r"unknown override name.*'ep_trr'.*'ep_tr'"):
-        prob.solve_batched(overrides={"ep_trr": jnp.zeros(2)})
-    with pytest.raises(ValueError, match=r"solve_jax: unknown override name.*'ep_trr'"):
-        prob.solve_jax(overrides={"ep_trr": 1e-4})
+    with pytest.raises(ValueError, match=r"unknown algorithm key.*'ep_trr'.*'ep_tr'"):
+        prob.solve_batched(algorithm={"ep_trr": jnp.zeros(2)})
+    with pytest.raises(ValueError, match=r"solve_jax: unknown algorithm key.*'ep_trr'"):
+        prob.solve_jax(algorithm={"ep_trr": 1e-4})
 
 
-def test_overrides_kwarg_collision_names_the_kwarg():
+def test_algorithm_construction_key_teaches_rebuild():
     prob = build_brachistochrone("cvxpy", n=4, k_max=1)
     prob.initialize()
-    with pytest.raises(ValueError, match=r"overrides\['k_max'\].*max_iters kwarg"):
-        prob.solve_batched(max_iters=jnp.array([2, 3]), overrides={"k_max": 5})
-    with pytest.raises(ValueError, match=r"overrides\['x'\].*x_guess kwarg"):
-        prob.solve_jax(x_guess=prob.state.x, overrides={"x": prob.state.x})
+    # `autotuner` selects program structure and `t_max` is a wall-clock budget
+    # outside the traced loop — both are construction-time settings, so they
+    # get the rebuild-the-Problem teaching error, not the generic unknown-name
+    # one.
+    with pytest.raises(
+        ValueError, match=r"algorithm\['autotuner'\].*construction-time.*rebuild the Problem"
+    ):
+        prob.solve_jax(algorithm={"autotuner": "RampProximalWeight"})
+    with pytest.raises(
+        ValueError, match=r"algorithm\['t_max'\].*construction-time.*rebuild the Problem"
+    ):
+        prob.solve_batched(algorithm={"t_max": jnp.ones(2)})
 
 
-def test_solve_jax_override_shape_mismatch_points_at_solve_batched():
+def test_algorithm_kwarg_collision_names_the_kwarg():
     prob = build_brachistochrone("cvxpy", n=4, k_max=1)
     prob.initialize()
-    with pytest.raises(ValueError, match=r"overrides\['ep_tr'\] has shape \(2,\).*solve_batched"):
-        prob.solve_jax(overrides={"ep_tr": jnp.zeros(2)})
+    with pytest.raises(ValueError, match=r"algorithm\['k_max'\].*max_iters kwarg"):
+        prob.solve_batched(max_iters=jnp.array([2, 3]), algorithm={"k_max": 5})
+    with pytest.raises(ValueError, match=r"algorithm\['x'\].*x_guess kwarg"):
+        prob.solve_jax(x_guess=prob.state.x, algorithm={"x": prob.state.x})
+
+
+def test_solve_jax_algorithm_shape_mismatch_points_at_solve_batched():
+    prob = build_brachistochrone("cvxpy", n=4, k_max=1)
+    prob.initialize()
+    with pytest.raises(ValueError, match=r"algorithm\['ep_tr'\] has shape \(2,\).*solve_batched"):
+        prob.solve_jax(algorithm={"ep_tr": jnp.zeros(2)})
 
 
 def test_solve_batched_before_initialize_raises():

--- a/tests/test_solve_batched_brachistochrone.py
+++ b/tests/test_solve_batched_brachistochrone.py
@@ -155,6 +155,27 @@ def test_solve_batched_mixed_shared_and_batched_parameters():
     jax.clear_caches()
 
 
+def test_solve_batched_in_axes_prefix_matches_inference():
+    pytest.importorskip("qpax")
+
+    prob = _build_brachistochrone_with_params("qpax", n=8, k_max=8)
+    prob.initialize()
+
+    # jax.vmap prefix semantics: in_axes={"parameters": 0} batches every
+    # passed parameter — same resolution the rank rule infers for these
+    # shapes, so the results must agree (and the batched closure is reused).
+    params = {
+        "gravity": jnp.array([[9.0], [10.5]]),  # (B, 1) vs declared (1,)
+        "gain": jnp.array([[0.9], [1.1]]),
+    }
+    inferred = prob.solve_batched(parameters=params)
+    prefixed = prob.solve_batched(parameters=params, in_axes={"parameters": 0})
+
+    np.testing.assert_allclose(np.asarray(prefixed.x), np.asarray(inferred.x), atol=1e-12, rtol=0)
+
+    jax.clear_caches()
+
+
 # === Hyperparameter sweeps ===
 
 

--- a/tests/test_solve_batched_export_roundtrip.py
+++ b/tests/test_solve_batched_export_roundtrip.py
@@ -5,9 +5,12 @@ solver cache on the first call; a later ``Problem`` with the same structure
 deserializes that artifact instead of recompiling. This is the entire reason
 ``solve_batched`` exists over ``jax.vmap(solve_jax)`` (which re-traces every
 launch). The second half asserts the correctness-critical cache key (§4):
-anything that changes the exported loop — backend, ``solver_args``, ``k_max``,
-discretizer, scaling — must produce a *different* path, so a stale artifact is
-never silently reused.
+anything that changes the exported loop — backend, ``solver_args``,
+discretizer, scaling, the shared/batched parameter split — must produce a
+*different* path, so a stale artifact is never silently reused. Tolerances and
+the iteration cap ride the state pytree as runtime inputs, so one artifact
+serves every ``max_iters`` setting — asserted both on the path function and on
+a real cross-process reuse.
 """
 
 import jax
@@ -66,6 +69,14 @@ def test_export_roundtrip_matches_and_skips_recompile(monkeypatch, tmp_path):
     np.testing.assert_allclose(np.asarray(second.x), np.asarray(first.x), atol=1e-5, rtol=1e-5)
     np.testing.assert_allclose(np.asarray(second.u), np.asarray(first.u), atol=1e-5, rtol=1e-5)
 
+    # max_iters is a runtime input on the state pytree, not a baked loop
+    # bound: a different cap reuses the very same artifact.
+    capped = prob2.solve_batched(x_guess=_guess_stack(prob2), max_iters=2)
+    assert artifact.stat().st_mtime_ns == mtime_after_first, (
+        "a different max_iters must reuse the artifact, not re-export"
+    )
+    assert capped.x.shape == first.x.shape
+
     jax.clear_caches()
 
 
@@ -75,7 +86,7 @@ def test_cache_key_invalidates_on_artifact_changing_state(tmp_path):
     prob = build_brachistochrone("qpax", n=8, k_max=20)
     prob.initialize()
 
-    def path(p, B=4, k_max=None):
+    def path(p, B=4, param_axes={}):
         return get_solve_batched_cache_path(
             p.symbolic,
             p.settings,
@@ -83,7 +94,7 @@ def test_cache_key_invalidates_on_artifact_changing_state(tmp_path):
             p._solver,
             p._discretizer,
             B,
-            p._algorithm.k_max if k_max is None else k_max,
+            param_axes,
             cache_dir=tmp_path,
         )
 
@@ -95,13 +106,20 @@ def test_cache_key_invalidates_on_artifact_changing_state(tmp_path):
     # Batch size is baked into the artifact → part of the key.
     assert path(prob, B=2) != base
 
-    # k_max is the resolved loop bound. Both routes that change it must re-key:
-    # bumping the algorithm default, and a per-call ``max_iters`` override.
+    # The shared/batched parameter split is baked into the vmap'd program →
+    # an artifact traced for one split must never be loaded for another.
+    assert path(prob, param_axes={"gravity": 0}) != base
+    assert path(prob, param_axes={"gravity": None}) != base
+
+    # The iteration cap and tolerances are runtime state inputs, NOT baked
+    # loop constants: changing them must reuse the artifact, not re-key it.
     prob._algorithm.k_max += 1
-    assert path(prob) != base
-    prob._algorithm.k_max -= 1
     assert path(prob) == base
-    assert path(prob, k_max=prob._algorithm.k_max + 1) != base
+    prob._algorithm.k_max -= 1
+    saved_ep_tr = prob._algorithm.ep_tr
+    prob._algorithm.ep_tr = saved_ep_tr * 10.0
+    assert path(prob) == base
+    prob._algorithm.ep_tr = saved_ep_tr
 
     # solver_args (tolerances / iteration caps) are baked into the backend solve.
     saved_max_iter = prob._solver.solver_args.get("max_iter")

--- a/tests/test_solve_batched_inference.py
+++ b/tests/test_solve_batched_inference.py
@@ -160,43 +160,43 @@ def test_in_axes_forced_zero_with_disagreeing_batch_size_raises():
         )
 
 
-# === Fill forms (overrides entries) ===
+# === Fill forms (algorithm entries) ===
 
 
 def test_fill_scalar_is_shared_fill():
     B, axes, fills = _resolve_batch_spec(
         {
             "x_initial": (np.zeros((3, 6)), (6,)),
-            "overrides.lam_prox": (2.0, (10, 4)),
+            "algorithm.lam_prox": (2.0, (10, 4)),
         },
-        fill={"overrides.lam_prox"},
+        fill={"algorithm.lam_prox"},
     )
     assert B == 3
-    assert axes["overrides.lam_prox"] is None
-    assert fills == {"overrides.lam_prox"}
+    assert axes["algorithm.lam_prox"] is None
+    assert fills == {"algorithm.lam_prox"}
 
 
 def test_fill_vector_is_batched_fill():
     B, axes, fills = _resolve_batch_spec(
-        {"overrides.lam_prox": (np.zeros(5), (10, 4))},
-        fill={"overrides.lam_prox"},
+        {"algorithm.lam_prox": (np.zeros(5), (10, 4))},
+        fill={"algorithm.lam_prox"},
     )
     assert B == 5
-    assert axes == {"overrides.lam_prox": 0}
-    assert fills == {"overrides.lam_prox"}
+    assert axes == {"algorithm.lam_prox": 0}
+    assert fills == {"algorithm.lam_prox"}
 
 
 def test_fill_exact_shapes_win_over_fills():
     # The field's exact shape and (B,) + it parse as exact, never as fill.
     B, axes, fills = _resolve_batch_spec(
         {
-            "overrides.lam_vc": (np.zeros((7, 4)), (7, 4)),
-            "overrides.lam_cost": (np.zeros((3, 2)), (2,)),
+            "algorithm.lam_vc": (np.zeros((7, 4)), (7, 4)),
+            "algorithm.lam_cost": (np.zeros((3, 2)), (2,)),
         },
-        fill={"overrides.lam_vc", "overrides.lam_cost"},
+        fill={"algorithm.lam_vc", "algorithm.lam_cost"},
     )
     assert B == 3
-    assert axes == {"overrides.lam_vc": None, "overrides.lam_cost": 0}
+    assert axes == {"algorithm.lam_vc": None, "algorithm.lam_cost": 0}
     assert fills == set()
 
 
@@ -206,44 +206,44 @@ def test_fill_rank1_field_of_length_B_reads_shared_exact():
     B, axes, fills = _resolve_batch_spec(
         {
             "x_initial": (np.zeros((4, 6)), (6,)),
-            "overrides.lam_cost": (np.zeros(4), (4,)),
+            "algorithm.lam_cost": (np.zeros(4), (4,)),
         },
-        fill={"overrides.lam_cost"},
+        fill={"algorithm.lam_cost"},
     )
-    assert axes["overrides.lam_cost"] is None
+    assert axes["algorithm.lam_cost"] is None
     assert fills == set()
 
 
 def test_fill_in_axes_forces_batched_fill_on_rank1_field():
     # ...and in_axes={name: 0} forces the per-element fill reading.
     B, axes, fills = _resolve_batch_spec(
-        {"overrides.lam_cost": (np.zeros(4), (4,))},
-        in_axes={"overrides.lam_cost": 0},
-        fill={"overrides.lam_cost"},
+        {"algorithm.lam_cost": (np.zeros(4), (4,))},
+        in_axes={"algorithm.lam_cost": 0},
+        fill={"algorithm.lam_cost"},
     )
     assert B == 4
-    assert axes == {"overrides.lam_cost": 0}
-    assert fills == {"overrides.lam_cost"}
+    assert axes == {"algorithm.lam_cost": 0}
+    assert fills == {"algorithm.lam_cost"}
 
 
 def test_fill_scalar_on_scalar_field_is_exact_not_fill():
     B, axes, fills = _resolve_batch_spec(
         {
-            "overrides.ep_tr": (1e-4, ()),
-            "overrides.k_max": (np.zeros(6), ()),
+            "algorithm.ep_tr": (1e-4, ()),
+            "algorithm.k_max": (np.zeros(6), ()),
         },
-        fill={"overrides.ep_tr", "overrides.k_max"},
+        fill={"algorithm.ep_tr", "algorithm.k_max"},
     )
     assert B == 6
-    assert axes == {"overrides.ep_tr": None, "overrides.k_max": 0}
+    assert axes == {"algorithm.ep_tr": None, "algorithm.k_max": 0}
     assert fills == set()
 
 
 def test_fill_bad_rank_lists_all_four_forms():
     with pytest.raises(ValueError, match=r"scalar \(\) to fill.*\(B,\) to fill one scalar"):
         _resolve_batch_spec(
-            {"overrides.lam_prox": (np.zeros((2, 3, 4, 5)), (10, 4))},
-            fill={"overrides.lam_prox"},
+            {"algorithm.lam_prox": (np.zeros((2, 3, 4, 5)), (10, 4))},
+            fill={"algorithm.lam_prox"},
         )
 
 
@@ -263,7 +263,7 @@ _PREFIX_ENTRIES = {
     "x_guess": (None, (10, 3)),
     "parameters.center": (np.zeros((4, 3)), (3,)),
     "parameters.radius": (0.5, ()),
-    "overrides.ep_tr": (np.zeros(4), ()),
+    "algorithm.ep_tr": (np.zeros(4), ()),
 }
 
 
@@ -277,7 +277,7 @@ def test_flatten_bare_zero_batches_every_passed_input():
         "x_initial": 0,
         "parameters.center": 0,
         "parameters.radius": 0,
-        "overrides.ep_tr": 0,
+        "algorithm.ep_tr": 0,
     }
 
 
@@ -286,6 +286,8 @@ def test_flatten_subtree_prefix_applies_to_every_passed_key():
     assert flat == {"parameters.center": 0, "parameters.radius": 0}
     flat = _flatten_in_axes({"parameters": None, "x_initial": 0}, _PREFIX_ENTRIES)
     assert flat == {"parameters.center": None, "parameters.radius": None, "x_initial": 0}
+    flat = _flatten_in_axes({"algorithm": 0}, _PREFIX_ENTRIES)
+    assert flat == {"algorithm.ep_tr": 0}
 
 
 def test_flatten_per_key_dict_unchanged():

--- a/tests/test_solve_batched_inference.py
+++ b/tests/test_solve_batched_inference.py
@@ -17,7 +17,7 @@ from openscvx.problem import _resolve_batch_spec
 
 
 def test_shared_when_shape_matches_declared():
-    B, axes = _resolve_batch_spec(
+    B, axes, _ = _resolve_batch_spec(
         {
             "x_initial": (np.zeros((4, 3)), (3,)),
             "parameters.center": (np.zeros(3), (3,)),
@@ -28,13 +28,13 @@ def test_shared_when_shape_matches_declared():
 
 
 def test_batched_when_one_extra_leading_axis():
-    B, axes = _resolve_batch_spec({"x_guess": (np.zeros((5, 10, 3)), (10, 3))})
+    B, axes, _ = _resolve_batch_spec({"x_guess": (np.zeros((5, 10, 3)), (10, 3))})
     assert B == 5
     assert axes == {"x_guess": 0}
 
 
 def test_scalar_declared_batched_as_vector():
-    B, axes = _resolve_batch_spec(
+    B, axes, _ = _resolve_batch_spec(
         {
             "parameters.radius": (np.zeros(7), ()),
             "parameters.gain": (1.5, ()),
@@ -45,7 +45,7 @@ def test_scalar_declared_batched_as_vector():
 
 
 def test_none_values_are_skipped():
-    B, axes = _resolve_batch_spec(
+    B, axes, _ = _resolve_batch_spec(
         {
             "x_initial": (np.zeros((2, 3)), (3,)),
             "x_final": (None, (3,)),
@@ -58,7 +58,7 @@ def test_none_values_are_skipped():
 def test_shared_matrix_with_leading_axis_equal_to_B_stays_shared():
     # Declared (4, 3) passed as (4, 3) alongside a B=4 batched pin: rank
     # matches declared, so the coincidental leading axis must not batch it.
-    B, axes = _resolve_batch_spec(
+    B, axes, _ = _resolve_batch_spec(
         {
             "x_initial": (np.zeros((4, 6)), (6,)),
             "parameters.waypoints": (np.zeros((4, 3)), (4, 3)),
@@ -69,7 +69,7 @@ def test_shared_matrix_with_leading_axis_equal_to_B_stays_shared():
 
 
 def test_matrix_batched_with_full_extra_axis():
-    B, axes = _resolve_batch_spec({"parameters.waypoints": (np.zeros((4, 4, 3)), (4, 3))})
+    B, axes, _ = _resolve_batch_spec({"parameters.waypoints": (np.zeros((4, 4, 3)), (4, 3))})
     assert B == 4
     assert axes == {"parameters.waypoints": 0}
 
@@ -80,7 +80,7 @@ def test_matrix_batched_with_full_extra_axis():
 def test_in_axes_forces_batched_on_rank_matching_value():
     # A declared-(4,) parameter passed as (4,) reads as shared; in_axes says
     # it is one scalar per batch element.
-    B, axes = _resolve_batch_spec(
+    B, axes, _ = _resolve_batch_spec(
         {"parameters.weights": (np.zeros(4), (4,))},
         in_axes={"parameters.weights": 0},
     )
@@ -89,7 +89,7 @@ def test_in_axes_forces_batched_on_rank_matching_value():
 
 
 def test_in_axes_forces_shared():
-    B, axes = _resolve_batch_spec(
+    B, axes, _ = _resolve_batch_spec(
         {
             "x_initial": (np.zeros((2, 3)), (3,)),
             "x_guess": (np.zeros((2, 10, 3)), (10, 3)),
@@ -101,7 +101,7 @@ def test_in_axes_forces_shared():
 
 
 def test_in_axes_partial_spec_merges_with_inference():
-    B, axes = _resolve_batch_spec(
+    B, axes, _ = _resolve_batch_spec(
         {
             "parameters.weights": (np.zeros(4), (4,)),
             "parameters.center": (np.zeros((4, 3)), (3,)),
@@ -158,6 +158,101 @@ def test_in_axes_forced_zero_with_disagreeing_batch_size_raises():
             },
             in_axes={"parameters.weights": 0},
         )
+
+
+# === Fill forms (overrides entries) ===
+
+
+def test_fill_scalar_is_shared_fill():
+    B, axes, fills = _resolve_batch_spec(
+        {
+            "x_initial": (np.zeros((3, 6)), (6,)),
+            "overrides.lam_prox": (2.0, (10, 4)),
+        },
+        fill={"overrides.lam_prox"},
+    )
+    assert B == 3
+    assert axes["overrides.lam_prox"] is None
+    assert fills == {"overrides.lam_prox"}
+
+
+def test_fill_vector_is_batched_fill():
+    B, axes, fills = _resolve_batch_spec(
+        {"overrides.lam_prox": (np.zeros(5), (10, 4))},
+        fill={"overrides.lam_prox"},
+    )
+    assert B == 5
+    assert axes == {"overrides.lam_prox": 0}
+    assert fills == {"overrides.lam_prox"}
+
+
+def test_fill_exact_shapes_win_over_fills():
+    # The field's exact shape and (B,) + it parse as exact, never as fill.
+    B, axes, fills = _resolve_batch_spec(
+        {
+            "overrides.lam_vc": (np.zeros((7, 4)), (7, 4)),
+            "overrides.lam_cost": (np.zeros((3, 2)), (2,)),
+        },
+        fill={"overrides.lam_vc", "overrides.lam_cost"},
+    )
+    assert B == 3
+    assert axes == {"overrides.lam_vc": None, "overrides.lam_cost": 0}
+    assert fills == set()
+
+
+def test_fill_rank1_field_of_length_B_reads_shared_exact():
+    # The documented collision: a rank-1 field whose length equals B parses
+    # as shared-exact by precedence...
+    B, axes, fills = _resolve_batch_spec(
+        {
+            "x_initial": (np.zeros((4, 6)), (6,)),
+            "overrides.lam_cost": (np.zeros(4), (4,)),
+        },
+        fill={"overrides.lam_cost"},
+    )
+    assert axes["overrides.lam_cost"] is None
+    assert fills == set()
+
+
+def test_fill_in_axes_forces_batched_fill_on_rank1_field():
+    # ...and in_axes={name: 0} forces the per-element fill reading.
+    B, axes, fills = _resolve_batch_spec(
+        {"overrides.lam_cost": (np.zeros(4), (4,))},
+        in_axes={"overrides.lam_cost": 0},
+        fill={"overrides.lam_cost"},
+    )
+    assert B == 4
+    assert axes == {"overrides.lam_cost": 0}
+    assert fills == {"overrides.lam_cost"}
+
+
+def test_fill_scalar_on_scalar_field_is_exact_not_fill():
+    B, axes, fills = _resolve_batch_spec(
+        {
+            "overrides.ep_tr": (1e-4, ()),
+            "overrides.k_max": (np.zeros(6), ()),
+        },
+        fill={"overrides.ep_tr", "overrides.k_max"},
+    )
+    assert B == 6
+    assert axes == {"overrides.ep_tr": None, "overrides.k_max": 0}
+    assert fills == set()
+
+
+def test_fill_bad_rank_lists_all_four_forms():
+    with pytest.raises(ValueError, match=r"scalar \(\) to fill.*\(B,\) to fill one scalar"):
+        _resolve_batch_spec(
+            {"overrides.lam_prox": (np.zeros((2, 3, 4, 5)), (10, 4))},
+            fill={"overrides.lam_prox"},
+        )
+
+
+def test_non_fill_entry_rejects_fill_forms():
+    # Without fill capability a (B,) value against a (10, 3) declared shape
+    # is just a shape mismatch — and the error does not advertise fills.
+    with pytest.raises(ValueError, match=r"'x_guess' has shape \(5,\)") as exc:
+        _resolve_batch_spec({"x_guess": (np.zeros(5), (10, 3))})
+    assert "fill" not in str(exc.value)
 
 
 # === Teaching errors ===

--- a/tests/test_solve_batched_inference.py
+++ b/tests/test_solve_batched_inference.py
@@ -1,0 +1,186 @@
+"""Unit tests for the rank-based batch resolver behind ``Problem.solve_batched``.
+
+``_resolve_batch_spec`` implements the one rule of the batched-solve API: a
+value whose shape equals its declared (unbatched) shape is shared across the
+batch; a value with exactly one extra leading axis is batched along it. Rank
+against the declared shape decides — never the leading-axis value — with an
+explicit ``jax.vmap``-style ``in_axes`` dict as the override. Pure-function
+tests: no problem build, no solver runs.
+"""
+
+import numpy as np
+import pytest
+
+from openscvx.problem import _resolve_batch_spec
+
+# === Rank rule ===
+
+
+def test_shared_when_shape_matches_declared():
+    B, axes = _resolve_batch_spec(
+        {
+            "x_initial": (np.zeros((4, 3)), (3,)),
+            "parameters.center": (np.zeros(3), (3,)),
+        }
+    )
+    assert B == 4
+    assert axes == {"x_initial": 0, "parameters.center": None}
+
+
+def test_batched_when_one_extra_leading_axis():
+    B, axes = _resolve_batch_spec({"x_guess": (np.zeros((5, 10, 3)), (10, 3))})
+    assert B == 5
+    assert axes == {"x_guess": 0}
+
+
+def test_scalar_declared_batched_as_vector():
+    B, axes = _resolve_batch_spec(
+        {
+            "parameters.radius": (np.zeros(7), ()),
+            "parameters.gain": (1.5, ()),
+        }
+    )
+    assert B == 7
+    assert axes == {"parameters.radius": 0, "parameters.gain": None}
+
+
+def test_none_values_are_skipped():
+    B, axes = _resolve_batch_spec(
+        {
+            "x_initial": (np.zeros((2, 3)), (3,)),
+            "x_final": (None, (3,)),
+        }
+    )
+    assert B == 2
+    assert axes == {"x_initial": 0}
+
+
+def test_shared_matrix_with_leading_axis_equal_to_B_stays_shared():
+    # Declared (4, 3) passed as (4, 3) alongside a B=4 batched pin: rank
+    # matches declared, so the coincidental leading axis must not batch it.
+    B, axes = _resolve_batch_spec(
+        {
+            "x_initial": (np.zeros((4, 6)), (6,)),
+            "parameters.waypoints": (np.zeros((4, 3)), (4, 3)),
+        }
+    )
+    assert B == 4
+    assert axes == {"x_initial": 0, "parameters.waypoints": None}
+
+
+def test_matrix_batched_with_full_extra_axis():
+    B, axes = _resolve_batch_spec({"parameters.waypoints": (np.zeros((4, 4, 3)), (4, 3))})
+    assert B == 4
+    assert axes == {"parameters.waypoints": 0}
+
+
+# === in_axes overrides ===
+
+
+def test_in_axes_forces_batched_on_rank_matching_value():
+    # A declared-(4,) parameter passed as (4,) reads as shared; in_axes says
+    # it is one scalar per batch element.
+    B, axes = _resolve_batch_spec(
+        {"parameters.weights": (np.zeros(4), (4,))},
+        in_axes={"parameters.weights": 0},
+    )
+    assert B == 4
+    assert axes == {"parameters.weights": 0}
+
+
+def test_in_axes_forces_shared():
+    B, axes = _resolve_batch_spec(
+        {
+            "x_initial": (np.zeros((2, 3)), (3,)),
+            "x_guess": (np.zeros((2, 10, 3)), (10, 3)),
+        },
+        in_axes={"x_guess": None},
+    )
+    assert B == 2
+    assert axes == {"x_initial": 0, "x_guess": None}
+
+
+def test_in_axes_partial_spec_merges_with_inference():
+    B, axes = _resolve_batch_spec(
+        {
+            "parameters.weights": (np.zeros(4), (4,)),
+            "parameters.center": (np.zeros((4, 3)), (3,)),
+        },
+        in_axes={"parameters.weights": 0},
+    )
+    assert B == 4
+    assert axes == {"parameters.weights": 0, "parameters.center": 0}
+
+
+def test_in_axes_unknown_name_raises():
+    with pytest.raises(ValueError, match=r"unknown entry.*'x_intial'"):
+        _resolve_batch_spec(
+            {"x_initial": (np.zeros((2, 3)), (3,))},
+            in_axes={"x_intial": 0},
+        )
+
+
+def test_in_axes_invalid_axis_value_raises():
+    with pytest.raises(ValueError, match=r"in_axes\['x_initial'\] must be 0.*or None"):
+        _resolve_batch_spec(
+            {"x_initial": (np.zeros((2, 3)), (3,))},
+            in_axes={"x_initial": 1},
+        )
+
+
+def test_in_axes_on_absent_entry_raises():
+    with pytest.raises(ValueError, match=r"'x_final' as batched, but no value"):
+        _resolve_batch_spec(
+            {
+                "x_initial": (np.zeros((2, 3)), (3,)),
+                "x_final": (None, (3,)),
+            },
+            in_axes={"x_final": 0},
+        )
+
+
+def test_in_axes_forced_zero_on_scalar_raises():
+    with pytest.raises(ValueError, match=r"scalar with no leading axis"):
+        _resolve_batch_spec(
+            {"parameters.gain": (1.5, ())},
+            in_axes={"parameters.gain": 0},
+        )
+
+
+def test_in_axes_forced_zero_with_disagreeing_batch_size_raises():
+    with pytest.raises(ValueError, match=r"'x_initial' has leading axis 2.*'parameters.weights' has leading axis 4"):
+        _resolve_batch_spec(
+            {
+                "x_initial": (np.zeros((2, 3)), (3,)),
+                "parameters.weights": (np.zeros(4), (4,)),
+            },
+            in_axes={"parameters.weights": 0},
+        )
+
+
+# === Teaching errors ===
+
+
+def test_shape_mismatch_names_entry_and_shapes():
+    with pytest.raises(ValueError, match=r"'parameters.center' has shape \(5, 2\).*unbatched.*\(3,\)"):
+        _resolve_batch_spec({"parameters.center": (np.zeros((5, 2)), (3,))})
+
+
+def test_batch_size_disagreement_names_both_entries():
+    with pytest.raises(ValueError, match=r"'x_initial' has leading axis 4 but 'x_final' has leading axis 5"):
+        _resolve_batch_spec(
+            {
+                "x_initial": (np.zeros((4, 3)), (3,)),
+                "x_final": (np.zeros((5, 3)), (3,)),
+            }
+        )
+
+
+def test_no_batched_entry_suggests_solve_jax():
+    with pytest.raises(ValueError, match=r"solve_jax\(\).*in_axes"):
+        _resolve_batch_spec(
+            {
+                "x_initial": (np.zeros(3), (3,)),
+                "parameters.center": (np.zeros(3), (3,)),
+            }
+        )

--- a/tests/test_solve_batched_inference.py
+++ b/tests/test_solve_batched_inference.py
@@ -11,7 +11,7 @@ tests: no problem build, no solver runs.
 import numpy as np
 import pytest
 
-from openscvx.problem import _resolve_batch_spec
+from openscvx.problem import _flatten_in_axes, _resolve_batch_spec
 
 # === Rank rule ===
 
@@ -253,6 +253,57 @@ def test_non_fill_entry_rejects_fill_forms():
     with pytest.raises(ValueError, match=r"'x_guess' has shape \(5,\)") as exc:
         _resolve_batch_spec({"x_guess": (np.zeros(5), (10, 3))})
     assert "fill" not in str(exc.value)
+
+
+# === in_axes prefix flattening ===
+
+
+_PREFIX_ENTRIES = {
+    "x_initial": (np.zeros((4, 3)), (3,)),
+    "x_guess": (None, (10, 3)),
+    "parameters.center": (np.zeros((4, 3)), (3,)),
+    "parameters.radius": (0.5, ()),
+    "overrides.ep_tr": (np.zeros(4), ()),
+}
+
+
+def test_flatten_none_means_infer():
+    assert _flatten_in_axes(None, _PREFIX_ENTRIES) == {}
+
+
+def test_flatten_bare_zero_batches_every_passed_input():
+    # x_guess was not passed (None) and must not be forced batched.
+    assert _flatten_in_axes(0, _PREFIX_ENTRIES) == {
+        "x_initial": 0,
+        "parameters.center": 0,
+        "parameters.radius": 0,
+        "overrides.ep_tr": 0,
+    }
+
+
+def test_flatten_subtree_prefix_applies_to_every_passed_key():
+    flat = _flatten_in_axes({"parameters": 0}, _PREFIX_ENTRIES)
+    assert flat == {"parameters.center": 0, "parameters.radius": 0}
+    flat = _flatten_in_axes({"parameters": None, "x_initial": 0}, _PREFIX_ENTRIES)
+    assert flat == {"parameters.center": None, "parameters.radius": None, "x_initial": 0}
+
+
+def test_flatten_per_key_dict_unchanged():
+    assert _flatten_in_axes({"parameters": {"center": 0}}, _PREFIX_ENTRIES) == {
+        "parameters.center": 0
+    }
+
+
+def test_flatten_rejects_non_dict_non_zero_top_level():
+    with pytest.raises(ValueError, match=r"in_axes must be 0.*a dict.*or None"):
+        _flatten_in_axes(1, _PREFIX_ENTRIES)
+
+
+def test_flatten_rejects_invalid_subtree_spec():
+    with pytest.raises(
+        ValueError, match=r"in_axes\['parameters'\] must be 0 or None.*per-key dict"
+    ):
+        _flatten_in_axes({"parameters": 1}, _PREFIX_ENTRIES)
 
 
 # === Teaching errors ===

--- a/tests/test_solve_batched_inference.py
+++ b/tests/test_solve_batched_inference.py
@@ -148,7 +148,9 @@ def test_in_axes_forced_zero_on_scalar_raises():
 
 
 def test_in_axes_forced_zero_with_disagreeing_batch_size_raises():
-    with pytest.raises(ValueError, match=r"'x_initial' has leading axis 2.*'parameters.weights' has leading axis 4"):
+    with pytest.raises(
+        ValueError, match=r"'x_initial' has leading axis 2.*'parameters.weights' has leading axis 4"
+    ):
         _resolve_batch_spec(
             {
                 "x_initial": (np.zeros((2, 3)), (3,)),
@@ -162,12 +164,16 @@ def test_in_axes_forced_zero_with_disagreeing_batch_size_raises():
 
 
 def test_shape_mismatch_names_entry_and_shapes():
-    with pytest.raises(ValueError, match=r"'parameters.center' has shape \(5, 2\).*unbatched.*\(3,\)"):
+    with pytest.raises(
+        ValueError, match=r"'parameters.center' has shape \(5, 2\).*unbatched.*\(3,\)"
+    ):
         _resolve_batch_spec({"parameters.center": (np.zeros((5, 2)), (3,))})
 
 
 def test_batch_size_disagreement_names_both_entries():
-    with pytest.raises(ValueError, match=r"'x_initial' has leading axis 4 but 'x_final' has leading axis 5"):
+    with pytest.raises(
+        ValueError, match=r"'x_initial' has leading axis 4 but 'x_final' has leading axis 5"
+    ):
         _resolve_batch_spec(
             {
                 "x_initial": (np.zeros((4, 3)), (3,)),


### PR DESCRIPTION
Follow-up to #520. `solve_batched` now shares `solve_jax`'s vocabulary with one rule on top: **add a leading batch axis to whatever varies across solves.**

## The new syntax

Same convention as `jax.vmap`: a batched input carries one extra leading axis (`in_axes=0`), a shared input keeps its natural shape (`in_axes=None`). `solve_batched` infers that axis spec by rank against declared shapes and applies the vmap internally — results gain a leading `B` axis, like vmap outputs.

```python
B = 4  # batch size. Just an int for building the arrays below — there is no
       # B argument; solve_batched infers it from leading-axis lengths (like jax.vmap)
results = problem.solve_batched(
    x_initial=x0_batch,                          # (B, n_x) -> batched boundary pins
    parameters={"gate_center": centers,          # (B, 3) vs declared (3,) -> batched
                "gate_radius": 0.5},             # () -> shared
    algorithm={                                  # same names/box as the constructor's
        "ep_tr":    jnp.logspace(-5, -3, B),     #   (B,) vs field () -> tolerance sweep
        "lam_prox": jnp.array([1.0, 2.0, 4.0]),  #   (B,) fill -> one weight per element
    },
    max_iters=jnp.array([5, 10, 20]),            # sugar for algorithm={"k_max": ...}
    # in_axes={"parameters": 0}                  # optional explicit override — vmap's
    #                                              # vocabulary incl. prefix semantics
)
```

There is no whitelist behind `algorithm`: it takes the same names (and box) as the `Problem` constructor's `algorithm` dict, derived from the `AlgorithmState` fields plus whatever the autotuner declares — solve-time mirrors construction-time. Writing a new autotuner gets batching for free — declaring the knob *is* the registration:

```python
class MyHyper(HyperParams):          # no decorator, no pytree code —
    ramp: float = 2.0                # the annotation drives the dtype

class MyAutotuner(AutotuningBase):
    def __init__(self, ramp=2.0):
        self.hyper = MyHyper(ramp=ramp)
    def update_weights(self, state, ...):
        ... state.hyper.ramp ...     # typed attribute read at trace time

problem.solve_batched(algorithm={"ramp": jnp.linspace(1, 4, B)})  # just works
```

## Changes

- **Unified signature** — `solve_batched` takes `solve_jax`'s argument names; `x0_stack`/`xf_stack` → `x_initial`/`x_final` (breaking, no shim — the method shipped days ago in #520).
- **Rank-based inference** — an input is batched iff it has exactly one more axis than its declared shape, never guessed from leading-axis values. Fixes two misclassifications in the old inference (a lone shared vector faking `B`; a shared matrix with leading axis `== B` being wrongly sliced).
- **`in_axes` override** — explicit escape hatch with `jax.vmap`'s vocabulary *and prefix semantics*: a bare `0` batches every passed input, `in_axes={"parameters": 0}` batches a whole subtree, per-key dicts pick out entries; partial specs fall back to the rank rule. (One documented divergence: the default infers by rank instead of vmap's batch-everything.)
- **Solve-time mirrors construction-time: the `algorithm={...}` dict** — every SCP constant (`ep_*`, `k_max`, weights `lam_prox`/`lam_vc`/`lam_cost`, autotuner knobs) is a runtime input on the `AlgorithmState` pytree, reachable on both solve methods through the same names and box the constructor uses. No whitelist (the name set derives from state fields + declared hyperparameters); array-shaped fields accept scalar/`(B,)` fill forms so weight sweeps don't require full stacks; construction-only keys (`autotuner`, `t_max`) get a teaching error pointing back at the constructor. Components are the namespace — a future `discretizer=`/`solver=` kwarg is the same mechanism with another box.
- **`HyperParams` container** — subclassing handles the frozen-dataclass transform, pytree + `jax.export` registration, and annotation-driven dtypes; flat `__init__` kwargs still work, preserving the YAML loader path. Proven by a test defining an autotuner entirely in-test and sweeping its knob with zero library edits.
- **Cache keys inverted accordingly** — tolerances, `max_iters`, weights, and hyperparameters no longer retrace or re-export (one `save_compiled` artifact serves every setting); the shared/batched parameter split now correctly keys both the in-memory closure and the disk-export hash.
- **Single convergence test** — `_converged(state)` shared by the pure loop, interactive `step()`, and result formatting (which previously read `algorithm.ep_*` and would misreport per-element convergence under sweeps).
- **Teaching errors** — unknown parameter/override names (listing the valid ones), shape mismatches (naming every accepted form), disagreeing batch sizes, kwarg/override collisions, and nothing-batched all raise before tracing; the docstring lists what can never be batched (`N`, backend, discretizer, autotuner type, dtype) and why.
- **Tests, examples, docs** — resolver unit tests incl. fill forms; element-wise sweep equivalence vs per-element `solve_jax` for tolerances, iteration budgets, weights, and a user-defined autotuner knob; export-roundtrip asserts artifact reuse across `max_iters` and re-keying across parameter splits; examples/docs migrated (also fixes `brachistochrone_batched.py`, whose `solve_batched` call passed positionals the shipped signature rejected).

## Notes for review

- `AugmentedLagrangian.rho_init`/`rho_max` turned out to have **no read sites** (the ρ in `update_weights` is the per-iteration acceptance ratio, governed by `eta_*`). They're declared on the AL `HyperParams` so the names resolve, but sweeping them is a no-op — wire up or delete in a follow-up.
- Component-level numerics (discretizer `rtol`/`atol`, QPAX `solver_args`) are **not** in the override surface — they're baked into separately exported artifacts. The `HyperParams` container is reusable for that promotion; deferred.
- Not verified locally: the two moreau-gated drone examples (API-key extra). Call sites unchanged; the same path is covered by QPAX parameter-batching tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)







---

Retroactive link: part of the batchable-solve line for #493 and #494.
