### PR TITLE
Feature/frax integration

### DIFF
--- a/examples/car/dubins_car_waypoint_stl.py
+++ b/examples/car/dubins_car_waypoint_stl.py
@@ -133,20 +133,9 @@ problem = Problem(
         "lam_prox": 6e-3,
         "lam_vc": 1e1,
         "lam_cost": 1e-3,
-        # "ep_vc": 1e-6,
-        # "ep_tr": 1e-3,
     },
     float_dtype="float64",
     licq_max=1e-10,
-    solver={
-        "cvx_solver": "Mosek",
-        "solver_args": {
-            "canon_backend": "COO",
-            "enforce_dpp": True,
-            # "abstol": 1e-7,
-            # "reltol": 1e-10,
-        },
-    },
 )
 
 plotting_dict = {

--- a/examples/drone/dr_vp_polytope.py
+++ b/examples/drone/dr_vp_polytope.py
@@ -32,7 +32,7 @@ from openscvx import Problem
 from openscvx.utils import gen_vertices, rot
 
 n = 33  # Number of Nodes
-total_time = 30.0  # Total time for the simulation
+total_time = 40.0  # Total time for the simulation
 
 # Define state components
 position = ox.State("position", shape=(3,))  # 3D position [x, y, z]
@@ -241,8 +241,7 @@ problem = Problem(
     time=time,
     constraints=constraints,
     N=n,
-    algorithm={"lam_prox": 5e-2, "lam_vc": 1e0, "lam_cost": 2.5e-3, "ep_tr": 1e-5},
-    discretizer=ox.VectorizeDiscretizeLinearize(diffrax_kwargs={"atol": 1e-4}),
+    # algorithm={"lam_prox": 5e-2, "lam_vc": 1e0, "lam_cost": 2.5e-3, "ep_tr": 1e-5},
 )
 
 plotting_dict = {

--- a/examples/frax/panda_frax.py
+++ b/examples/frax/panda_frax.py
@@ -1,0 +1,430 @@
+"""Franka Panda joint-space point-to-point motion using frax dynamics.
+
+This example demonstrates how to plug a `frax.Robot` directly into an OpenSCvx
+problem via the `FraxDynamics` adapter. The 7-DOF Panda is driven from a home
+configuration to a target joint configuration in minimum time, subject to the
+robot's URDF joint position / velocity / torque limits (read automatically
+from the model).
+
+Requires:
+    pip install openscvx[frax]
+
+The Franka Panda model ships inside the ``frax`` package, so this example is
+fully self-contained — no external URDF file is needed.
+"""
+
+import os
+import sys
+
+import numpy as np
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+grandparent_dir = os.path.dirname(os.path.dirname(current_dir))
+sys.path.append(grandparent_dir)
+
+try:
+    import frax
+except ImportError:
+    print(
+        "frax is not installed. Install with: pip install openscvx[frax]",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+import openscvx as ox
+
+# ── frax dynamics as a first-class adapter ────────────────────────────────────
+# `FraxDynamics` builds default q / qd / tau State and Control objects matching
+# the robot's joint count and routes frax's forward dynamics into the BYOF
+# channel internally — no separate `byof=` plumbing required. Joint limits and
+# torque bounds are auto-populated from the robot's URDF.
+robot = frax.load_panda()
+dyn = ox.FraxDynamics(robot)
+q, qd = dyn.states
+(tau,) = dyn.controls
+
+n_j = robot.num_joints  # 7
+n = 4
+total_time = 1.0
+
+# Home configuration and a reachable target configuration.
+q_start = np.array([0.0, -0.7854, 0.0, -2.3562, 0.0, 1.5708, 0.7854])
+q_goal = np.array([0.6, -0.3, 0.2, -1.8, 0.3, 1.2, 0.5])
+
+q.initial = q_start
+q.final = q_goal
+qd.initial = np.zeros(n_j)
+qd.final = np.zeros(n_j)
+
+# Initial guesses: linear interpolation in joint space, zero velocity.
+#
+# The torque guess is *gravity-compensating*, not zero. frax integrates the
+# full rigid-body dynamics (mass matrix + Coriolis + gravity), so a zero-torque
+# guess implies the arm is in free-fall: forward_dynamics(q, 0, 0) returns joint
+# accelerations of tens of rad/s² at this configuration. Over a coarse time grid
+# (few nodes ⇒ large dt) the propagated guess diverges wildly from the qd≈0
+# guess, producing huge dynamics defects that drive the convex subproblem
+# infeasible. Seeding tau with g(q) makes forward_dynamics(q, 0, g(q)) ≈ 0, so
+# the qd channel of the guess is self-consistent and SCvx converges even at very
+# low node counts. (Linear ``I q̈ = τ`` models without gravity don't need this.)
+q_guess = np.linspace(q_start, q_goal, n)
+q.guess = q_guess
+qd.guess = np.zeros((n, n_j))
+# gravity_vector returns one entry per joint; tau covers only the actuated
+# joints, so take the last num_actuated_joints entries (the FraxDynamics adapter
+# slices torque bounds the same way for floating-base robots).
+grav = np.array([np.asarray(robot.gravity_vector(qi)) for qi in q_guess])
+tau.guess = grav[:, n_j - robot.num_actuated_joints :]
+
+# Box constraints from the auto-populated bounds (continuous-time enforcement).
+constraints = []
+for state in dyn.states:
+    constraints.extend([ox.ctcs(state <= state.max), ox.ctcs(state.min <= state)])
+for control in dyn.controls:
+    constraints.extend([ox.ctcs(control <= control.max), ox.ctcs(control.min <= control)])
+
+time = ox.Time(
+    initial=0.0,
+    final=ox.Minimize(total_time),
+    min=0.0,
+    max=2.0 * total_time,
+    uniform_time_grid=True,
+)
+
+problem = ox.Problem(
+    dynamics=dyn,
+    states=dyn.states,
+    controls=dyn.controls,
+    time=time,
+    constraints=constraints,
+    N=n,
+    algorithm={
+        "lam_vc": 1e1,
+        "lam_cost": 4e-1,
+        "autotuner": ox.AugmentedLagrangian(ep=1e0),
+    },
+    float_dtype="float64",
+)
+
+
+def _compute_panda_keypoints(q_traj: np.ndarray, robot) -> tuple[np.ndarray, np.ndarray]:
+    """Compute skeleton keypoints and EE positions for a joint trajectory.
+
+    Returns:
+        keypoints: ``(T, num_joints + 2, 3)`` — world base, link origins, EE tip.
+        ee_pos: ``(T, 3)`` end-effector positions from ``robot.ee_transform``.
+    """
+    q_traj = np.asarray(q_traj, dtype=float)
+    n_frames = q_traj.shape[0]
+    n_links = robot.num_joints
+    keypoints = np.zeros((n_frames, n_links + 2, 3))
+    ee_pos = np.zeros((n_frames, 3))
+
+    for t in range(n_frames):
+        q = q_traj[t]
+        links = np.asarray(robot.link_to_world_transforms(q))
+        ee = np.asarray(robot.ee_transform(q))
+        keypoints[t, 0] = (0.0, 0.0, 0.0)
+        keypoints[t, 1 : 1 + n_links] = links[:, :3, 3]
+        keypoints[t, -1] = ee[:3, 3]
+        ee_pos[t] = ee[:3, 3]
+
+    return keypoints, ee_pos
+
+
+def visualize(results, robot, q_start: np.ndarray, q_goal: np.ndarray) -> None:
+    """Animate the optimized Panda trajectory in a Viser 3D scene.
+
+    Uses frax forward kinematics (``link_to_world_transforms`` / ``ee_transform``)
+    to pose a stick-model arm, an EE trail, and sidebar joint/torque plots.
+    """
+    import plotly.graph_objects as go
+
+    from openscvx.plotting.viser import (
+        add_animated_trail,
+        add_animation_controls,
+        add_ghost_trajectory,
+        add_position_marker,
+        add_target_markers,
+        compute_velocity_colors,
+        create_server,
+    )
+    from openscvx.plotting.viser.plotly_integration import add_animated_plotly_vline
+
+    t_vec = np.asarray(results.trajectory["time"]).flatten()
+    q_traj = np.asarray(results.trajectory["q"])
+    tau_traj = np.asarray(results.trajectory["tau"])
+
+    keypoints, ee_pos = _compute_panda_keypoints(q_traj, robot)
+    n_segs = robot.num_joints + 1
+
+    ee_start = np.asarray(robot.ee_transform(q_start))[:3, 3]
+    ee_goal = np.asarray(robot.ee_transform(q_goal))[:3, 3]
+
+    ee_vel = np.gradient(ee_pos, t_vec, axis=0, edge_order=2)
+    ee_colors = compute_velocity_colors(ee_vel)
+
+    server = create_server(ee_pos, show_grid=False)
+    server.scene.add_grid("/grid", width=1.5, height=1.5, cell_size=0.25)
+    server.scene.add_frame("/origin", axes_length=0.08, axes_radius=0.003)
+
+    add_target_markers(
+        server,
+        [ee_start, ee_goal],
+        radius=0.012,
+        colors=[(100, 150, 255), (255, 80, 80)],
+    )
+
+    add_ghost_trajectory(server, ee_pos, ee_colors, point_size=0.005)
+    _, update_trail = add_animated_trail(server, ee_pos, ee_colors, point_size=0.008)
+    _, update_marker = add_position_marker(server, ee_pos, radius=0.012)
+
+    # -----------------------------------------------------------------------
+    # Load Panda CAD meshes and pre-compute per-frame link transforms.
+    # Falls back to line-segment stick model if mujoco / trimesh / menagerie
+    # assets are unavailable.
+    # -----------------------------------------------------------------------
+    n_frames = len(q_traj)
+    _use_cad_mesh = False
+    _link_meshes_local: dict = {}
+    _link_body_ids: dict = {}
+    _link_world_T: dict = {}
+    try:
+        import mujoco
+        import trimesh  # type: ignore
+
+        from openscvx.integrations.menagerie import get_model_dir
+
+        _panda_dir = get_model_dir("franka_emika_panda")
+        _mj_model_vis = mujoco.MjModel.from_xml_path(str(_panda_dir / "panda_nohand.xml"))
+        _mj_model_vis.opt.disableflags |= mujoco.mjtDisableBit.mjDSBL_CONTACT
+        _mj_data_vis = mujoco.MjData(_mj_model_vis)
+        _asset_dir = _panda_dir / "assets"
+
+        # Visual OBJ files per body (group=2 geoms from panda_nohand.xml).
+        _link_visual_files = {
+            "link0": [
+                "link0_0.obj",
+                "link0_1.obj",
+                "link0_2.obj",
+                "link0_3.obj",
+                "link0_4.obj",
+                "link0_5.obj",
+                "link0_7.obj",
+                "link0_8.obj",
+                "link0_9.obj",
+                "link0_10.obj",
+                "link0_11.obj",
+            ],
+            "link1": ["link1.obj"],
+            "link2": ["link2.obj"],
+            "link3": ["link3_0.obj", "link3_1.obj", "link3_2.obj", "link3_3.obj"],
+            "link4": ["link4_0.obj", "link4_1.obj", "link4_2.obj", "link4_3.obj"],
+            "link5": ["link5_0.obj", "link5_1.obj", "link5_2.obj"],
+            "link6": [
+                "link6_0.obj",
+                "link6_1.obj",
+                "link6_2.obj",
+                "link6_3.obj",
+                "link6_4.obj",
+                "link6_5.obj",
+                "link6_6.obj",
+                "link6_7.obj",
+                "link6_8.obj",
+                "link6_9.obj",
+                "link6_10.obj",
+                "link6_11.obj",
+                "link6_12.obj",
+                "link6_13.obj",
+                "link6_14.obj",
+                "link6_15.obj",
+                "link6_16.obj",
+            ],
+            "link7": [
+                "link7_0.obj",
+                "link7_1.obj",
+                "link7_2.obj",
+                "link7_3.obj",
+                "link7_4.obj",
+                "link7_5.obj",
+                "link7_6.obj",
+                "link7_7.obj",
+            ],
+        }
+
+        for link_name, files in _link_visual_files.items():
+            all_verts, all_faces, offset = [], [], 0
+            for fname in files:
+                obj_path = _asset_dir / fname
+                if not obj_path.exists():
+                    continue
+                tm = trimesh.load(str(obj_path), force="mesh", process=False)
+                all_verts.append(np.asarray(tm.vertices, dtype=np.float32))
+                all_faces.append(np.asarray(tm.faces, dtype=np.uint32) + offset)
+                offset += len(tm.vertices)
+            if not all_verts:
+                continue
+            _link_meshes_local[link_name] = (np.vstack(all_verts), np.vstack(all_faces))
+            _link_body_ids[link_name] = mujoco.mj_name2id(
+                _mj_model_vis, mujoco.mjtObj.mjOBJ_BODY, link_name
+            )
+
+        for name in _link_meshes_local:
+            _link_world_T[name] = np.zeros((n_frames, 4, 4))
+        for t_idx in range(n_frames):
+            _mj_data_vis.qpos[:7] = q_traj[t_idx]
+            mujoco.mj_kinematics(_mj_model_vis, _mj_data_vis)
+            for name, body_id in _link_body_ids.items():
+                T = np.eye(4)
+                T[:3, :3] = _mj_data_vis.xmat[body_id].copy().reshape(3, 3)
+                T[:3, 3] = _mj_data_vis.xpos[body_id].copy()
+                _link_world_T[name][t_idx] = T
+
+        _use_cad_mesh = len(_link_meshes_local) > 0
+        if _use_cad_mesh:
+            print(f"[viser] Loaded {len(_link_meshes_local)} Panda CAD link meshes from menagerie.")
+    except Exception as exc:
+        print(
+            f"[viser] CAD mesh unavailable "
+            f"({type(exc).__name__}: {exc}); falling back to line segments."
+        )
+
+    # -----------------------------------------------------------------------
+    # Robot body: CAD meshes when available, line segments otherwise.
+    # -----------------------------------------------------------------------
+    server.scene.add_box(
+        "/panda_base",
+        dimensions=(0.12, 0.12, 0.08),
+        position=(0.0, 0.0, 0.04),
+        color=(60, 60, 60),
+    )
+    update_robot = None
+    if _use_cad_mesh:
+        from scipy.spatial.transform import Rotation as _Rotation
+
+        def _pose_from_T(T: np.ndarray):
+            R = np.asarray(T, dtype=np.float64)[:3, :3]
+            t = T[:3, 3]
+            q_xyzw = _Rotation.from_matrix(R).as_quat()
+            wxyz = (float(q_xyzw[3]), float(q_xyzw[0]), float(q_xyzw[1]), float(q_xyzw[2]))
+            return (float(t[0]), float(t[1]), float(t[2])), wxyz
+
+        _panda_link_color = {
+            "link0": (120, 120, 120),
+            "link1": (215, 215, 218),
+            "link2": (215, 215, 218),
+            "link3": (215, 215, 218),
+            "link4": (215, 215, 218),
+            "link5": (210, 210, 215),
+            "link6": (200, 205, 215),
+            "link7": (190, 195, 210),
+        }
+        _link_handles = {}
+        for link_name, (verts_local, faces) in _link_meshes_local.items():
+            T0 = _link_world_T[link_name][0]
+            pos0, wxyz0 = _pose_from_T(T0)
+            handle = server.scene.add_mesh_simple(
+                f"/robot/{link_name}",
+                vertices=np.asarray(verts_local, dtype=np.float32, order="C"),
+                faces=faces,
+                color=_panda_link_color.get(link_name, (210, 210, 215)),
+                opacity=1.0,
+                position=pos0,
+                wxyz=wxyz0,
+            )
+            _link_handles[link_name] = handle
+
+        def update_robot(frame_idx: int) -> None:
+            for link_name, handle in _link_handles.items():
+                T = _link_world_T[link_name][frame_idx]
+                pos, wxyz = _pose_from_T(T)
+                handle.position = pos
+                handle.wxyz = wxyz
+
+    else:
+        link_rgb = np.linspace([80, 100, 180], [255, 120, 80], n_segs).astype(np.uint8)
+        link_colors = np.stack([link_rgb, link_rgb], axis=1)
+        init_points = np.stack(
+            [np.stack([keypoints[0, k], keypoints[0, k + 1]]) for k in range(n_segs)]
+        ).astype(np.float32)
+        arm_handle = server.scene.add_line_segments(
+            "/panda_links",
+            points=init_points,
+            colors=link_colors,
+            line_width=5.0,
+        )
+
+        def update_robot(frame_idx: int) -> None:
+            pts = np.stack(
+                [
+                    np.stack([keypoints[frame_idx, k], keypoints[frame_idx, k + 1]])
+                    for k in range(n_segs)
+                ]
+            ).astype(np.float32)
+            arm_handle.points = pts
+
+    fig_joints = go.Figure()
+    for j in range(robot.num_joints):
+        fig_joints.add_trace(
+            go.Scatter(
+                x=t_vec.tolist(),
+                y=np.rad2deg(q_traj[:, j]).tolist(),
+                mode="lines",
+                name=f"q{j + 1}",
+            )
+        )
+    fig_joints.update_layout(
+        title="Joint angles (deg)",
+        xaxis_title="Time (s)",
+        yaxis_title="θ (deg)",
+        margin={"l": 40, "r": 10, "t": 40, "b": 40},
+    )
+
+    fig_tau = go.Figure()
+    for j in range(robot.num_actuated_joints):
+        fig_tau.add_trace(
+            go.Scatter(
+                x=t_vec.tolist(),
+                y=tau_traj[:, j].tolist(),
+                mode="lines",
+                name=f"τ{j + 1}",
+            )
+        )
+    fig_tau.update_layout(
+        title="Joint torques (Nm)",
+        xaxis_title="Time (s)",
+        yaxis_title="τ (Nm)",
+        margin={"l": 40, "r": 10, "t": 40, "b": 40},
+    )
+
+    with server.gui.add_folder("Plots"):
+        _, update_joints = add_animated_plotly_vline(server, fig_joints, t_vec, folder_name=None)
+        _, update_tau = add_animated_plotly_vline(server, fig_tau, t_vec, folder_name=None)
+
+    add_animation_controls(
+        server,
+        t_vec,
+        [update_robot, update_trail, update_marker, update_joints, update_tau],
+    )
+    server.sleep_forever()
+
+
+if __name__ == "__main__":
+    print("Franka Panda joint-space point-to-point via frax dynamics")
+    print("=" * 60)
+    print(f"num_joints = {n_j}, N = {n}")
+    print()
+
+    problem.initialize()
+    problem.solve()
+    results = problem.post_process()
+
+    q_final = np.asarray(results.nodes["q"][-1])
+    err = np.linalg.norm(q_final - q_goal)
+    print()
+    print(f"Final joint config:  {np.array2string(q_final, precision=3)}")
+    print(f"Target joint config: {np.array2string(q_goal, precision=3)}")
+    print(f"||q_final - q_goal|| = {err:.4e}")
+    print()
+    print("Launching Viser visualization (Ctrl+C to exit)...")
+    visualize(results, robot, q_start, q_goal)

--- a/examples/frax/panda_frax_pick_place.py
+++ b/examples/frax/panda_frax_pick_place.py
@@ -1,0 +1,586 @@
+"""Franka Panda pick-and-place via frax rigid-body dynamics.
+
+Mirrors ``examples/arm/franka_fr3v2_pick_place.py`` but replaces the
+simplified diagonal-inertia model (I q̈ = τ) and hand-coded PoE FK with:
+
+  - ``FraxDynamics`` — full rigid-body forward dynamics from the frax URDF.
+  - frax FK (``ee_transform`` / ``link_to_world_transforms``) for all task
+    constraints via the BYOF channel.
+  - frax collision spheres (``link_collision_positions``,
+    ``self_collision_distances``) for obstacle and self-collision avoidance,
+    also via BYOF CTCS.
+
+Task
+----
+Six-waypoint pick-and-place::
+
+    home → pre_grasp → grasp → pre_grasp → pre_place → place
+
+Waypoints are derived from forward kinematics of known-reachable joint
+configurations, so the gravity-compensated joint-space initial guess is
+already consistent with the dynamics and the waypoint targets.
+
+Constraints
+-----------
+- Box bounds: CTCS from ``FraxDynamics`` auto-populated limits.
+- EE position at each of the six waypoint nodes (1 cm tolerance), nodal.
+- EE stays above floor (z ≥ 0), CTCS.
+- Self-collision avoidance via ``robot.self_collision_distances``, CTCS.
+- Spherical obstacle clearance via ``robot.link_collision_positions``, CTCS.
+
+Requires
+--------
+    pip install openscvx[frax]
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import jax.numpy as jnp
+import numpy as np
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+grandparent_dir = os.path.dirname(os.path.dirname(current_dir))
+sys.path.append(grandparent_dir)
+
+try:
+    import frax
+except ImportError:
+    print(
+        "frax is not installed. Install with: pip install openscvx[frax]",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+import openscvx as ox
+
+# =============================================================================
+# Robot and dynamics
+# =============================================================================
+
+robot = frax.load_panda()
+dyn = ox.FraxDynamics(robot)
+q, qd = dyn.states
+(tau,) = dyn.controls
+n_j = robot.num_joints  # 7
+
+# =============================================================================
+# Pick-and-place task geometry
+# =============================================================================
+# Waypoint joint configurations — chosen so that frax FK gives clearly
+# reachable EE positions.  Using FK-derived targets means the joint-space
+# linear-interpolation initial guess is already at the right EE locations.
+
+q_home = np.array([0.0, -0.7854, 0.0, -2.3562, 0.0, 1.5708, 0.7854])
+q_pre_grasp = np.array([0.5, -0.7854, 0.0, -2.3562, 0.0, 1.5708, 0.7854])
+q_grasp = np.array([0.5, -0.3, 0.0, -2.5, 0.0, 2.2, 0.7854])
+q_pre_place = np.array([-0.5, -0.7854, 0.0, -2.3562, 0.0, 1.5708, 0.7854])
+q_place = np.array([-0.5, -0.3, 0.0, -2.5, 0.0, 2.2, 0.7854])
+
+# Reference configs ordered along the trajectory (pre_grasp appears twice)
+_wp_configs = [q_home, q_pre_grasp, q_grasp, q_pre_grasp, q_pre_place, q_place]
+_wp_names = ["home", "pre_grasp", "grasp", "pre_grasp", "pre_place", "place"]
+
+# Compute EE targets from FK (exact, no IK error)
+waypoint_ee_positions = [np.asarray(robot.ee_transform(q_i))[:3, 3] for q_i in _wp_configs]
+
+nodes_per_segment = 4
+n_segments = len(_wp_configs) - 1  # 5
+n = nodes_per_segment * n_segments + 1  # 21
+waypoint_nodes = [i * nodes_per_segment for i in range(len(_wp_configs))]
+total_time = 6.0
+ee_tol = 0.01  # m — nodal EE position tolerance
+
+# Spherical obstacle (sits in the sweep path between home and grasp)
+obstacle_center = np.array([0.38, 0.08, 0.43])
+obstacle_radius = 0.07
+
+# =============================================================================
+# States and controls (from FraxDynamics)
+# =============================================================================
+
+q.initial = q_home
+q.final = [("free", 0.0)] * n_j
+qd.initial = np.zeros(n_j)
+qd.final = np.zeros(n_j)
+
+# =============================================================================
+# Initial guess
+# =============================================================================
+# Joint-space linear interpolation through the FK-derived waypoint configs.
+# Torque seeded with gravity compensation (not zero) for dynamics consistency.
+
+q_guess = ox.init.linspace(_wp_configs, waypoint_nodes)
+q.guess = q_guess
+qd.guess = np.zeros((n, n_j))
+grav = np.array([np.asarray(robot.gravity_vector(qi)) for qi in q_guess])
+tau.guess = grav[:, n_j - robot.num_actuated_joints :]
+
+# =============================================================================
+# Box constraints (symbolic CTCS from FraxDynamics bounds)
+# =============================================================================
+
+constraints = []
+for state in dyn.states:
+    constraints.extend([ox.ctcs(state <= state.max), ox.ctcs(state.min <= state)])
+for control in dyn.controls:
+    constraints.extend([ox.ctcs(control <= control.max), ox.ctcs(control.min <= control)])
+
+# =============================================================================
+# BYOF: frax-based task and safety constraints
+# =============================================================================
+# All BYOF CTCS use idx=0 (sharing the same augmented state as the symbolic
+# box CTCS above).  Sign convention: g <= 0 means satisfied.
+
+
+# --- Nodal EE position constraints (one per waypoint) ---------------------
+# Use a factory to capture each waypoint array without adding extra parameters
+# to the BYOF function signature (which must be exactly (x, u, node, params)).
+def _make_ee_pos_residual(wp_jnp):
+    def _fn(x, u, node, params):
+        q_val = x[q.slice]
+        T = robot.ee_transform(q_val)
+        p = jnp.asarray(T)[:3, 3]
+        return jnp.linalg.norm(p - wp_jnp) - ee_tol
+
+    return _fn
+
+
+_byof_nodal: list[dict] = [
+    {"constraint_fn": _make_ee_pos_residual(jnp.array(wp_ee)), "nodes": [node]}
+    for wp_ee, node in zip(waypoint_ee_positions, waypoint_nodes)
+]
+
+
+# --- CTCS: EE stays above floor -------------------------------------------
+def _floor_ctcs(x, u, node, params):
+    q_val = x[q.slice]
+    T = robot.ee_transform(q_val)
+    return -jnp.asarray(T)[2, 3]  # <= 0 when EE z >= 0
+
+
+# --- CTCS: self-collision avoidance (frax sphere-pair distances) -----------
+# robot.self_collision_distances returns gap distances for non-adjacent body
+# sphere pairs; positive = no collision.  We want min(dists) >= 0.
+def _self_collision_ctcs(x, u, node, params):
+    q_val = x[q.slice]
+    dists = robot.self_collision_distances(q_val)
+    return -jnp.min(dists)  # <= 0 when all pairwise distances >= 0
+
+
+# --- CTCS: obstacle clearance (frax link collision spheres) ---------------
+_obs_center_jnp = jnp.array(obstacle_center)
+_flat_radii_jnp = jnp.array(robot.flat_collision_radii)
+
+
+def _obstacle_ctcs(x, u, node, params):
+    q_val = x[q.slice]
+    centers = robot.link_collision_positions(q_val)  # (n_spheres, 3)
+    dists = jnp.linalg.norm(centers - _obs_center_jnp, axis=1)
+    clearances = dists - _flat_radii_jnp - obstacle_radius
+    return -jnp.min(clearances)  # <= 0 when all clearances >= 0
+
+
+_byof_ctcs = [
+    {"constraint_fn": _floor_ctcs},
+    {"constraint_fn": _self_collision_ctcs},
+    {"constraint_fn": _obstacle_ctcs},
+]
+
+byof: dict = {
+    "nodal_constraints": _byof_nodal,
+    "ctcs_constraints": _byof_ctcs,
+}
+
+# =============================================================================
+# Time and Problem
+# =============================================================================
+
+time = ox.Time(
+    initial=0.0,
+    final=ox.Minimize(total_time),
+    min=0.0,
+    max=2.0 * total_time,
+)
+
+problem = ox.Problem(
+    dynamics=dyn,
+    states=dyn.states,
+    controls=dyn.controls,
+    time=time,
+    constraints=constraints,
+    byof=byof,
+    N=n,
+    algorithm={
+        "lam_vb": 1e1,
+        "lam_vc": 1e2,
+        "lam_cost": 1e-1,
+    },
+    float_dtype="float64",
+)
+
+# =============================================================================
+# Visualization helpers
+# =============================================================================
+
+
+def _compute_panda_keypoints(
+    q_traj: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return stick-model keypoints and EE positions using frax FK."""
+    q_traj = np.asarray(q_traj)
+    n_frames = q_traj.shape[0]
+    n_links = robot.num_joints
+    keypoints = np.zeros((n_frames, n_links + 2, 3))
+    ee_pos = np.zeros((n_frames, 3))
+
+    for t in range(n_frames):
+        qi = q_traj[t]
+        links = np.asarray(robot.link_to_world_transforms(qi))
+        ee = np.asarray(robot.ee_transform(qi))
+        keypoints[t, 0] = (0.0, 0.0, 0.0)
+        keypoints[t, 1 : 1 + n_links] = links[:, :3, 3]
+        keypoints[t, -1] = ee[:3, 3]
+        ee_pos[t] = ee[:3, 3]
+
+    return keypoints, ee_pos
+
+
+def _q_from_V_multishot(
+    V: np.ndarray,
+    n_x: int,
+    n_u: int,
+    q_slice: slice,
+    t_nodes: np.ndarray,
+) -> tuple[np.ndarray | None, np.ndarray | None]:
+    """Unpack joint angles from the SCP multi-shoot V matrix.
+
+    V has shape ``((N-1) * i4, n_substeps)`` where
+    ``i4 = n_x + n_x² + 2·n_x·n_u``.  The first ``n_x`` rows of each
+    ``i4``-row block are the integrated state at that substep.
+
+    Returns ``(q_traj, t_traj)`` or ``(None, None)`` if extraction fails.
+    """
+    i4 = n_x + n_x * n_x + 2 * n_x * n_u
+    n_rows, n_sub = V.shape
+    if i4 <= 0 or n_rows % i4 != 0 or n_sub < 1:
+        return None, None
+    n_seg = n_rows // i4
+    if n_seg != len(t_nodes) - 1:
+        return None, None
+    q_rows: list[np.ndarray] = []
+    t_rows: list[float] = []
+    for seg in range(n_seg):
+        t0, t1 = float(t_nodes[seg]), float(t_nodes[seg + 1])
+        j0 = 0 if seg == 0 else 1  # skip duplicated segment-start sample
+        for j in range(j0, n_sub):
+            alpha = j / (n_sub - 1) if n_sub > 1 else 0.0
+            x_vec = np.asarray(V[seg * i4 : seg * i4 + n_x, j], dtype=np.float64)
+            q_rows.append(x_vec[q_slice])
+            t_rows.append((1.0 - alpha) * t0 + alpha * t1)
+    if not q_rows:
+        return None, None
+    return np.stack(q_rows), np.asarray(t_rows, dtype=np.float64)
+
+
+def visualize(results, robot) -> None:
+    """Animate the optimised trajectory in Viser (CAD mesh + markers).
+
+    Uses the multi-shoot V matrix from the final SCP iteration when available
+    (``results.discretization_history[-1]``), showing the per-segment
+    integration substeps exactly as the solver used them.  Falls back to the
+    post-process single propagation (``results.trajectory``) if V is absent.
+    """
+    from openscvx.plotting.viser import (
+        add_animated_trail,
+        add_animation_controls,
+        add_ellipsoid_obstacles,
+        add_position_marker,
+        add_target_markers,
+        compute_velocity_colors,
+        create_server,
+    )
+
+    t_vec = np.asarray(results.trajectory["time"]).flatten()
+    q_traj = np.asarray(results.trajectory["q"])
+
+    # ── Prefer multishot V over post-process single propagation ──────────────
+    _dh = getattr(results, "discretization_history", None) or []
+    if _dh:
+        _V = np.asarray(_dh[-1], dtype=np.float64)
+        _n_x = results.x.shape[1]
+        _n_u = results.u.shape[1]
+        _t_nodes_raw = results.nodes.get("time", None)
+        if _t_nodes_raw is None:
+            _t_nodes = np.linspace(0.0, float(t_vec[-1]), len(results.nodes["q"]))
+        else:
+            _t_nodes = np.asarray(_t_nodes_raw).flatten()
+        _q_ms, _t_ms = _q_from_V_multishot(_V, _n_x, _n_u, q.slice, _t_nodes)
+        if _q_ms is not None:
+            print(f"[viser] Multishot V: {len(_q_ms)} frames across {len(_t_nodes) - 1} segments.")
+            q_traj, t_vec = _q_ms, _t_ms
+        else:
+            print("[viser] Multishot V extraction failed; using post-process trajectory.")
+
+    n_frames = len(q_traj)
+    n_segs = robot.num_joints + 1
+
+    keypoints, ee_pos = _compute_panda_keypoints(q_traj)
+    ee_colors = compute_velocity_colors(np.gradient(ee_pos, t_vec, axis=0, edge_order=2))
+
+    server = create_server(ee_pos, show_grid=False)
+    server.scene.add_grid("/grid", width=1.5, height=1.5, cell_size=0.2)
+    server.scene.add_frame("/origin", axes_length=0.08, axes_radius=0.003)
+
+    # Obstacle sphere
+    add_ellipsoid_obstacles(
+        server,
+        centers=[obstacle_center],
+        radii=[np.full(3, 1.0 / obstacle_radius)],
+    )
+
+    # Waypoint markers
+    _wp_colors = {
+        "home": (100, 150, 255),
+        "pre_grasp": (255, 180, 50),
+        "grasp": (255, 50, 50),
+        "pre_place": (255, 180, 50),
+        "place": (255, 50, 50),
+    }
+    add_target_markers(
+        server,
+        waypoint_ee_positions,
+        radius=0.012,
+        colors=[_wp_colors.get(n, (200, 200, 200)) for n in _wp_names],
+        show_trails=False,
+    )
+
+    _, update_trail = add_animated_trail(server, ee_pos, ee_colors, point_size=0.008)
+    _, update_marker = add_position_marker(server, ee_pos, radius=0.012)
+
+    # -----------------------------------------------------------------------
+    # Load Panda CAD meshes and pre-compute per-frame link transforms.
+    # Falls back to line-segment stick model if mujoco / trimesh / menagerie
+    # assets are unavailable.
+    # -----------------------------------------------------------------------
+    _use_cad_mesh = False
+    _link_meshes_local: dict = {}
+    _link_body_ids: dict = {}
+    _link_world_T: dict = {}
+    try:
+        import mujoco
+        import trimesh  # type: ignore
+
+        from openscvx.integrations.menagerie import get_model_dir
+
+        _panda_dir = get_model_dir("franka_emika_panda")
+        _mj_model_vis = mujoco.MjModel.from_xml_path(str(_panda_dir / "panda_nohand.xml"))
+        _mj_model_vis.opt.disableflags |= mujoco.mjtDisableBit.mjDSBL_CONTACT
+        _mj_data_vis = mujoco.MjData(_mj_model_vis)
+        _asset_dir = _panda_dir / "assets"
+
+        _link_visual_files = {
+            "link0": [
+                "link0_0.obj",
+                "link0_1.obj",
+                "link0_2.obj",
+                "link0_3.obj",
+                "link0_4.obj",
+                "link0_5.obj",
+                "link0_7.obj",
+                "link0_8.obj",
+                "link0_9.obj",
+                "link0_10.obj",
+                "link0_11.obj",
+            ],
+            "link1": ["link1.obj"],
+            "link2": ["link2.obj"],
+            "link3": ["link3_0.obj", "link3_1.obj", "link3_2.obj", "link3_3.obj"],
+            "link4": ["link4_0.obj", "link4_1.obj", "link4_2.obj", "link4_3.obj"],
+            "link5": ["link5_0.obj", "link5_1.obj", "link5_2.obj"],
+            "link6": [
+                "link6_0.obj",
+                "link6_1.obj",
+                "link6_2.obj",
+                "link6_3.obj",
+                "link6_4.obj",
+                "link6_5.obj",
+                "link6_6.obj",
+                "link6_7.obj",
+                "link6_8.obj",
+                "link6_9.obj",
+                "link6_10.obj",
+                "link6_11.obj",
+                "link6_12.obj",
+                "link6_13.obj",
+                "link6_14.obj",
+                "link6_15.obj",
+                "link6_16.obj",
+            ],
+            "link7": [
+                "link7_0.obj",
+                "link7_1.obj",
+                "link7_2.obj",
+                "link7_3.obj",
+                "link7_4.obj",
+                "link7_5.obj",
+                "link7_6.obj",
+                "link7_7.obj",
+            ],
+        }
+
+        for link_name, files in _link_visual_files.items():
+            all_verts, all_faces, offset = [], [], 0
+            for fname in files:
+                obj_path = _asset_dir / fname
+                if not obj_path.exists():
+                    continue
+                tm = trimesh.load(str(obj_path), force="mesh", process=False)
+                all_verts.append(np.asarray(tm.vertices, dtype=np.float32))
+                all_faces.append(np.asarray(tm.faces, dtype=np.uint32) + offset)
+                offset += len(tm.vertices)
+            if not all_verts:
+                continue
+            _link_meshes_local[link_name] = (np.vstack(all_verts), np.vstack(all_faces))
+            _link_body_ids[link_name] = mujoco.mj_name2id(
+                _mj_model_vis, mujoco.mjtObj.mjOBJ_BODY, link_name
+            )
+
+        for name in _link_meshes_local:
+            _link_world_T[name] = np.zeros((n_frames, 4, 4))
+        for t_idx in range(n_frames):
+            _mj_data_vis.qpos[:7] = q_traj[t_idx]
+            mujoco.mj_kinematics(_mj_model_vis, _mj_data_vis)
+            for name, body_id in _link_body_ids.items():
+                T = np.eye(4)
+                T[:3, :3] = _mj_data_vis.xmat[body_id].copy().reshape(3, 3)
+                T[:3, 3] = _mj_data_vis.xpos[body_id].copy()
+                _link_world_T[name][t_idx] = T
+
+        _use_cad_mesh = len(_link_meshes_local) > 0
+        if _use_cad_mesh:
+            print(f"[viser] Loaded {len(_link_meshes_local)} Panda CAD link meshes from menagerie.")
+    except Exception as exc:
+        print(
+            f"[viser] CAD mesh unavailable "
+            f"({type(exc).__name__}: {exc}); falling back to line segments."
+        )
+
+    # -----------------------------------------------------------------------
+    # Robot body: CAD meshes when available, line segments otherwise.
+    # -----------------------------------------------------------------------
+    server.scene.add_box(
+        "/panda_base",
+        dimensions=(0.12, 0.12, 0.08),
+        position=(0.0, 0.0, 0.04),
+        color=(60, 60, 60),
+    )
+    update_robot = None
+    if _use_cad_mesh:
+        from scipy.spatial.transform import Rotation as _Rotation
+
+        def _pose_from_T(T: np.ndarray):
+            R = np.asarray(T, dtype=np.float64)[:3, :3]
+            t = T[:3, 3]
+            q_xyzw = _Rotation.from_matrix(R).as_quat()
+            wxyz = (float(q_xyzw[3]), float(q_xyzw[0]), float(q_xyzw[1]), float(q_xyzw[2]))
+            return (float(t[0]), float(t[1]), float(t[2])), wxyz
+
+        _panda_link_color = {
+            "link0": (120, 120, 120),
+            "link1": (215, 215, 218),
+            "link2": (215, 215, 218),
+            "link3": (215, 215, 218),
+            "link4": (215, 215, 218),
+            "link5": (210, 210, 215),
+            "link6": (200, 205, 215),
+            "link7": (190, 195, 210),
+        }
+        _link_handles = {}
+        for link_name, (verts_local, faces) in _link_meshes_local.items():
+            T0 = _link_world_T[link_name][0]
+            pos0, wxyz0 = _pose_from_T(T0)
+            handle = server.scene.add_mesh_simple(
+                f"/robot/{link_name}",
+                vertices=np.asarray(verts_local, dtype=np.float32, order="C"),
+                faces=faces,
+                color=_panda_link_color.get(link_name, (210, 210, 215)),
+                opacity=1.0,
+                position=pos0,
+                wxyz=wxyz0,
+            )
+            _link_handles[link_name] = handle
+
+        def update_robot(frame_idx: int) -> None:
+            for link_name, handle in _link_handles.items():
+                T = _link_world_T[link_name][frame_idx]
+                pos, wxyz = _pose_from_T(T)
+                handle.position = pos
+                handle.wxyz = wxyz
+
+    else:
+        link_rgb = np.linspace([80, 100, 180], [255, 120, 80], n_segs).astype(np.uint8)
+        link_colors = np.stack([link_rgb, link_rgb], axis=1)
+
+        def _arm_segments(frame_idx: int) -> np.ndarray:
+            pts = np.zeros((n_segs, 2, 3), dtype=np.float32)
+            pts[0] = [np.zeros(3), keypoints[frame_idx, 0]]
+            for k in range(robot.num_joints - 1):
+                pts[k + 1] = [keypoints[frame_idx, k], keypoints[frame_idx, k + 1]]
+            pts[-1] = [keypoints[frame_idx, -2], keypoints[frame_idx, -1]]
+            return pts
+
+        arm_handle = server.scene.add_line_segments(
+            "/panda_links",
+            points=_arm_segments(0),
+            colors=link_colors,
+            line_width=5.0,
+        )
+
+        def update_robot(frame_idx: int) -> None:
+            arm_handle.points = _arm_segments(frame_idx)
+
+    add_animation_controls(
+        server,
+        t_vec,
+        [update_robot, update_trail, update_marker],
+        loop=True,
+    )
+    server.sleep_forever()
+
+
+# =============================================================================
+# Main
+# =============================================================================
+
+if __name__ == "__main__":
+    print("Franka Panda Pick-and-Place via frax dynamics")
+    print("=" * 60)
+    print(f"Nodes: {n}  ({nodes_per_segment} per segment, {n_segments} segments)")
+    print(f"Obstacle: center={list(np.round(obstacle_center, 3))} m, r={obstacle_radius} m")
+    for name, pos, node in zip(_wp_names, waypoint_ee_positions, waypoint_nodes):
+        print(f"  {name:>12s} (node {node:2d}): EE={list(np.round(pos, 3))}")
+    print()
+
+    problem.initialize()
+    problem.solve()
+    results = problem.post_process()
+
+    q_traj = np.asarray(results.trajectory["q"])
+    ee_traj = np.array([np.asarray(robot.ee_transform(qi))[:3, 3] for qi in q_traj])
+
+    print("\nResults:")
+    for name, wp_ee, node in zip(_wp_names, waypoint_ee_positions, waypoint_nodes):
+        frame_idx = int(round(node / (n - 1) * (len(ee_traj) - 1)))
+        err = np.linalg.norm(ee_traj[frame_idx] - wp_ee)
+        print(
+            f"  {name:>12s}: "
+            f"EE=[{ee_traj[frame_idx, 0]:.3f}, "
+            f"{ee_traj[frame_idx, 1]:.3f}, "
+            f"{ee_traj[frame_idx, 2]:.3f}]  err={err:.4f} m"
+        )
+    print(f"\nCTCS violation: {results.ctcs_violation}")
+    print("\nLaunching Viser visualization (Ctrl+C to exit)...")
+    visualize(results, robot)

--- a/examples/frax/panda_frax_viewplanning.py
+++ b/examples/frax/panda_frax_viewplanning.py
@@ -1,0 +1,610 @@
+"""Franka Panda view planning — wrist camera viewcone via frax rigid-body dynamics.
+
+Mirrors ``examples/arm/franka_fr3v2_viewplanning.py`` but replaces the
+simplified diagonal-inertia model (I q̈ = τ) and PoE FK with:
+
+  - ``FraxDynamics`` — full rigid-body forward dynamics.
+  - frax FK (``ee_transform``) for both the EE goal constraint and the
+    per-target viewcone inequality, all via BYOF.
+
+Task
+----
+Move the EE from a start position to a goal position (1 cm tolerance at the
+terminal node) while continuously satisfying a wrist-camera viewcone constraint
+for each of the three workspace viewpoint targets::
+
+    ||A_cone @ p_sensor|| - c^T @ p_sensor <= 0
+    p_sensor = R_sb @ R_ee^T @ (p_target - p_ee)
+
+With α_x = α_y = 8 (half-angle ≈ 22.5°) the constraint is non-trivially
+active: it forces the optimizer to keep the arm oriented toward the targets
+throughout the sweep, not just at the start and goal.
+
+Requires
+--------
+    pip install openscvx[frax]
+    pip install jaxlie          # for SO3 quaternion extraction in visualization
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import jax.numpy as jnp
+import numpy as np
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+grandparent_dir = os.path.dirname(os.path.dirname(current_dir))
+sys.path.append(grandparent_dir)
+
+try:
+    import frax
+except ImportError:
+    print(
+        "frax is not installed. Install with: pip install openscvx[frax]",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+import openscvx as ox
+
+# =============================================================================
+# Robot and dynamics
+# =============================================================================
+
+robot = frax.load_panda()
+dyn = ox.FraxDynamics(robot)
+q, qd = dyn.states
+(tau,) = dyn.controls
+n_j = robot.num_joints  # 7
+
+# =============================================================================
+# Wrist camera (viewcone) — same convention as 7_dof_arm_vp.py
+# =============================================================================
+# Camera boresight = EE local z-axis.  At the home configuration the EE z-axis
+# points world −z (straight down).  The constraint ||A_cone p_s|| ≤ c^T p_s
+# (with c=[0,0,1]) enforces that each viewpoint lies within a symmetric pyramid
+# of half-angle π/α around the boresight.
+
+alpha_x = 6.0
+alpha_y = 6.0
+A_cone = np.diag(
+    [
+        1.0 / np.tan(np.pi / alpha_x),
+        1.0 / np.tan(np.pi / alpha_y),
+        0.0,
+    ]
+)
+_c_np = np.array([0.0, 0.0, 1.0])
+norm_type = 2
+R_sb = np.eye(3)  # sensor body = EE body frame
+
+# Viewpoint targets: three table-level positions in front of the arm.
+# The arm sweeps laterally (left ↔ right), so the outer targets (y = ±0.08)
+# are naturally off-axis and force the optimizer to actively aim the camera.
+vp_targets = np.array(
+    [
+        [0.38, 0.08, 0.08],
+        [0.42, 0.00, 0.08],
+        [0.38, -0.08, 0.08],
+    ]
+)
+
+# =============================================================================
+# Discretisation
+# =============================================================================
+
+n = 10
+total_time = 5.0
+
+# =============================================================================
+# Start / goal configurations
+# =============================================================================
+# q_start: home-like config with J1 rotated 0.4 rad right → EE sweeps left in Y.
+# q_goal:  mirror (J1 = −0.4) → EE sweeps right in Y.
+# Keeping the remaining joints at the "home" values means the gravity-compensated
+# torque guess is consistent with the full frax dynamics from the very first
+# iteration.
+
+q_start = np.array([0.4, -0.7854, 0.0, -2.3562, 0.0, 1.5708, 0.7854])
+q_goal_config = np.array([-0.4, -0.7854, 0.0, -2.3562, 0.0, 1.5708, 0.7854])
+
+home_ee_pos = np.asarray(robot.ee_transform(q_start))[:3, 3].copy()
+goal_ee_pos = np.asarray(robot.ee_transform(q_goal_config))[:3, 3].copy()
+
+# =============================================================================
+# States and controls
+# =============================================================================
+
+q.initial = q_start
+q.final = [("free", 0.0)] * n_j
+qd.initial = np.zeros(n_j)
+qd.final = np.zeros(n_j)
+
+# =============================================================================
+# Initial guess
+# =============================================================================
+
+q_guess = np.linspace(q_start, q_goal_config, n)
+q.guess = q_guess
+qd.guess = np.zeros((n, n_j))
+grav = np.array([np.asarray(robot.gravity_vector(qi)) for qi in q_guess])
+tau.guess = grav[:, n_j - robot.num_actuated_joints :]
+
+# =============================================================================
+# Box constraints (symbolic CTCS from FraxDynamics bounds)
+# =============================================================================
+
+constraints = []
+for state in dyn.states:
+    constraints.extend([ox.ctcs(state <= state.max), ox.ctcs(state.min <= state)])
+for control in dyn.controls:
+    constraints.extend([ox.ctcs(control <= control.max), ox.ctcs(control.min <= control)])
+
+# =============================================================================
+# BYOF: frax-based task and viewcone constraints
+# =============================================================================
+# Sign convention: g(x,u) <= 0 means satisfied.
+# All BYOF CTCS share idx=0 with the symbolic box CTCS above.
+
+_goal_jnp = jnp.array(goal_ee_pos)
+ee_tol = 0.01  # m
+
+
+# --- Nodal: EE position at the goal node -----------------------------------
+def _goal_ee_residual(x, u, node, params):
+    q_val = x[q.slice]
+    T = robot.ee_transform(q_val)
+    p = jnp.asarray(T)[:3, 3]
+    return jnp.linalg.norm(p - _goal_jnp) - ee_tol
+
+
+# --- CTCS: EE stays above floor --------------------------------------------
+def _floor_ctcs(x, u, node, params):
+    q_val = x[q.slice]
+    T = robot.ee_transform(q_val)
+    return -jnp.asarray(T)[2, 3]  # <= 0 when EE z >= 0
+
+
+# --- CTCS: viewcone constraints (one per target) ---------------------------
+_A_cone_jnp = jnp.array(A_cone)
+_c_jnp = jnp.array(_c_np)
+_R_sb_jnp = jnp.array(R_sb)
+
+
+# Use a factory so each viewpoint is captured cleanly without adding extra
+# parameters to the BYOF function signature (must be exactly (x, u, node, params)).
+def _make_vp_ctcs(pt_jnp):
+    def _fn(x, u, node, params):
+        q_val = x[q.slice]
+        T = robot.ee_transform(q_val)
+        p_ee = jnp.asarray(T)[:3, 3]
+        R_ee = jnp.asarray(T)[:3, :3]
+        p_s = _R_sb_jnp @ R_ee.T @ (pt_jnp - p_ee)
+        # Use sqrt(sum + eps) rather than jnp.linalg.norm to avoid a zero-
+        # gradient singularity when the viewpoint sits exactly on the boresight
+        # (the last row of A_cone is 0, so the z component always vanishes).
+        vec = _A_cone_jnp @ p_s
+        safe_norm = jnp.sqrt(jnp.sum(vec**2) + 1e-30)
+        return safe_norm - (_c_jnp @ p_s)
+
+    return _fn
+
+
+_byof_ctcs_vp = [{"constraint_fn": _make_vp_ctcs(jnp.array(pt))} for pt in vp_targets]
+
+byof: dict = {
+    "nodal_constraints": [
+        {"constraint_fn": _goal_ee_residual, "nodes": [n - 1]},
+    ],
+    "ctcs_constraints": [{"constraint_fn": _floor_ctcs}] + _byof_ctcs_vp,
+}
+
+# =============================================================================
+# Time and Problem
+# =============================================================================
+
+time = ox.Time(
+    initial=0.0,
+    final=ox.Minimize(total_time),
+    min=0.0,
+    max=total_time,
+)
+
+problem = ox.Problem(
+    dynamics=dyn,
+    states=dyn.states,
+    controls=dyn.controls,
+    time=time,
+    constraints=constraints,
+    byof=byof,
+    N=n,
+    algorithm={
+        "lam_vb": 1e0,
+        "lam_vc": 1e1,
+        # "autotuner": ox.AugmentedLagrangian(eta_lambda=1e0),
+        "autotuner": ox.ConstantProximalWeight(),
+    },
+    float_dtype="float64",
+)
+
+problem.settings.prp.dt = 0.01
+
+# =============================================================================
+# Visualization
+# =============================================================================
+
+
+def _compute_panda_keypoints(
+    q_traj: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return stick-model keypoints, EE positions, and EE quaternions (wxyz)."""
+    try:
+        import jaxlie
+    except ImportError:
+        jaxlie = None
+
+    q_traj = np.asarray(q_traj)
+    n_frames = q_traj.shape[0]
+    n_links = robot.num_joints
+    keypoints = np.zeros((n_frames, n_links + 2, 3))
+    ee_pos = np.zeros((n_frames, 3))
+    ee_quats = np.zeros((n_frames, 4))
+
+    for t in range(n_frames):
+        qi = q_traj[t]
+        links = np.asarray(robot.link_to_world_transforms(qi))
+        T_ee = np.asarray(robot.ee_transform(qi))
+        keypoints[t, 0] = (0.0, 0.0, 0.0)
+        keypoints[t, 1 : 1 + n_links] = links[:, :3, 3]
+        keypoints[t, -1] = T_ee[:3, 3]
+        ee_pos[t] = T_ee[:3, 3]
+        if jaxlie is not None:
+            ee_quats[t] = jaxlie.SO3.from_matrix(T_ee[:3, :3]).wxyz
+        else:
+            # Fallback: identity quaternion
+            ee_quats[t] = [1.0, 0.0, 0.0, 0.0]
+
+    return keypoints, ee_pos, ee_quats
+
+
+def _q_from_V_multishot(
+    V: np.ndarray,
+    n_x: int,
+    n_u: int,
+    q_slice: slice,
+    t_nodes: np.ndarray,
+) -> tuple[np.ndarray | None, np.ndarray | None]:
+    """Unpack joint angles from the SCP multi-shoot V matrix.
+
+    V has shape ``((N-1) * i4, n_substeps)`` where
+    ``i4 = n_x + n_x² + 2·n_x·n_u``.  The first ``n_x`` rows of each
+    ``i4``-row block are the integrated state at that substep.
+
+    Returns ``(q_traj, t_traj)`` or ``(None, None)`` if extraction fails.
+    """
+    i4 = n_x + n_x * n_x + 2 * n_x * n_u
+    n_rows, n_sub = V.shape
+    if i4 <= 0 or n_rows % i4 != 0 or n_sub < 1:
+        return None, None
+    n_seg = n_rows // i4
+    if n_seg != len(t_nodes) - 1:
+        return None, None
+    q_rows: list[np.ndarray] = []
+    t_rows: list[float] = []
+    for seg in range(n_seg):
+        t0, t1 = float(t_nodes[seg]), float(t_nodes[seg + 1])
+        j0 = 0 if seg == 0 else 1  # skip duplicated segment-start sample
+        for j in range(j0, n_sub):
+            alpha = j / (n_sub - 1) if n_sub > 1 else 0.0
+            x_vec = np.asarray(V[seg * i4 : seg * i4 + n_x, j], dtype=np.float64)
+            q_rows.append(x_vec[q_slice])
+            t_rows.append((1.0 - alpha) * t0 + alpha * t1)
+    if not q_rows:
+        return None, None
+    return np.stack(q_rows), np.asarray(t_rows, dtype=np.float64)
+
+
+def visualize(results, robot) -> None:
+    """Animate the trajectory in Viser: CAD mesh + viewcone + markers.
+
+    Uses the multi-shoot V matrix from the final SCP iteration when available
+    (``results.discretization_history[-1]``), showing the per-segment
+    integration substeps exactly as the solver used them.  Falls back to the
+    post-process single propagation (``results.trajectory``) if V is absent.
+    """
+    from openscvx.plotting.viser import (
+        add_animated_trail,
+        add_animation_controls,
+        add_ghost_trajectory,
+        add_position_marker,
+        add_target_markers,
+        add_viewcone,
+        compute_velocity_colors,
+        create_server,
+    )
+
+    t_vec = np.asarray(results.trajectory["time"]).flatten()
+    q_traj = np.asarray(results.trajectory["q"])
+
+    # ── Prefer multishot V over post-process single propagation ──────────────
+    _dh = getattr(results, "discretization_history", None) or []
+    if _dh:
+        _V = np.asarray(_dh[-1], dtype=np.float64)
+        _n_x = results.x.shape[1]
+        _n_u = results.u.shape[1]
+        _t_nodes_raw = results.nodes.get("time", None)
+        if _t_nodes_raw is None:
+            _t_nodes = np.linspace(0.0, float(t_vec[-1]), len(results.nodes["q"]))
+        else:
+            _t_nodes = np.asarray(_t_nodes_raw).flatten()
+        _q_ms, _t_ms = _q_from_V_multishot(_V, _n_x, _n_u, q.slice, _t_nodes)
+        if _q_ms is not None:
+            print(f"[viser] Multishot V: {len(_q_ms)} frames across {len(_t_nodes) - 1} segments.")
+            q_traj, t_vec = _q_ms, _t_ms
+        else:
+            print("[viser] Multishot V extraction failed; using post-process trajectory.")
+
+    n_frames = len(q_traj)
+    n_segs = robot.num_joints + 1
+
+    keypoints, ee_pos, ee_quats = _compute_panda_keypoints(q_traj)
+    ee_vel = np.gradient(ee_pos, t_vec, axis=0, edge_order=2)
+    ee_colors = compute_velocity_colors(ee_vel)
+
+    server = create_server(ee_pos, show_grid=False)
+    server.scene.add_grid("/grid", width=1.5, height=1.5, cell_size=0.2)
+    server.scene.add_frame("/origin", axes_length=0.08, axes_radius=0.003)
+
+    # Goal and viewpoint markers
+    add_target_markers(server, [goal_ee_pos], radius=0.015, colors=[(255, 50, 50)])
+    add_target_markers(
+        server,
+        vp_targets,
+        radius=0.010,
+        colors=[(50, 255, 100)] * len(vp_targets),
+    )
+
+    add_ghost_trajectory(server, ee_pos, ee_colors, point_size=0.005)
+    _, update_trail = add_animated_trail(server, ee_pos, ee_colors, point_size=0.008)
+    _, update_marker = add_position_marker(server, ee_pos, radius=0.012)
+
+    # Animated viewcone
+    _, update_viewcone = add_viewcone(
+        server,
+        ee_pos,
+        ee_quats,
+        half_angle_x=np.pi / alpha_x,
+        half_angle_y=np.pi / alpha_y,
+        scale=0.15,
+        norm_type=norm_type,
+        R_sb=R_sb,
+        color=(80, 180, 200),
+        opacity=0.3,
+    )
+
+    # -----------------------------------------------------------------------
+    # Load Panda CAD meshes and pre-compute per-frame link transforms.
+    # Falls back to line-segment stick model if mujoco / trimesh / menagerie
+    # assets are unavailable.
+    # -----------------------------------------------------------------------
+    _use_cad_mesh = False
+    _link_meshes_local: dict = {}
+    _link_body_ids: dict = {}
+    _link_world_T: dict = {}
+    try:
+        import mujoco
+        import trimesh  # type: ignore
+
+        from openscvx.integrations.menagerie import get_model_dir
+
+        _panda_dir = get_model_dir("franka_emika_panda")
+        _mj_model_vis = mujoco.MjModel.from_xml_path(str(_panda_dir / "panda_nohand.xml"))
+        _mj_model_vis.opt.disableflags |= mujoco.mjtDisableBit.mjDSBL_CONTACT
+        _mj_data_vis = mujoco.MjData(_mj_model_vis)
+        _asset_dir = _panda_dir / "assets"
+
+        _link_visual_files = {
+            "link0": [
+                "link0_0.obj",
+                "link0_1.obj",
+                "link0_2.obj",
+                "link0_3.obj",
+                "link0_4.obj",
+                "link0_5.obj",
+                "link0_7.obj",
+                "link0_8.obj",
+                "link0_9.obj",
+                "link0_10.obj",
+                "link0_11.obj",
+            ],
+            "link1": ["link1.obj"],
+            "link2": ["link2.obj"],
+            "link3": ["link3_0.obj", "link3_1.obj", "link3_2.obj", "link3_3.obj"],
+            "link4": ["link4_0.obj", "link4_1.obj", "link4_2.obj", "link4_3.obj"],
+            "link5": ["link5_0.obj", "link5_1.obj", "link5_2.obj"],
+            "link6": [
+                "link6_0.obj",
+                "link6_1.obj",
+                "link6_2.obj",
+                "link6_3.obj",
+                "link6_4.obj",
+                "link6_5.obj",
+                "link6_6.obj",
+                "link6_7.obj",
+                "link6_8.obj",
+                "link6_9.obj",
+                "link6_10.obj",
+                "link6_11.obj",
+                "link6_12.obj",
+                "link6_13.obj",
+                "link6_14.obj",
+                "link6_15.obj",
+                "link6_16.obj",
+            ],
+            "link7": [
+                "link7_0.obj",
+                "link7_1.obj",
+                "link7_2.obj",
+                "link7_3.obj",
+                "link7_4.obj",
+                "link7_5.obj",
+                "link7_6.obj",
+                "link7_7.obj",
+            ],
+        }
+
+        for link_name, files in _link_visual_files.items():
+            all_verts, all_faces, offset = [], [], 0
+            for fname in files:
+                obj_path = _asset_dir / fname
+                if not obj_path.exists():
+                    continue
+                tm = trimesh.load(str(obj_path), force="mesh", process=False)
+                all_verts.append(np.asarray(tm.vertices, dtype=np.float32))
+                all_faces.append(np.asarray(tm.faces, dtype=np.uint32) + offset)
+                offset += len(tm.vertices)
+            if not all_verts:
+                continue
+            _link_meshes_local[link_name] = (np.vstack(all_verts), np.vstack(all_faces))
+            _link_body_ids[link_name] = mujoco.mj_name2id(
+                _mj_model_vis, mujoco.mjtObj.mjOBJ_BODY, link_name
+            )
+
+        for name in _link_meshes_local:
+            _link_world_T[name] = np.zeros((n_frames, 4, 4))
+        for t_idx in range(n_frames):
+            _mj_data_vis.qpos[:7] = q_traj[t_idx]
+            mujoco.mj_kinematics(_mj_model_vis, _mj_data_vis)
+            for name, body_id in _link_body_ids.items():
+                T = np.eye(4)
+                T[:3, :3] = _mj_data_vis.xmat[body_id].copy().reshape(3, 3)
+                T[:3, 3] = _mj_data_vis.xpos[body_id].copy()
+                _link_world_T[name][t_idx] = T
+
+        _use_cad_mesh = len(_link_meshes_local) > 0
+        if _use_cad_mesh:
+            print(f"[viser] Loaded {len(_link_meshes_local)} Panda CAD link meshes from menagerie.")
+    except Exception as exc:
+        print(
+            f"[viser] CAD mesh unavailable "
+            f"({type(exc).__name__}: {exc}); falling back to line segments."
+        )
+
+    # -----------------------------------------------------------------------
+    # Robot body: CAD meshes when available, line segments otherwise.
+    # -----------------------------------------------------------------------
+    server.scene.add_box(
+        "/panda_base",
+        dimensions=(0.12, 0.12, 0.08),
+        position=(0.0, 0.0, 0.04),
+        color=(60, 60, 60),
+    )
+    update_robot = None
+    if _use_cad_mesh:
+        from scipy.spatial.transform import Rotation as _Rotation
+
+        def _pose_from_T(T: np.ndarray):
+            R = np.asarray(T, dtype=np.float64)[:3, :3]
+            t = T[:3, 3]
+            q_xyzw = _Rotation.from_matrix(R).as_quat()
+            wxyz = (float(q_xyzw[3]), float(q_xyzw[0]), float(q_xyzw[1]), float(q_xyzw[2]))
+            return (float(t[0]), float(t[1]), float(t[2])), wxyz
+
+        _panda_link_color = {
+            "link0": (120, 120, 120),
+            "link1": (215, 215, 218),
+            "link2": (215, 215, 218),
+            "link3": (215, 215, 218),
+            "link4": (215, 215, 218),
+            "link5": (210, 210, 215),
+            "link6": (200, 205, 215),
+            "link7": (190, 195, 210),
+        }
+        _link_handles = {}
+        for link_name, (verts_local, faces) in _link_meshes_local.items():
+            T0 = _link_world_T[link_name][0]
+            pos0, wxyz0 = _pose_from_T(T0)
+            handle = server.scene.add_mesh_simple(
+                f"/robot/{link_name}",
+                vertices=np.asarray(verts_local, dtype=np.float32, order="C"),
+                faces=faces,
+                color=_panda_link_color.get(link_name, (210, 210, 215)),
+                opacity=1.0,
+                position=pos0,
+                wxyz=wxyz0,
+            )
+            _link_handles[link_name] = handle
+
+        def update_robot(frame_idx: int) -> None:
+            for link_name, handle in _link_handles.items():
+                T = _link_world_T[link_name][frame_idx]
+                pos, wxyz = _pose_from_T(T)
+                handle.position = pos
+                handle.wxyz = wxyz
+
+    else:
+        link_rgb = np.linspace([80, 100, 180], [255, 120, 80], n_segs).astype(np.uint8)
+        link_colors = np.stack([link_rgb, link_rgb], axis=1)
+
+        def _arm_segments(frame_idx: int) -> np.ndarray:
+            pts = np.zeros((n_segs, 2, 3), dtype=np.float32)
+            pts[0] = [np.zeros(3), keypoints[frame_idx, 0]]
+            for k in range(robot.num_joints - 1):
+                pts[k + 1] = [keypoints[frame_idx, k], keypoints[frame_idx, k + 1]]
+            pts[-1] = [keypoints[frame_idx, -2], keypoints[frame_idx, -1]]
+            return pts
+
+        arm_handle = server.scene.add_line_segments(
+            "/panda_links",
+            points=_arm_segments(0),
+            colors=link_colors,
+            line_width=5.0,
+        )
+
+        def update_robot(frame_idx: int) -> None:
+            arm_handle.points = _arm_segments(frame_idx)
+
+    add_animation_controls(
+        server,
+        t_vec,
+        [update_robot, update_trail, update_marker, update_viewcone],
+        loop=True,
+    )
+    server.sleep_forever()
+
+
+# =============================================================================
+# Main
+# =============================================================================
+
+if __name__ == "__main__":
+    print("Franka Panda View Planning via frax dynamics")
+    print("=" * 60)
+    print(f"Nodes: {n}  |  View targets: {len(vp_targets)}")
+    print(f"Viewcone half-angle: {np.degrees(np.pi / alpha_x):.1f}° (α={alpha_x})")
+    print(f"Start EE: {np.round(home_ee_pos, 3)}")
+    print(f"Goal EE:  {np.round(goal_ee_pos, 3)}")
+    print("Viewpoints:")
+    for i, pt in enumerate(vp_targets):
+        print(f"  vp{i}: {list(np.round(pt, 3))}")
+    print()
+
+    problem.initialize()
+    problem.solve()
+    results = problem.post_process()
+
+    q_traj = np.asarray(results.trajectory["q"])
+    ee_traj = np.array([np.asarray(robot.ee_transform(qi))[:3, 3] for qi in q_traj])
+    final_ee = ee_traj[-1]
+    err = np.linalg.norm(final_ee - goal_ee_pos)
+
+    print("\nResults:")
+    print(f"  Final EE:    [{final_ee[0]:.3f}, {final_ee[1]:.3f}, {final_ee[2]:.3f}]")
+    print(f"  Goal EE:     [{goal_ee_pos[0]:.3f}, {goal_ee_pos[1]:.3f}, {goal_ee_pos[2]:.3f}]")
+    print(f"  EE error:    {err:.4f} m")
+    print(f"  CTCS violation: {results.ctcs_violation}")
+    print()
+    print("Launching Viser visualization (Ctrl+C to exit)...")
+    visualize(results, robot)

--- a/examples/frax/panda_frax_viewplanning.py
+++ b/examples/frax/panda_frax_viewplanning.py
@@ -223,13 +223,11 @@ problem = ox.Problem(
     algorithm={
         "lam_vb": 1e0,
         "lam_vc": 1e1,
-        # "autotuner": ox.AugmentedLagrangian(eta_lambda=1e0),
+        "lam_prox": 1e1,
         "autotuner": ox.ConstantProximalWeight(),
     },
     float_dtype="float64",
 )
-
-problem.settings.prp.dt = 0.01
 
 # =============================================================================
 # Visualization

--- a/examples/frax/panda_frax_waypoint.py
+++ b/examples/frax/panda_frax_waypoint.py
@@ -1,0 +1,575 @@
+"""Franka Panda point-to-point motion with an intermediate EE waypoint (frax dynamics).
+
+Extends ``examples/frax/panda_frax.py``: same ``FraxDynamics`` setup, joint
+start/goal boundary conditions, CTCS box limits, and Viser stick-model animation,
+but adds a **nodal** end-effector position constraint at the midpoint of the
+horizon (node ``N // 2``). Task kinematics use ``frax`` forward kinematics
+(``ee_transform``) via a BYOF nodal constraint so the waypoint matches the
+bundled Panda URDF exactly.
+
+Nodal (non-CTCS) constraints are handled by the default ``CVXPyPTRSolver``; use
+``lam_vb=1e3`` so the virtual-buffer penalty can drive the waypoint constraint
+to feasibility alongside full frax rigid-body dynamics.
+
+Requires:
+    pip install openscvx[frax]
+"""
+
+import os
+import sys
+
+import jax.numpy as jnp
+import numpy as np
+from scipy.optimize import minimize
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+grandparent_dir = os.path.dirname(os.path.dirname(current_dir))
+sys.path.append(grandparent_dir)
+
+try:
+    import frax
+except ImportError:
+    print(
+        "frax is not installed. Install with: pip install openscvx[frax]",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+import openscvx as ox
+
+robot = frax.load_panda()
+dyn = ox.FraxDynamics(robot)
+q, qd = dyn.states
+(tau,) = dyn.controls
+
+n_j = robot.num_joints
+n = 12
+total_time = 5.0
+waypoint_node = n // 2
+ee_tol = 0.02  # m
+
+q_start = np.array([0.0, -0.7854, 0.0, -2.3562, 0.0, 1.5708, 0.7854])
+q_goal = np.array([0.6, -0.3, 0.2, -1.8, 0.3, 1.2, 0.5])
+
+ee_start = np.asarray(robot.ee_transform(q_start))[:3, 3]
+ee_goal = np.asarray(robot.ee_transform(q_goal))[:3, 3]
+# Intermediate target: modest offset from the start pose.
+ee_waypoint = ee_start + np.array([0.08, 0.05, 0.04])
+
+q_min = np.asarray(robot.joint_lower_limits, dtype=float)
+q_max = np.asarray(robot.joint_upper_limits, dtype=float)
+
+
+def _ik_position(target: np.ndarray, q_seed: np.ndarray) -> np.ndarray:
+    """Position-only IK for initial-guess seeding (not part of the optimization model)."""
+
+    def objective(qv: np.ndarray) -> float:
+        p = np.asarray(robot.ee_transform(qv))[:3, 3]
+        return float(np.sum((p - target) ** 2))
+
+    result = minimize(
+        objective,
+        q_seed,
+        method="L-BFGS-B",
+        bounds=list(zip(q_min, q_max)),
+    )
+    return result.x
+
+
+def _build_initial_guess(
+    q_start: np.ndarray,
+    q_goal: np.ndarray,
+    ee_waypoint: np.ndarray,
+    *,
+    n_nodes: int,
+    waypoint_node: int,
+    total_time: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Joint / velocity guesses respecting BCs and the EE waypoint.
+
+    * ``q_start`` / ``q_goal`` are pinned at nodes 0 and N-1 (match boundaries).
+    * ``q_mid`` comes from position-only IK to ``ee_waypoint``, seeded from
+      ``q_start`` so the leg does not jump toward the chord midpoint in joint space.
+    * ``ox.init.linspace`` connects the three joint keyframes; interior nodes are
+      filled consistently on both trajectory segments.
+    * ``qd`` uses a nominal-time finite difference with zero velocity at endpoints.
+    """
+    keyframe_nodes = [0, waypoint_node, n_nodes - 1]
+    q_mid = _ik_position(ee_waypoint, q_start)
+    q_guess = ox.init.linspace([q_start, q_mid, q_goal], keyframe_nodes)
+    q_guess[0] = q_start
+    q_guess[waypoint_node] = q_mid
+    q_guess[-1] = q_goal
+
+    qd_guess = np.zeros((n_nodes, n_j))
+    if n_nodes > 2:
+        dt_nom = total_time / (n_nodes - 1)
+        qd_guess[1:-1] = np.gradient(q_guess, dt_nom, axis=0)[1:-1]
+    return q_guess, qd_guess
+
+
+q.initial = q_start
+q.final = q_goal
+qd.initial = np.zeros(n_j)
+qd.final = np.zeros(n_j)
+
+q.guess, qd.guess = _build_initial_guess(
+    q_start,
+    q_goal,
+    ee_waypoint,
+    n_nodes=n,
+    waypoint_node=waypoint_node,
+    total_time=total_time,
+)
+# Gravity-compensating torque guess (not zero). frax integrates the full
+# rigid-body dynamics, so a zero-torque guess implies free-fall — joint
+# accelerations of tens of rad/s² — which produces large dynamics defects that
+# can drive the convex subproblem infeasible at low node counts. Seeding tau with
+# g(q) makes forward_dynamics(q, 0, g(q)) ≈ 0, so the qd channel of the guess is
+# self-consistent and SCvx stays robust even on a coarse time grid.
+grav = np.array([np.asarray(robot.gravity_vector(qi)) for qi in q.guess])
+tau.guess = grav[:, n_j - robot.num_actuated_joints :]
+
+ee_waypoint_param = ox.Parameter("ee_waypoint", shape=(3,), value=ee_waypoint)
+
+
+def _ee_waypoint_residual(x, u, node, params):
+    del u, node
+    q_val = x[q.slice]
+    p = jnp.asarray(robot.ee_transform(q_val))[:3, 3]
+    return jnp.linalg.norm(p - params["ee_waypoint"]) - ee_tol
+
+
+byof = {
+    "parameters": [ee_waypoint_param],
+    "nodal_constraints": [
+        {
+            "constraint_fn": _ee_waypoint_residual,
+            "nodes": [waypoint_node],
+        }
+    ],
+}
+
+constraints = []
+for state in dyn.states:
+    constraints.extend([ox.ctcs(state <= state.max), ox.ctcs(state.min <= state)])
+
+time = ox.Time(
+    initial=0.0,
+    final=ox.Minimize(total_time),
+    min=0.0,
+    max=2.0 * total_time,
+)
+
+problem = ox.Problem(
+    dynamics=dyn,
+    states=dyn.states,
+    controls=dyn.controls,
+    time=time,
+    constraints=constraints,
+    byof=byof,
+    N=n,
+    float_dtype="float64",
+    algorithm={
+        "lam_vb": 1e1,
+        "lam_vc": 1e1,
+        "lam_cost": 1e-1,
+    },
+)
+
+
+def _compute_panda_keypoints(q_traj: np.ndarray, robot) -> tuple[np.ndarray, np.ndarray]:
+    q_traj = np.asarray(q_traj, dtype=float)
+    n_frames = q_traj.shape[0]
+    n_links = robot.num_joints
+    keypoints = np.zeros((n_frames, n_links + 2, 3))
+    ee_pos = np.zeros((n_frames, 3))
+
+    for t in range(n_frames):
+        qi = q_traj[t]
+        links = np.asarray(robot.link_to_world_transforms(qi))
+        ee = np.asarray(robot.ee_transform(qi))
+        keypoints[t, 0] = (0.0, 0.0, 0.0)
+        keypoints[t, 1 : 1 + n_links] = links[:, :3, 3]
+        keypoints[t, -1] = ee[:3, 3]
+        ee_pos[t] = ee[:3, 3]
+
+    return keypoints, ee_pos
+
+
+def _q_from_V_multishot(
+    V: np.ndarray,
+    n_x: int,
+    n_u: int,
+    q_slice: slice,
+    t_nodes: np.ndarray,
+) -> tuple[np.ndarray | None, np.ndarray | None]:
+    """Unpack joint angles from the SCP multi-shoot V matrix.
+
+    V has shape ``((N-1) * i4, n_substeps)`` where
+    ``i4 = n_x + n_x² + 2·n_x·n_u``.  The first ``n_x`` rows of each
+    ``i4``-row block are the integrated state at that substep.
+
+    Returns ``(q_traj, t_traj)`` or ``(None, None)`` if extraction fails.
+    """
+    i4 = n_x + n_x * n_x + 2 * n_x * n_u
+    n_rows, n_sub = V.shape
+    if i4 <= 0 or n_rows % i4 != 0 or n_sub < 1:
+        return None, None
+    n_seg = n_rows // i4
+    if n_seg != len(t_nodes) - 1:
+        return None, None
+    q_rows: list[np.ndarray] = []
+    t_rows: list[float] = []
+    for seg in range(n_seg):
+        t0, t1 = float(t_nodes[seg]), float(t_nodes[seg + 1])
+        j0 = 0 if seg == 0 else 1  # skip duplicated segment-start sample
+        for j in range(j0, n_sub):
+            alpha = j / (n_sub - 1) if n_sub > 1 else 0.0
+            x_vec = np.asarray(V[seg * i4 : seg * i4 + n_x, j], dtype=np.float64)
+            q_rows.append(x_vec[q_slice])
+            t_rows.append((1.0 - alpha) * t0 + alpha * t1)
+    if not q_rows:
+        return None, None
+    return np.stack(q_rows), np.asarray(t_rows, dtype=np.float64)
+
+
+def visualize(
+    results,
+    robot,
+    ee_targets: list[np.ndarray],
+    target_colors: list[tuple[int, int, int]],
+) -> None:
+    """Animate the Panda trajectory in Viser with joint/torque plots.
+
+    Uses the multi-shoot V matrix from the final SCP iteration when available
+    (``results.discretization_history[-1]``), showing the per-segment
+    integration substeps exactly as the solver used them.  Falls back to the
+    post-process single propagation (``results.trajectory``) if V is absent.
+    """
+    import plotly.graph_objects as go
+
+    from openscvx.plotting.viser import (
+        add_animated_trail,
+        add_animation_controls,
+        add_ghost_trajectory,
+        add_position_marker,
+        add_target_markers,
+        compute_velocity_colors,
+        create_server,
+    )
+    from openscvx.plotting.viser.plotly_integration import add_animated_plotly_vline
+
+    t_vec = np.asarray(results.trajectory["time"]).flatten()
+    q_traj = np.asarray(results.trajectory["q"])
+    tau_traj = np.asarray(results.trajectory["tau"])
+
+    # ── Prefer multishot V over post-process single propagation ──────────────
+    _dh = getattr(results, "discretization_history", None) or []
+    if _dh:
+        _V = np.asarray(_dh[-1], dtype=np.float64)
+        _n_x = results.x.shape[1]
+        _n_u = results.u.shape[1]
+        _t_nodes_raw = results.nodes.get("time", None)
+        if _t_nodes_raw is None:
+            _t_nodes = np.linspace(0.0, float(t_vec[-1]), len(results.nodes["q"]))
+        else:
+            _t_nodes = np.asarray(_t_nodes_raw).flatten()
+        _q_ms, _t_ms = _q_from_V_multishot(_V, _n_x, _n_u, q.slice, _t_nodes)
+        if _q_ms is not None:
+            print(f"[viser] Multishot V: {len(_q_ms)} frames across {len(_t_nodes) - 1} segments.")
+            q_traj, t_vec = _q_ms, _t_ms
+            # Torque is ZOH: replicate each node's tau value across its substeps.
+            _tau_nodes = np.asarray(results.nodes["tau"])
+            _n_sub = _V.shape[1]
+            _tau_rows: list[np.ndarray] = []
+            for _seg in range(len(_t_nodes) - 1):
+                _j0 = 0 if _seg == 0 else 1
+                for _j in range(_j0, _n_sub):
+                    _tau_rows.append(_tau_nodes[_seg])
+            tau_traj = np.stack(_tau_rows)
+        else:
+            print("[viser] Multishot V extraction failed; using post-process trajectory.")
+
+    keypoints, ee_pos = _compute_panda_keypoints(q_traj, robot)
+    n_segs = robot.num_joints + 1
+
+    ee_vel = np.gradient(ee_pos, t_vec, axis=0, edge_order=2)
+    ee_colors = compute_velocity_colors(ee_vel)
+
+    server = create_server(ee_pos, show_grid=False)
+    server.scene.add_grid("/grid", width=1.5, height=1.5, cell_size=0.25)
+    server.scene.add_frame("/origin", axes_length=0.08, axes_radius=0.003)
+
+    add_target_markers(server, ee_targets, radius=0.012, colors=target_colors)
+
+    add_ghost_trajectory(server, ee_pos, ee_colors, point_size=0.005)
+    _, update_trail = add_animated_trail(server, ee_pos, ee_colors, point_size=0.008)
+    _, update_marker = add_position_marker(server, ee_pos, radius=0.012)
+
+    # -----------------------------------------------------------------------
+    # Load Panda CAD meshes and pre-compute per-frame link transforms.
+    # Falls back to line-segment stick model if mujoco / trimesh / menagerie
+    # assets are unavailable.
+    # -----------------------------------------------------------------------
+    n_frames = len(q_traj)
+    _use_cad_mesh = False
+    _link_meshes_local: dict = {}
+    _link_body_ids: dict = {}
+    _link_world_T: dict = {}
+    try:
+        import mujoco
+        import trimesh  # type: ignore
+
+        from openscvx.integrations.menagerie import get_model_dir
+
+        _panda_dir = get_model_dir("franka_emika_panda")
+        _mj_model_vis = mujoco.MjModel.from_xml_path(str(_panda_dir / "panda_nohand.xml"))
+        _mj_model_vis.opt.disableflags |= mujoco.mjtDisableBit.mjDSBL_CONTACT
+        _mj_data_vis = mujoco.MjData(_mj_model_vis)
+        _asset_dir = _panda_dir / "assets"
+
+        _link_visual_files = {
+            "link0": [
+                "link0_0.obj",
+                "link0_1.obj",
+                "link0_2.obj",
+                "link0_3.obj",
+                "link0_4.obj",
+                "link0_5.obj",
+                "link0_7.obj",
+                "link0_8.obj",
+                "link0_9.obj",
+                "link0_10.obj",
+                "link0_11.obj",
+            ],
+            "link1": ["link1.obj"],
+            "link2": ["link2.obj"],
+            "link3": ["link3_0.obj", "link3_1.obj", "link3_2.obj", "link3_3.obj"],
+            "link4": ["link4_0.obj", "link4_1.obj", "link4_2.obj", "link4_3.obj"],
+            "link5": ["link5_0.obj", "link5_1.obj", "link5_2.obj"],
+            "link6": [
+                "link6_0.obj",
+                "link6_1.obj",
+                "link6_2.obj",
+                "link6_3.obj",
+                "link6_4.obj",
+                "link6_5.obj",
+                "link6_6.obj",
+                "link6_7.obj",
+                "link6_8.obj",
+                "link6_9.obj",
+                "link6_10.obj",
+                "link6_11.obj",
+                "link6_12.obj",
+                "link6_13.obj",
+                "link6_14.obj",
+                "link6_15.obj",
+                "link6_16.obj",
+            ],
+            "link7": [
+                "link7_0.obj",
+                "link7_1.obj",
+                "link7_2.obj",
+                "link7_3.obj",
+                "link7_4.obj",
+                "link7_5.obj",
+                "link7_6.obj",
+                "link7_7.obj",
+            ],
+        }
+
+        for link_name, files in _link_visual_files.items():
+            all_verts, all_faces, offset = [], [], 0
+            for fname in files:
+                obj_path = _asset_dir / fname
+                if not obj_path.exists():
+                    continue
+                tm = trimesh.load(str(obj_path), force="mesh", process=False)
+                all_verts.append(np.asarray(tm.vertices, dtype=np.float32))
+                all_faces.append(np.asarray(tm.faces, dtype=np.uint32) + offset)
+                offset += len(tm.vertices)
+            if not all_verts:
+                continue
+            _link_meshes_local[link_name] = (np.vstack(all_verts), np.vstack(all_faces))
+            _link_body_ids[link_name] = mujoco.mj_name2id(
+                _mj_model_vis, mujoco.mjtObj.mjOBJ_BODY, link_name
+            )
+
+        for name in _link_meshes_local:
+            _link_world_T[name] = np.zeros((n_frames, 4, 4))
+        for t_idx in range(n_frames):
+            _mj_data_vis.qpos[:7] = q_traj[t_idx]
+            mujoco.mj_kinematics(_mj_model_vis, _mj_data_vis)
+            for name, body_id in _link_body_ids.items():
+                T = np.eye(4)
+                T[:3, :3] = _mj_data_vis.xmat[body_id].copy().reshape(3, 3)
+                T[:3, 3] = _mj_data_vis.xpos[body_id].copy()
+                _link_world_T[name][t_idx] = T
+
+        _use_cad_mesh = len(_link_meshes_local) > 0
+        if _use_cad_mesh:
+            print(f"[viser] Loaded {len(_link_meshes_local)} Panda CAD link meshes from menagerie.")
+    except Exception as exc:
+        print(
+            f"[viser] CAD mesh unavailable "
+            f"({type(exc).__name__}: {exc}); falling back to line segments."
+        )
+
+    # -----------------------------------------------------------------------
+    # Robot body: CAD meshes when available, line segments otherwise.
+    # -----------------------------------------------------------------------
+    server.scene.add_box(
+        "/panda_base",
+        dimensions=(0.12, 0.12, 0.08),
+        position=(0.0, 0.0, 0.04),
+        color=(60, 60, 60),
+    )
+    update_robot = None
+    if _use_cad_mesh:
+        from scipy.spatial.transform import Rotation as _Rotation
+
+        def _pose_from_T(T: np.ndarray):
+            R = np.asarray(T, dtype=np.float64)[:3, :3]
+            t = T[:3, 3]
+            q_xyzw = _Rotation.from_matrix(R).as_quat()
+            wxyz = (float(q_xyzw[3]), float(q_xyzw[0]), float(q_xyzw[1]), float(q_xyzw[2]))
+            return (float(t[0]), float(t[1]), float(t[2])), wxyz
+
+        _panda_link_color = {
+            "link0": (120, 120, 120),
+            "link1": (215, 215, 218),
+            "link2": (215, 215, 218),
+            "link3": (215, 215, 218),
+            "link4": (215, 215, 218),
+            "link5": (210, 210, 215),
+            "link6": (200, 205, 215),
+            "link7": (190, 195, 210),
+        }
+        _link_handles = {}
+        for link_name, (verts_local, faces) in _link_meshes_local.items():
+            T0 = _link_world_T[link_name][0]
+            pos0, wxyz0 = _pose_from_T(T0)
+            handle = server.scene.add_mesh_simple(
+                f"/robot/{link_name}",
+                vertices=np.asarray(verts_local, dtype=np.float32, order="C"),
+                faces=faces,
+                color=_panda_link_color.get(link_name, (210, 210, 215)),
+                opacity=1.0,
+                position=pos0,
+                wxyz=wxyz0,
+            )
+            _link_handles[link_name] = handle
+
+        def update_robot(frame_idx: int) -> None:
+            for link_name, handle in _link_handles.items():
+                T = _link_world_T[link_name][frame_idx]
+                pos, wxyz = _pose_from_T(T)
+                handle.position = pos
+                handle.wxyz = wxyz
+
+    else:
+        link_rgb = np.linspace([80, 100, 180], [255, 120, 80], n_segs).astype(np.uint8)
+        link_colors = np.stack([link_rgb, link_rgb], axis=1)
+        init_points = np.stack(
+            [np.stack([keypoints[0, k], keypoints[0, k + 1]]) for k in range(n_segs)]
+        ).astype(np.float32)
+        arm_handle = server.scene.add_line_segments(
+            "/panda_links",
+            points=init_points,
+            colors=link_colors,
+            line_width=5.0,
+        )
+
+        def update_robot(frame_idx: int) -> None:
+            pts = np.stack(
+                [
+                    np.stack([keypoints[frame_idx, k], keypoints[frame_idx, k + 1]])
+                    for k in range(n_segs)
+                ]
+            ).astype(np.float32)
+            arm_handle.points = pts
+
+    fig_joints = go.Figure()
+    for j in range(robot.num_joints):
+        fig_joints.add_trace(
+            go.Scatter(
+                x=t_vec.tolist(),
+                y=np.rad2deg(q_traj[:, j]).tolist(),
+                mode="lines",
+                name=f"q{j + 1}",
+            )
+        )
+    fig_joints.update_layout(
+        title="Joint angles (deg)",
+        xaxis_title="Time (s)",
+        yaxis_title="θ (deg)",
+        margin={"l": 40, "r": 10, "t": 40, "b": 40},
+    )
+
+    fig_tau = go.Figure()
+    for j in range(robot.num_actuated_joints):
+        fig_tau.add_trace(
+            go.Scatter(
+                x=t_vec.tolist(),
+                y=tau_traj[:, j].tolist(),
+                mode="lines",
+                name=f"τ{j + 1}",
+            )
+        )
+    fig_tau.update_layout(
+        title="Joint torques (Nm)",
+        xaxis_title="Time (s)",
+        yaxis_title="τ (Nm)",
+        margin={"l": 40, "r": 10, "t": 40, "b": 40},
+    )
+
+    with server.gui.add_folder("Plots"):
+        _, update_joints = add_animated_plotly_vline(server, fig_joints, t_vec, folder_name=None)
+        _, update_tau = add_animated_plotly_vline(server, fig_tau, t_vec, folder_name=None)
+
+    add_animation_controls(
+        server,
+        t_vec,
+        [update_robot, update_trail, update_marker, update_joints, update_tau],
+    )
+    server.sleep_forever()
+
+
+if __name__ == "__main__":
+    print("Franka Panda via frax dynamics — intermediate EE waypoint")
+    print("=" * 60)
+    print(f"num_joints = {n_j}, N = {n}, waypoint node = {waypoint_node}")
+    print(f"EE start:     {np.round(ee_start, 3)}")
+    print(f"EE waypoint:  {np.round(ee_waypoint, 3)}  (tol = {ee_tol} m)")
+    print(f"EE goal:      {np.round(ee_goal, 3)}")
+    ee_guess_mid = np.asarray(robot.ee_transform(q.guess[waypoint_node]))[:3, 3]
+    print(
+        f"Init guess @ node {waypoint_node}: "
+        f"||EE - waypoint|| = {np.linalg.norm(ee_guess_mid - ee_waypoint):.4e} m"
+    )
+    print()
+
+    problem.initialize()
+    problem.solve()
+    results = problem.post_process()
+
+    q_traj = np.asarray(results.trajectory["q"])
+    ee_traj = np.array([np.asarray(robot.ee_transform(qi))[:3, 3] for qi in q_traj])
+
+    err_joints = np.linalg.norm(q_traj[-1] - q_goal)
+    err_waypoint = np.linalg.norm(ee_traj[waypoint_node] - ee_waypoint)
+
+    print()
+    print("Results:")
+    print(f"  ||q_final - q_goal|| = {err_joints:.4e}")
+    print(f"  ||EE(node {waypoint_node}) - waypoint|| = {err_waypoint:.4e} m")
+    print(f"  CTCS violation = {results.ctcs_violation}")
+    print()
+    print("Launching Viser visualization (Ctrl+C to exit)...")
+    visualize(
+        results,
+        robot,
+        [ee_start, ee_waypoint, ee_goal],
+        [(100, 150, 255), (255, 180, 50), (255, 80, 80)],
+    )

--- a/examples/rocket/ascent_launch_vehicle.py
+++ b/examples/rocket/ascent_launch_vehicle.py
@@ -77,7 +77,6 @@ def build_true_anomaly_transfer_guess(r_start, r_end, mu, n_nodes):
 
 
 def orbital_elements_2_cartesian_rv(orbital_elements, gravitational_parameter):
-
     semimajor, eccentricity, inclination, right_ascension, arg_periapsis, true_anomaly = (
         orbital_elements
     )

--- a/openscvx/__init__.py
+++ b/openscvx/__init__.py
@@ -26,7 +26,7 @@ from openscvx.discretization import (
     VectorizeDiscretizeLinearize,
 )
 from openscvx.expert import ByofSpec
-from openscvx.integrations import DynamicsAdapter, MjxDynamics
+from openscvx.integrations import DynamicsAdapter, FraxDynamics, MjxDynamics
 from openscvx.loader import load_dict, load_json, load_yaml
 from openscvx.problem import Problem
 from openscvx.solvers import CVXPyPTRSolver, PTRSolver
@@ -198,6 +198,7 @@ __all__ = [
     # External-backend dynamics adapters
     "DynamicsAdapter",
     "MjxDynamics",
+    "FraxDynamics",
     # Discretization
     "DiscretizeLinearizeVectorize",
     "LinearizeDiscretize",

--- a/openscvx/integrations/__init__.py
+++ b/openscvx/integrations/__init__.py
@@ -1,9 +1,18 @@
 """External-backend dynamics adapters for OpenSCvx.
 
-The recommended entry-point is `MjxDynamics`, which goes directly into the
-``dynamics=`` slot of `Problem` and constructs the matching State/Control
-objects for the user. Free-joint quaternion kinematics for floating-base
-models (drones, humanoids) are detected and handled automatically::
+Two backends are currently supported. `MjxDynamics` wraps a MuJoCo MJX model;
+`FraxDynamics` wraps a `frax.Robot` (Fast Robot Kinematics and Dynamics in
+JAX). Both go directly into the ``dynamics=`` slot of `Problem` and construct
+the matching State/Control objects for the user::
+
+    from openscvx.integrations import FraxDynamics
+    from frax.robots.franka_panda import load_panda
+
+    dyn = FraxDynamics(load_panda())
+    problem = ox.Problem(dynamics=dyn, states=dyn.states, controls=dyn.controls, ...)
+
+For MJX, free-joint quaternion kinematics for floating-base models (drones,
+humanoids) are detected and handled automatically::
 
     from openscvx.integrations import MjxDynamics
 
@@ -40,6 +49,7 @@ Example — quadrotor with free joint (``nq=7``, ``nv=6``)::
 from typing import Any
 
 from .base import DynamicsAdapter
+from .frax import FraxDynamics
 from .mjx import MjxDynamics
 
 
@@ -48,6 +58,13 @@ def mjx_dynamics(*args: Any, **kwargs: Any) -> Any:
     from .mjx import mjx_dynamics as _mjx_dynamics
 
     return _mjx_dynamics(*args, **kwargs)
+
+
+def frax_dynamics(*args: Any, **kwargs: Any) -> Any:
+    """Lazy delegate to the low-level frax BYOF factory."""
+    from .frax import frax_dynamics as _frax_dynamics
+
+    return _frax_dynamics(*args, **kwargs)
 
 
 def __getattr__(name: str) -> Any:
@@ -62,5 +79,7 @@ __all__ = [
     "DynamicsAdapter",
     "MjxDynamics",
     "mjx_dynamics",
+    "FraxDynamics",
+    "frax_dynamics",
     "menagerie",
 ]

--- a/openscvx/integrations/_utils.py
+++ b/openscvx/integrations/_utils.py
@@ -1,0 +1,34 @@
+"""Shared utilities for the integrations subpackage."""
+
+
+def _resolve_slice(arg, name: str) -> slice:
+    """Accept either a State/Control or a slice and return the slice.
+
+    Used inside BYOF dynamics factories so they can be constructed before
+    ``Problem`` preprocessing assigns ``.slice`` to State/Control objects.
+    The resolved slice is cached by the caller on first invocation.
+
+    Args:
+        arg: A ``State`` / ``Control`` object (reads ``.slice`` lazily) or
+            a plain ``slice``.
+        name: Human-readable name for the argument, used in error messages.
+
+    Returns:
+        The resolved ``slice`` into the unified ``x`` or ``u`` vector.
+
+    Raises:
+        ValueError: If ``arg`` has a ``.slice`` attribute but it is ``None``
+            (preprocessing has not yet run).
+        TypeError: If ``arg`` is neither a State/Control nor a ``slice``.
+    """
+    if hasattr(arg, "slice"):
+        sl = arg.slice
+        if sl is None:
+            raise ValueError(
+                f"{name} has no .slice yet — pass it after Problem construction has called "
+                "preprocessing, or pass an explicit slice."
+            )
+        return sl
+    if isinstance(arg, slice):
+        return arg
+    raise TypeError(f"{name} must be a State/Control or slice, got {type(arg).__name__}")

--- a/openscvx/integrations/frax.py
+++ b/openscvx/integrations/frax.py
@@ -51,7 +51,7 @@ Note:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Tuple
 
 import jax.numpy as jnp
 import numpy as np
@@ -83,7 +83,7 @@ def _desentinel(values: np.ndarray) -> np.ndarray:
     return np.where(np.abs(values) >= _FRAX_UNLIMITED, np.sign(values) * np.inf, values)
 
 
-def _bounds_from_robot(robot) -> tuple:
+def _bounds_from_robot(robot: Any) -> tuple:
     """Extract State/Control bounds from a ``frax.Robot``.
 
     Reads ``joint_lower_limits``, ``joint_upper_limits``,
@@ -119,7 +119,7 @@ def _bounds_from_robot(robot) -> tuple:
 
 
 def frax_dynamics(
-    robot,
+    robot: Any,
     *,
     q: "State | slice",
     qd: "State | slice",
@@ -265,7 +265,7 @@ class FraxDynamics(DynamicsAdapter):
         mapped to ``±inf`` on all of the above.
     """
 
-    def __init__(self, robot) -> None:
+    def __init__(self, robot: Any) -> None:
         from openscvx.symbolic.expr.control import Control
         from openscvx.symbolic.expr.state import State
 

--- a/openscvx/integrations/frax.py
+++ b/openscvx/integrations/frax.py
@@ -1,0 +1,309 @@
+"""frax dynamics adapters for OpenSCvx.
+
+The recommended entry-point is `FraxDynamics`, a `DynamicsAdapter` that goes
+directly into the ``dynamics=`` slot of `Problem` and exposes the synthesized
+State/Control objects on ``.states`` / ``.controls``::
+
+    from frax.robots.franka_panda import load_panda
+    import openscvx as ox
+
+    dyn = ox.FraxDynamics(load_panda())
+    problem = ox.Problem(
+        dynamics=dyn,
+        states=dyn.states,
+        controls=dyn.controls,
+        ...
+    )
+
+Joint limits and torque bounds are read automatically from the robot's URDF
+and set on the State/Control objects. Override them after construction if
+needed::
+
+    q, qd = dyn.states
+    q.initial = np.array([0.0, -0.7854, 0.0, -2.3562, 0.0, 1.5708, 0.7854])
+
+Because `frax.Robot` is registered as a JAX static pytree
+(``@jax.tree_util.register_static``), it is captured safely inside the BYOF
+callable without special handling.
+
+The lower-level `frax_dynamics` factory is also public for advanced users who
+need to assemble their own BYOF dynamics dict::
+
+    from openscvx.integrations import frax_dynamics
+
+    q   = ox.State("q",   shape=(robot.num_joints,))
+    qd  = ox.State("qd",  shape=(robot.num_joints,))
+    tau = ox.Control("tau", shape=(robot.num_actuated_joints,))
+
+    problem = ox.Problem(
+        dynamics={"q": qd},
+        byof={"dynamics": {"qd": frax_dynamics(robot, q=q, qd=qd, tau=tau)}},
+        states=[q, qd],
+        controls=[tau],
+        ...
+    )
+
+Note:
+    frax uses Euler-angle / rotation-matrix representation for all joint DOFs,
+    including floating-base joints. There is no ``nq != nv`` split, so
+    ``dynamics_dict`` is always ``{"q": qd}`` regardless of robot type.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable, Tuple
+
+import jax.numpy as jnp
+import numpy as np
+
+from openscvx.integrations._utils import _resolve_slice
+from openscvx.integrations.base import DynamicsAdapter
+
+if TYPE_CHECKING:
+    from openscvx.symbolic.expr.control import Control
+    from openscvx.symbolic.expr.state import State
+
+
+# frax encodes an "unlimited" joint DOF as ±1e6 (not 0.0 and not inf). This
+# is emitted by frax's URDF / floating-base construction — e.g. every entry of
+# a 6-DOF floating base's position / velocity / effort limits is ±1e6. We map
+# entries at or beyond this magnitude to ±inf so that unbounded DOFs become
+# genuinely unbounded box constraints (matching the MJX adapter's convention)
+# rather than leaking a hard ±1e6 box into the optimization problem.
+_FRAX_UNLIMITED = 1e6
+
+
+def _desentinel(values: np.ndarray) -> np.ndarray:
+    """Map frax's ±1e6 "no limit" sentinel to signed ``±inf``.
+
+    Entries whose magnitude is at least ``_FRAX_UNLIMITED`` are replaced with
+    ``+inf`` (if positive) or ``-inf`` (if negative); all other entries are
+    left untouched.
+    """
+    return np.where(np.abs(values) >= _FRAX_UNLIMITED, np.sign(values) * np.inf, values)
+
+
+def _bounds_from_robot(robot) -> tuple:
+    """Extract State/Control bounds from a ``frax.Robot``.
+
+    Reads ``joint_lower_limits``, ``joint_upper_limits``,
+    ``joint_max_velocities``, and ``joint_max_forces`` from the robot. frax
+    encodes "no limit" as ``±1e6`` (e.g. for floating-base DOFs); those entries
+    are mapped to ``±inf`` via :func:`_desentinel`.
+
+    For floating-base robots, the first 6 entries of ``joint_max_forces``
+    correspond to the unactuated floating-base DOFs; only the remaining
+    ``num_actuated_joints`` entries form the ``tau`` bounds.
+
+    Args:
+        robot: A ``frax.Robot`` (or subclass) instance.
+
+    Returns:
+        Tuple ``(q_min, q_max, qd_min, qd_max, tau_min, tau_max)``, each a
+        NumPy array of the appropriate length.
+    """
+    nj = robot.num_joints
+    na = robot.num_actuated_joints
+
+    q_min = _desentinel(np.asarray(robot.joint_lower_limits, dtype=float))
+    q_max = _desentinel(np.asarray(robot.joint_upper_limits, dtype=float))
+
+    vel = _desentinel(np.asarray(robot.joint_max_velocities, dtype=float))
+
+    forces = _desentinel(np.asarray(robot.joint_max_forces, dtype=float))
+    # For floating-base robots the first 6 entries are the unactuated base;
+    # take the last na entries as the actuated-joint torque limits.
+    tau_max = forces[nj - na :]
+
+    return q_min, q_max, -vel, vel, -tau_max, tau_max
+
+
+def frax_dynamics(
+    robot,
+    *,
+    q: "State | slice",
+    qd: "State | slice",
+    tau: "Control | slice",
+) -> Callable:
+    """Wrap a ``frax.Robot`` as a BYOF dynamics function.
+
+    Returns a callable ``f(x, u, node, params) -> qdd`` (shape
+    ``(robot.num_joints,)``) suitable for ``byof["dynamics"]["qd"]``.
+
+    For floating-base robots (``robot.includes_floating_dof = True``), the
+    ``tau`` control covers only the ``num_actuated_joints`` actuated DOFs.
+    Internally, the callable prepends six zeros to form the full
+    ``(num_joints,)`` torque vector before calling
+    ``robot.forward_dynamics``. The floating-base DOFs are assumed to appear
+    first in the joint ordering (standard robotics convention, verified for
+    ``frax.load_g1``).
+
+    ``robot`` is captured in the closure safely because ``frax.Robot`` is
+    decorated with ``@jax.tree_util.register_static``, making it a hashable
+    JAX static type.
+
+    Args:
+        robot: A ``frax.Robot`` (or subclass) instance.
+        q: Position state (or slice into the unified ``x`` vector).
+            Length must equal ``robot.num_joints``.
+        qd: Velocity state (or slice). Length must equal ``robot.num_joints``.
+        tau: Control variable (or slice into the unified ``u`` vector).
+            Length must equal ``robot.num_actuated_joints``.
+
+    Returns:
+        A function ``f(x, u, node, params) -> jnp.ndarray`` matching the BYOF
+        dynamics signature. The output is ``qdd``, the joint acceleration
+        vector of shape ``(robot.num_joints,)``.
+
+    Example:
+        Franka Panda joint-space dynamics::
+
+            from frax.robots.franka_panda import load_panda
+            import openscvx as ox
+            from openscvx.integrations import frax_dynamics
+
+            robot = load_panda()
+            q   = ox.State("q",   shape=(robot.num_joints,))
+            qd  = ox.State("qd",  shape=(robot.num_joints,))
+            tau = ox.Control("tau", shape=(robot.num_actuated_joints,))
+
+            qdd = frax_dynamics(robot, q=q, qd=qd, tau=tau)
+
+            problem = ox.Problem(
+                dynamics={"q": qd},
+                byof={"dynamics": {"qd": qdd}},
+                states=[q, qd],
+                controls=[tau],
+                ...
+            )
+    """
+    _q_arg = q
+    _qd_arg = qd
+    _tau_arg = tau
+    # Populated lazily on first call so the factory can be called before
+    # Problem preprocessing assigns .slice to the State/Control objects.
+    _resolved: list = []
+
+    def f(x, u, node, params):
+        del node, params
+        if not _resolved:
+            _resolved.append(_resolve_slice(_q_arg, "q"))
+            _resolved.append(_resolve_slice(_qd_arg, "qd"))
+            _resolved.append(_resolve_slice(_tau_arg, "tau"))
+        q_sl, qd_sl, tau_sl = _resolved
+
+        q_val = x[q_sl]
+        qd_val = x[qd_sl]
+        tau_val = u[tau_sl]
+
+        if robot.includes_floating_dof:
+            # First 6 DOF are the unactuated floating base; user ctrl covers
+            # only the remaining num_actuated_joints.
+            tau_full = jnp.concatenate([jnp.zeros(6, dtype=tau_val.dtype), tau_val])
+        else:
+            tau_full = tau_val
+
+        # frax's forward_dynamics declares fext with no default; pass it
+        # explicitly.
+        return robot.forward_dynamics(q_val, qd_val, tau_full, fext=None)
+
+    return f
+
+
+class FraxDynamics(DynamicsAdapter):
+    """First-class frax dynamics adapter for `Problem`.
+
+    Wraps a ``frax.Robot`` so it can be passed directly to the ``dynamics=``
+    argument of `Problem`. The adapter constructs default ``q`` / ``qd`` State
+    objects and a ``tau`` Control matching the robot's joint count, exposes
+    them via ``.states`` / ``.controls``, and routes the frax forward dynamics
+    through the BYOF channel internally — without requiring the user to know
+    about BYOF.
+
+    Joint limits and torque bounds are read from the robot's URDF and
+    auto-populated on the State/Control objects. Override any of them after
+    construction if you want tighter problem-specific bounds::
+
+        dyn = ox.FraxDynamics(load_panda())
+        q, qd = dyn.states
+        q.initial = np.array([0.0, -0.7854, 0.0, -2.3562, 0.0, 1.5708, 0.7854])
+        # tighten velocity limits for a slow approach
+        qd.max = np.full(7, 1.0)
+
+    Example:
+        Franka Panda::
+
+            from frax.robots.franka_panda import load_panda
+            import openscvx as ox
+
+            dyn = ox.FraxDynamics(load_panda())
+            problem = ox.Problem(
+                dynamics=dyn,
+                states=dyn.states,
+                controls=dyn.controls,
+                constraints=[...],
+                N=50,
+                time=ox.Time(...),
+            )
+
+    Floating-base robots (``robot.includes_floating_dof = True``) are
+    supported. The ``tau`` Control covers only the ``num_actuated_joints``
+    actuated DOFs; the adapter inserts the required zero-torque entries for the
+    unactuated floating-base DOFs internally.
+
+    Custom State/Control names are *not* supported — drop to the lower-level
+    `frax_dynamics` helper for that.
+
+    Auto-populated bounds:
+        * ``q.min`` / ``q.max``: from the URDF ``<limit lower/upper>``.
+        * ``qd.min`` / ``qd.max``: from the URDF ``<limit velocity>``
+          (mirrored as ``±max_vel``).
+        * ``tau.min`` / ``tau.max``: from the URDF ``<limit effort>`` for the
+          actuated joints.
+
+        frax's ``±1e6`` "no limit" sentinel (used for floating-base DOFs) is
+        mapped to ``±inf`` on all of the above.
+    """
+
+    def __init__(self, robot) -> None:
+        from openscvx.symbolic.expr.control import Control
+        from openscvx.symbolic.expr.state import State
+
+        self._robot = robot
+        nj = robot.num_joints
+        na = robot.num_actuated_joints
+
+        self._q = State("q", shape=(nj,))
+        self._qd = State("qd", shape=(nj,))
+        self._tau = Control("tau", shape=(na,))
+
+        q_min, q_max, qd_min, qd_max, tau_min, tau_max = _bounds_from_robot(robot)
+        self._q.min = q_min
+        self._q.max = q_max
+        self._qd.min = qd_min
+        self._qd.max = qd_max
+        self._tau.min = tau_min
+        self._tau.max = tau_max
+
+        self.states: list[State] = [self._q, self._qd]
+        self.controls: list[Control] = [self._tau]
+
+    def expand(self) -> Tuple[dict, dict]:
+        """Return ``(dynamics_dict, byof_dict)`` for this frax robot.
+
+        frax always has ``nq == nv`` (no quaternion floating-base split), so
+        ``dynamics_dict`` is always ``{"q": qd}`` and the full joint
+        acceleration goes through BYOF.
+        """
+        dynamics_dict = {"q": self._qd}
+        byof_dict = {
+            "dynamics": {
+                "qd": frax_dynamics(
+                    self._robot,
+                    q=self._q,
+                    qd=self._qd,
+                    tau=self._tau,
+                )
+            }
+        }
+        return dynamics_dict, byof_dict

--- a/openscvx/integrations/mjx.py
+++ b/openscvx/integrations/mjx.py
@@ -28,26 +28,12 @@ from typing import TYPE_CHECKING, Any, Callable, Optional, Tuple
 
 import jax.numpy as jnp
 
+from openscvx.integrations._utils import _resolve_slice
 from openscvx.integrations.base import DynamicsAdapter
 
 if TYPE_CHECKING:
     from openscvx.symbolic.expr.control import Control
     from openscvx.symbolic.expr.state import State
-
-
-def _resolve_slice(arg, name: str) -> slice:
-    """Accept either a State/Control or a slice and return the slice."""
-    if hasattr(arg, "slice"):
-        sl = arg.slice
-        if sl is None:
-            raise ValueError(
-                f"{name} has no .slice yet — pass it after Problem construction has called "
-                "preprocessing, or pass an explicit slice."
-            )
-        return sl
-    if isinstance(arg, slice):
-        return arg
-    raise TypeError(f"{name} must be a State/Control or slice, got {type(arg).__name__}")
 
 
 def mjx_dynamics(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,12 +59,16 @@ mjx = [
     "mujoco>=3.0",
     "mujoco-mjx>=3.0",
 ]
+frax = [
+    "frax>=0.0.4",
+]
 test = [
     "pytest",
     "scipy",
     "jaxlie",
     "svgpathtools",
-    "pytest-xdist"
+    "pytest-xdist",
+    "frax>=0.0.4",
 ]
 
 [tool.setuptools.packages.find]

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -24,11 +24,9 @@ EXCLUDED_EXAMPLES = {
     "arm/7_dof_arm_collision.py",
     "drone/logo.py",
     "drone/openscvx_logo.py",
-    # Heavy MJX examples (keep cartpole + skydio below)
-    "mjx/double_cartpole_mjx.py",
-    "mjx/triple_cartpole_mjx.py",
+    "drone/obstacle_avoidance_vmap.py",
     "mjx/triple_cartpole_game.py",
-    "mjx/triple_cartpole_3d_mjx.py",
+    "rocket/ascent_launch_vehicle.py",
 }
 
 # MJX examples included in discovery only when mujoco.mjx is installed (others
@@ -37,6 +35,9 @@ _MJX_EXAMPLES_REQUIRE_MUJOCO = frozenset(
     {
         "mjx/cartpole_mjx.py",
         "mjx/skydio_x2_mjx.py",
+        "mjx/triple_cartpole_mjx.py",
+        "mjx/triple_cartpole_3d_mjx.py",
+        "mjx/double_cartpole_mjx.py",
     }
 )
 


### PR DESCRIPTION
## Add frax integration and Franka Panda examples

### Summary

Adds **`FraxDynamics`**, an adapter for [frax](https://pypi.org/project/frax/) rigid-body robots, alongside the existing MJX integration. Users can pass a `frax.Robot` directly into `Problem(dynamics=...)`; joint position/velocity/torque limits are read from the URDF and mapped into OpenSCvx State/Control bounds (including handling frax’s ±1e6 “unlimited” sentinels).

Also ships four Franka Panda examples under `examples/frax/`:

- **`panda_frax.py`** — joint-space point-to-point motion
- **`panda_frax_waypoint.py`** — EE waypoint via BYOF nodal constraints
- **`panda_frax_pick_place.py`** — multi-waypoint pick-and-place with collision avoidance
- **`panda_frax_viewplanning.py`** — wrist-camera viewcone constraints

Install with `pip install openscvx[frax]`.

### Other changes

- Extract shared `_resolve_slice` helper used by MJX and frax adapters
- Minor example cleanup (remove Mosek override in `dubins_car_waypoint_stl`, tune `dr_vp_polytope`)
- CI: re-enable some MJX examples in discovery; exclude heavier examples (`obstacle_avoidance_vmap`, `ascent_launch_vehicle`)