### PR TITLE
Smooth-convex composite function curvature info

### DIFF
--- a/openscvx/algorithms/scvx/iteration.py
+++ b/openscvx/algorithms/scvx/iteration.py
@@ -395,6 +395,11 @@ def make_proxconvex_iteration(
         # Evaluate the SR composite: R(x_k), ∇s(R), sign mask, ∇R.
         R_val, ds_val, I_neg_mask, grad_R = composite.eval(state.x, state.u, params)
 
+        # Curvature augmentation: H⁺_k = Π_{S+}(H_{s,k}) for Q_k = µ_k I + H⁺_k.
+        H_plus = composite.compute_hessian(
+            state.x, state.u, params, R_val, ds_val, I_neg_mask, grad_R
+        )
+
         data = ProxConvexSubproblemData(
             x_bar=state.x,
             u_bar=state.u,
@@ -423,6 +428,7 @@ def make_proxconvex_iteration(
             ds_val=ds_val,
             I_neg_mask=I_neg_mask,
             grad_R=grad_R,
+            H_plus=H_plus,
         )
 
         solution = solver_callback(state, data)

--- a/openscvx/algorithms/scvx/prox_convex.py
+++ b/openscvx/algorithms/scvx/prox_convex.py
@@ -2,8 +2,10 @@
 
 Minimizes F(x) = g(x) + h(C(x)) + s(R(x)) by keeping convex ``r_i``
 components exact in the CVXPy subproblem when ∇_i s(R(x_k)) ≥ 0, and
-linearizing them when ∇_i s(R(x_k)) < 0.  The scalar proximal metric
-Q_k = µ_k I is adapted via an acceptance-ratio test.
+linearizing them when ∇_i s(R(x_k)) < 0.  The proximal metric
+Q_k = µ_k I + H⁺_k combines a scalar weight µ_k (adapted via an
+acceptance-ratio test) with the PSD-projected curvature block H⁺_k from
+s(R(x)) (outer pullback + inner compensation, Section 2.3.1).
 
 Usage::
 
@@ -126,6 +128,72 @@ class SRComposite:
         )
         return R_val, ds_val, I_neg_mask, grad_R
 
+    def compute_hessian(
+        self,
+        x: jnp.ndarray,
+        u: jnp.ndarray,
+        params: dict,
+        R_val: jnp.ndarray,
+        ds_val: jnp.ndarray,
+        I_neg_mask: jnp.ndarray,
+        grad_R: jnp.ndarray,
+    ) -> jnp.ndarray:
+        """Compute the PSD-projected curvature block H⁺_k for s(R(x)).
+
+        Implements Eq. (Section 2.3.1) of arXiv:2512.20602v1:
+
+            H_{s,k} = G_R^T ∇²s(R_k) G_R           [outer pullback]
+                    + Σ_{i∈I⁻_k} [∇s]_i ∇²r_i(x_k) [inner compensation]
+            H⁺_k = Π_{S+}(H_{s,k})
+
+        Args:
+            x: Current state trajectory, shape ``(N, n_x)``.
+            u: Current control trajectory, shape ``(N, n_u)``.
+            params: Problem parameters.
+            R_val: SR component values ``R(x_k)``, shape ``(n_r,)``.
+            ds_val: Outer gradient ``∇s(R_k)``, shape ``(n_r,)``.
+            I_neg_mask: Boolean mask; ``True`` where ``ds_val[i] < 0``,
+                shape ``(n_r,)``.
+            grad_R: Row-stacked Jacobian of R w.r.t. full trajectory x,
+                shape ``(n_r, N, n_x)``.
+
+        Returns:
+            ``H_plus``, shape ``(N*n_x, N*n_x)``, symmetric and PSD.
+        """
+        assert self._r_jax_fns is not None, "call lower_jax() before compute_hessian()"
+        N, n_x = x.shape
+        n_r = R_val.shape[0]
+        n_total = N * n_x
+
+        # Outer pullback: G_R^T H²s G_R  (n_total, n_total)
+        H2s = jax.hessian(lambda R: self.s(R, params))(R_val)  # (n_r, n_r)
+        G_R = grad_R.reshape(n_r, n_total)  # (n_r, n_total)
+        H_outer = G_R.T @ H2s @ G_R  # (n_total, n_total)
+
+        # Inner compensation: Σ_{i∈I⁻_k} [∇s]_i ∇²r_i(x[node_i])
+        # Each Hessian is (n_x, n_x) and sits at the block diagonal position
+        # corresponding to node_i.  Use jnp.where so the computation is always
+        # traced (no data-dependent branching) and the weight is zeroed out for
+        # channels that are NOT linearized (I_neg_mask[i] == False).
+        H_inner = jnp.zeros((n_total, n_total))
+        for i, (fn, node_idx) in enumerate(zip(self._r_jax_fns, self._nodes)):
+            H2r_i = jax.hessian(lambda xi, _fn=fn, _n=node_idx: _fn(xi, u[_n], _n, params))(
+                x[node_idx]
+            )  # (n_x, n_x)
+            weight = jnp.where(I_neg_mask[i], ds_val[i], 0.0)
+            contribution = weight * H2r_i  # (n_x, n_x)
+            s = node_idx * n_x
+            H_inner = H_inner.at[s : s + n_x, s : s + n_x].add(contribution)
+
+        # PSD projection via eigendecomposition of the symmetric sum.
+        # NaN entries (e.g. from ||r_i||=0 singularities) are zeroed out — this
+        # conservatively drops the second-order correction for ill-defined channels
+        # and falls back to the isotropic µ_k I metric for those directions.
+        H_s = jnp.nan_to_num(H_outer + H_inner, nan=0.0)
+        eigenvalues, eigenvectors = jnp.linalg.eigh(H_s)
+        H_plus = eigenvectors @ jnp.diag(jnp.maximum(0.0, eigenvalues)) @ eigenvectors.T
+        return H_plus
+
 
 def check_sr_composite(composite: "SRComposite", x_var, u_var, params: dict) -> None:
     """Validate an :class:`SRComposite` at initialize-time.
@@ -165,8 +233,10 @@ class ProxConvex(Algorithm):
     Minimizes F(x) = g(x) + h(C(x)) + s(R(x)).  The ``s∘R`` term is an
     :class:`SRComposite`: each ``r_i`` is kept exact in the CVXPy subproblem
     when ``∇_i s(R(x_k)) ≥ 0``, and linearized when ``∇_i s(R(x_k)) < 0``.
-    The scalar proximal metric ``Q_k = µ_k I`` is adapted by an
-    acceptance-ratio test identical to Algorithm 1 of the paper.
+    The proximal metric ``Q_k = µ_k I + H⁺_k`` combines the scalar weight
+    ``µ_k`` (adapted by an acceptance-ratio test, Algorithm 1 of the paper)
+    with the PSD-projected curvature block
+    ``H⁺_k = Π_{S+}(H_{s,k})`` from ``s(R(x))`` (Section 2.3.1).
 
     Pair this algorithm with :class:`~openscvx.solvers.cvxpy_ptr_solver.CVXPyProxConvexSolver`.
     :meth:`Problem.initialize` forwards the composite to the solver automatically.

--- a/openscvx/algorithms/scvx/prox_convex.py
+++ b/openscvx/algorithms/scvx/prox_convex.py
@@ -164,18 +164,17 @@ class SRComposite:
                 shape ``(n_r, N, n_x)``.
 
         Returns:
-            ``H_plus``, shape ``(N*n_x, N*n_x)``, symmetric and PSD; the zero
-            block when ``use_hessian`` is ``False`` (``Q_k = µ_k I``).
+            ``H_plus``, shape ``(N*n_x, N*n_x)``, symmetric and PSD; a scalar
+            ``0.0`` placeholder when ``use_hessian`` is ``False`` (``Q_k = µ_k
+            I``).
         """
         assert self._r_jax_fns is not None, "call lower_jax() before compute_hessian()"
         N, n_x = x.shape
         n_r = R_val.shape[0]
         n_total = N * n_x
 
-        # Curvature disabled (Q_k = µ_k I). Only an explicit False disables;
-        # an unresolved None behaves as enabled.
         if self.use_hessian is False:
-            return jnp.zeros((n_total, n_total))
+            return jnp.zeros(())
 
         # Outer pullback: G_R^T H²s G_R  (n_total, n_total)
         H2s = jax.hessian(lambda R: self.s(R, params))(R_val)  # (n_r, n_r)

--- a/openscvx/algorithms/scvx/prox_convex.py
+++ b/openscvx/algorithms/scvx/prox_convex.py
@@ -77,11 +77,17 @@ class SRComposite:
         nodes: Node index (or list of indices, one per ``r_i``) at which each
             component is evaluated.  A single ``int`` is broadcast to all
             components.
+        use_hessian: Override for the curvature block ``H⁺_k``. ``None``
+            (default) inherits ``ProxConvex(hessian_composite=...)``; an
+            explicit ``True``/``False`` overrides it. ``False`` drops ``H⁺_k``
+            (``Q_k = µ_k I``), needed when ``s`` or an inner ``r_i`` is not
+            ``C²``.
     """
 
     s: Callable
     r: List
     nodes: Union[int, List[int]]
+    use_hessian: Optional[bool] = None
 
     def __post_init__(self):
         if isinstance(self.nodes, int):
@@ -158,12 +164,18 @@ class SRComposite:
                 shape ``(n_r, N, n_x)``.
 
         Returns:
-            ``H_plus``, shape ``(N*n_x, N*n_x)``, symmetric and PSD.
+            ``H_plus``, shape ``(N*n_x, N*n_x)``, symmetric and PSD; the zero
+            block when ``use_hessian`` is ``False`` (``Q_k = µ_k I``).
         """
         assert self._r_jax_fns is not None, "call lower_jax() before compute_hessian()"
         N, n_x = x.shape
         n_r = R_val.shape[0]
         n_total = N * n_x
+
+        # Curvature disabled (Q_k = µ_k I). Only an explicit False disables;
+        # an unresolved None behaves as enabled.
+        if self.use_hessian is False:
+            return jnp.zeros((n_total, n_total))
 
         # Outer pullback: G_R^T H²s G_R  (n_total, n_total)
         H2s = jax.hessian(lambda R: self.s(R, params))(R_val)  # (n_r, n_r)
@@ -236,13 +248,19 @@ class ProxConvex(Algorithm):
     The proximal metric ``Q_k = µ_k I + H⁺_k`` combines the scalar weight
     ``µ_k`` (adapted by an acceptance-ratio test, Algorithm 1 of the paper)
     with the PSD-projected curvature block
-    ``H⁺_k = Π_{S+}(H_{s,k})`` from ``s(R(x))`` (Section 2.3.1).
+    ``H⁺_k = Π_{S+}(H_{s,k})`` from ``s(R(x))`` (Section 2.3.1).  Disable
+    ``H⁺_k`` (``Q_k = µ_k I``) via ``hessian_composite`` when the curvature
+    is unavailable (e.g. a non-``C²`` inner function).
 
     Pair this algorithm with :class:`~openscvx.solvers.cvxpy_ptr_solver.CVXPyProxConvexSolver`.
     :meth:`Problem.initialize` forwards the composite to the solver automatically.
 
     Args:
         composite: :class:`SRComposite` encoding the ``s`` and ``r`` functions.
+        hessian_composite: Default for the curvature block ``H⁺_k``
+            (``Q_k = µ_k I + H⁺_k``), default ``True``. Applied to ``composite``
+            unless it sets ``use_hessian`` explicitly. ``False`` gives
+            ``Q_k = µ_k I`` (e.g. for a non-``C²`` inner function).
         autotuner: Weight-update rule.  Defaults to
             :class:`~openscvx.algorithms.autotuner.adaptive_proximal_weight.AdaptiveProximalWeight`
             configured with the ``alpha_1 / alpha_2 / nu_inc / nu_dec`` knobs
@@ -283,6 +301,7 @@ class ProxConvex(Algorithm):
     def __init__(
         self,
         composite: SRComposite,
+        hessian_composite: bool = True,
         autotuner: "AutotuningBase" = None,
         k_max: int = 200,
         t_max: Optional[float] = None,
@@ -302,6 +321,10 @@ class ProxConvex(Algorithm):
         states: List["State"] = None,
         controls: List["Control"] = None,
     ):
+        # Composite override wins; else inherit the algorithm default.
+        if composite.use_hessian is None:
+            composite.use_hessian = hessian_composite
+
         self._composite = composite
         self._iteration_fn: Optional[Callable] = None
         self._emitter: Optional[Callable] = None

--- a/openscvx/solvers/cvxpy_ptr_solver.py
+++ b/openscvx/solvers/cvxpy_ptr_solver.py
@@ -1408,14 +1408,19 @@ class CVXPyProxConvexSolver(CVXPyPTRSolver):
         # Hessian curvature term: 0.5 * ||L^T (x - x_bar)||²  where  H⁺ = L L^T.
         # L = V diag(√λ⁺); offset = L^T x_bar is precomputed on the CPU so the
         # CVXPy expression reduces to cp.sum_squares(param_matrix @ variable - param_vector).
-        n_total = N * n_x
-        L_hplus_p = cp.Parameter((n_total, n_total))
-        offset_hplus_p = cp.Parameter(n_total)
-        x_flat = cp.hstack([x_nonscaled[k] for k in range(N)])
-        hess_cost = 0.5 * cp.sum_squares(L_hplus_p.T @ x_flat - offset_hplus_p)
-        # Zero initialisation → first iteration behaves as Q_k = µ_k I.
-        L_hplus_p.value = np.zeros((n_total, n_total))
-        offset_hplus_p.value = np.zeros(n_total)
+        if self._composite.use_hessian is False:
+            L_hplus_p = None
+            offset_hplus_p = None
+            hess_cost = cp.Constant(0)
+        else:
+            n_total = N * n_x
+            L_hplus_p = cp.Parameter((n_total, n_total))
+            offset_hplus_p = cp.Parameter(n_total)
+            x_flat = cp.hstack([x_nonscaled[k] for k in range(N)])
+            hess_cost = 0.5 * cp.sum_squares(L_hplus_p.T @ x_flat - offset_hplus_p)
+            # Zero initialisation → first iteration behaves as Q_k = µ_k I.
+            L_hplus_p.value = np.zeros((n_total, n_total))
+            offset_hplus_p.value = np.zeros(n_total)
 
         # Re-build the base PTR cost expression (no side effects; all
         # Parameter references are shared with _ocp_vars).
@@ -1458,6 +1463,8 @@ class CVXPyProxConvexSolver(CVXPyPTRSolver):
         # Update the square-root factor L = V diag(√λ⁺) for Q_k = µ_k I + H⁺_k.
         # offset = L^T x_bar is precomputed here so _build_sr_problem only needs a
         # single param_matrix @ variable product (DPP-compliant).
+        if entry["L_hplus"] is None:
+            return
         eigvals, eigvecs = np.linalg.eigh(H_plus_np)
         sqrt_eigvals = np.sqrt(np.maximum(0.0, eigvals))
         L = eigvecs @ np.diag(sqrt_eigvals)

--- a/openscvx/solvers/cvxpy_ptr_solver.py
+++ b/openscvx/solvers/cvxpy_ptr_solver.py
@@ -1405,9 +1405,23 @@ class CVXPyProxConvexSolver(CVXPyPTRSolver):
                 ri_expr = lowerer.lower(self._composite.r[i])
                 sr_cost = sr_cost + ds_p * ri_expr
 
+        # Hessian curvature term: 0.5 * ||L^T (x - x_bar)||²  where  H⁺ = L L^T.
+        # L = V diag(√λ⁺) is the square-root factor; L_p @ x_flat is DPP-compliant
+        # (param_matrix @ variable), unlike the earlier multiply-of-eigenvalues form.
+        # offset_p = L^T x_bar is precomputed on the CPU so only one param appears
+        # per product, satisfying CVXPy's DPP requirement.
+        n_total = N * n_x
+        L_hplus_p = cp.Parameter((n_total, n_total))
+        offset_hplus_p = cp.Parameter(n_total)
+        x_flat = cp.hstack([x_nonscaled[k] for k in range(N)])
+        hess_cost = 0.5 * cp.sum_squares(L_hplus_p.T @ x_flat - offset_hplus_p)
+        # Zero initialisation → first iteration behaves as Q_k = µ_k I.
+        L_hplus_p.value = np.zeros((n_total, n_total))
+        offset_hplus_p.value = np.zeros(n_total)
+
         # Re-build the base PTR cost expression (no side effects; all
         # Parameter references are shared with _ocp_vars).
-        total_cost = CVXPyPTRSolver.cost(self, settings, lowered) + sr_cost
+        total_cost = CVXPyPTRSolver.cost(self, settings, lowered) + sr_cost + hess_cost
         problem = cp.Problem(cp.Minimize(total_cost), self.constraints(settings, lowered))
 
         return {
@@ -1415,6 +1429,8 @@ class CVXPyProxConvexSolver(CVXPyPTRSolver):
             "ds_params": ds_params,
             "lin_coef_params": lin_coef_params,
             "lin_bias_params": lin_bias_params,
+            "L_hplus": L_hplus_p,
+            "offset_hplus": offset_hplus_p,
         }
 
     def _update_sr_params(
@@ -1425,6 +1441,7 @@ class CVXPyProxConvexSolver(CVXPyPTRSolver):
         R_val_np: np.ndarray,
         grad_R_np: np.ndarray,
         x_bar_np: np.ndarray,
+        H_plus_np: np.ndarray,
     ) -> None:
         """Push current-iterate SR values into the cached problem's Parameters."""
         n_r = len(self._composite.r)
@@ -1439,6 +1456,16 @@ class CVXPyProxConvexSolver(CVXPyPTRSolver):
                 entry["lin_bias_params"][i].value = bias
             else:
                 entry["ds_params"][i].value = max(0.0, ds_i)
+
+        # Update the square-root factor L = V diag(√λ⁺) for Q_k = µ_k I + H⁺_k.
+        # Precomputing offset = L^T x_bar avoids a param×param product in the CVXPy
+        # expression, which would break DPP and force re-canonicalization every solve.
+        eigvals, eigvecs = np.linalg.eigh(H_plus_np)
+        sqrt_eigvals = np.sqrt(np.maximum(0.0, eigvals))
+        L = eigvecs @ np.diag(sqrt_eigvals)
+        x_bar_flat = x_bar_np.reshape(-1)
+        entry["L_hplus"].value = L
+        entry["offset_hplus"].value = L.T @ x_bar_flat
 
     def _solve_sr_problem(self, problem: cp.Problem) -> None:
         """Solve a cached SR problem with the standard DPP fallback."""
@@ -1588,6 +1615,7 @@ class CVXPyProxConvexSolver(CVXPyPTRSolver):
                 R_val_np=np.asarray(data.R_val),
                 grad_R_np=np.asarray(data.grad_R),
                 x_bar_np=np.asarray(data.x_bar),
+                H_plus_np=np.asarray(data.H_plus),
             )
 
             try:

--- a/openscvx/solvers/cvxpy_ptr_solver.py
+++ b/openscvx/solvers/cvxpy_ptr_solver.py
@@ -1406,10 +1406,8 @@ class CVXPyProxConvexSolver(CVXPyPTRSolver):
                 sr_cost = sr_cost + ds_p * ri_expr
 
         # Hessian curvature term: 0.5 * ||L^T (x - x_bar)||²  where  H⁺ = L L^T.
-        # L = V diag(√λ⁺) is the square-root factor; L_p @ x_flat is DPP-compliant
-        # (param_matrix @ variable), unlike the earlier multiply-of-eigenvalues form.
-        # offset_p = L^T x_bar is precomputed on the CPU so only one param appears
-        # per product, satisfying CVXPy's DPP requirement.
+        # L = V diag(√λ⁺); offset = L^T x_bar is precomputed on the CPU so the
+        # CVXPy expression reduces to cp.sum_squares(param_matrix @ variable - param_vector).
         n_total = N * n_x
         L_hplus_p = cp.Parameter((n_total, n_total))
         offset_hplus_p = cp.Parameter(n_total)
@@ -1458,8 +1456,8 @@ class CVXPyProxConvexSolver(CVXPyPTRSolver):
                 entry["ds_params"][i].value = max(0.0, ds_i)
 
         # Update the square-root factor L = V diag(√λ⁺) for Q_k = µ_k I + H⁺_k.
-        # Precomputing offset = L^T x_bar avoids a param×param product in the CVXPy
-        # expression, which would break DPP and force re-canonicalization every solve.
+        # offset = L^T x_bar is precomputed here so _build_sr_problem only needs a
+        # single param_matrix @ variable product (DPP-compliant).
         eigvals, eigvecs = np.linalg.eigh(H_plus_np)
         sqrt_eigvals = np.sqrt(np.maximum(0.0, eigvals))
         L = eigvecs @ np.diag(sqrt_eigvals)

--- a/openscvx/solvers/ptr_solver.py
+++ b/openscvx/solvers/ptr_solver.py
@@ -260,12 +260,15 @@ class ProxConvexSubproblemData(SubproblemData):
             ``ds_val[i] < 0`` (channel must be linearized).
         grad_R: Jacobian of each ``r_i`` w.r.t. the full state trajectory
             ``x``, shape ``(n_r, N, n_x)``.  Computed via ``jax.jacrev``.
+        H_plus: PSD-projected curvature block ``H⁺_k = Π_{S+}(H_{s,k})`` for
+            the proximal metric ``Q_k = µ_k I + H⁺_k``, shape ``(N*n_x, N*n_x)``.
     """
 
     R_val: jnp.ndarray
     ds_val: jnp.ndarray
     I_neg_mask: jnp.ndarray
     grad_R: jnp.ndarray
+    H_plus: jnp.ndarray
 
     def tree_flatten(self):
         children = tuple(getattr(self, f.name) for f in fields(self))


### PR DESCRIPTION
Added Hessian contribution for smooth-composite cost; allows to avoid Hessian computation when s is not of class C^2