### PR TITLE
Fix double-applied node-0 impulse in post-processing

### DIFF
--- a/openscvx/propagation/post_processing.py
+++ b/openscvx/propagation/post_processing.py
@@ -81,18 +81,23 @@ def propagate_trajectory_results(
     n_opt_states = x.shape[1]
     n_prop_states = settings.sim.x_prop.initial.shape[0]
 
-    # For a converged solution x[0, :] is the actual IC for every optimisation-state
-    # component regardless of initial_type (Fix / Free / Maximize).  Using the
-    # trajectory value directly avoids a subtle bug where "Fix" components would
-    # be seeded from settings.sim.x_prop.initial — the lowering-time default —
-    # rather than the value enforced by a param-fix pin for this particular solve.
+    # Seed from x[0, :] directly so param-fixed "Fix" components use this solve's
+    # pinned value rather than the lowering-time x_prop.initial default.
+    x0_opt = np.array(x[0, :], dtype=float)
+
+    # Seed from the pre-impulse state to avoid impulse duplication
+    if dynamics_discrete is not None and np.any(settings.sim.u._impulsive_mask()):
+        init_fixed = np.asarray(settings.sim.x.initial_type) == "Fix"
+        x_initial = np.asarray(settings.sim.x.initial, dtype=float)
+        x0_opt = np.where(init_fixed, x_initial, x0_opt)
+
     if n_opt_states == n_prop_states:
-        x_prop_for_propagation.initial = np.array(x[0, :], dtype=float)
+        x_prop_for_propagation.initial = x0_opt
     else:
         # Propagation has extra states appended beyond the optimisation states;
         # copy only the overlapping prefix and leave prop-only states untouched.
         x_prop_initial_updated = np.array(settings.sim.x_prop.initial, dtype=float)
-        x_prop_initial_updated[:n_opt_states] = np.array(x[0, :], dtype=float)
+        x_prop_initial_updated[:n_opt_states] = x0_opt
         x_prop_for_propagation.initial = x_prop_initial_updated
 
     # Temporarily replace x_prop with our modified copy for propagation


### PR DESCRIPTION
## Problem

For impulsive problems the post-processed trajectory applies the first burn twice (starts from `x.initial + 2·dv[0]` instead of `x.initial + dv[0]`). `x[0]` is the post-impulse node-0 state, but post-processing seeds the re-propagation from it and then re-applies `dynamics_discrete` at node 0.

## Regression source

Introduced in #520 (`6b1cd407`), which replaced the impulse-safe seed `jnp.where(mask, x[0,:], x_prop.initial)` with an unconditional `x[0,:]`. The old `where` had been feeding the pre-impulse value for fixed initial states; collapsing it dropped that protection.

## Fix

Seed node 0 from the pre-impulse state when impulses are present, mirroring the solver's node-0 prior (`where(init_fixed, x.initial, x[0])`). Only activates for impulsive problems, so #520's non-impulsive behavior is unchanged.

## Verification

Verified on the Hohmann test (start velocity corrected to `v_initial + dv[0]`; `tests/test_impulsive.py` passes). Contained to `openscvx/propagation/post_processing.py`.
