### PR TITLE
Support nonconvex equality constraints as L1-penalized nodal/cross-node constraints

### DIFF
--- a/openscvx/algorithms/autotuner/augmented_lagrangian.py
+++ b/openscvx/algorithms/autotuner/augmented_lagrangian.py
@@ -206,7 +206,7 @@ class AugmentedLagrangian(AcceptanceRatioAutotuner):
 
         for idx, constraint in enumerate(nodal_constraints.nodal):
             g = constraint.func(candidate.x, candidate.u, 0, params)
-            nu = jnp.maximum(0.0, g)
+            nu = jnp.abs(g) if constraint.is_equality else jnp.maximum(0.0, g)
 
             if constraint.nodes is not None:
                 nodes_array = jnp.asarray(constraint.nodes)
@@ -245,7 +245,7 @@ class AugmentedLagrangian(AcceptanceRatioAutotuner):
 
         for idx, constraint in enumerate(nodal_constraints.cross_node):
             g = constraint.func(candidate.x, candidate.u, params)
-            nu = jnp.sum(jnp.maximum(0.0, g))
+            nu = jnp.sum(jnp.abs(g) if constraint.is_equality else jnp.maximum(0.0, g))
             current = state.lam_vb_cross[idx]
             case1 = current + nu * scale
             case2 = current + (nu**2) / state.hyper.ep * scale

--- a/openscvx/algorithms/penalty.py
+++ b/openscvx/algorithms/penalty.py
@@ -96,12 +96,14 @@ def calculate_nonlinear_penalty(
         else:
             g_filtered = g
             w = lam_vb_nodal[:, idx]
-        nodal_penalty = nodal_penalty + jnp.sum(w * jnp.maximum(0.0, g_filtered))
+        viol = jnp.abs(g_filtered) if constraint.is_equality else jnp.maximum(0.0, g_filtered)
+        nodal_penalty = nodal_penalty + jnp.sum(w * viol)
 
     for idx, constraint in enumerate(nodal_constraints.cross_node):
         w = lam_vb_cross[idx]
         g = constraint.func(x_bar, u_bar, params)
-        nodal_penalty = nodal_penalty + w * jnp.sum(jnp.maximum(0.0, g))
+        viol = jnp.abs(g) if constraint.is_equality else jnp.maximum(0.0, g)
+        nodal_penalty = nodal_penalty + w * jnp.sum(viol)
 
     cost = calculate_cost_from_state(x_bar, settings, lam_cost)
     x_diff = settings.sim.inv_S_x @ (x_bar[1:, :] - x_prop).T

--- a/openscvx/algorithms/scvx/iteration.py
+++ b/openscvx/algorithms/scvx/iteration.py
@@ -145,6 +145,11 @@ def make_scp_iteration(
     n_u = settings.sim.n_controls
     n_nodal = len(jax_constraints.nodal)
 
+    # Equality columns measure violation two-sided (|nu_vb|); inequalities use
+    # the positive part. Built once at trace time as static boolean masks.
+    nodal_eq_mask = jnp.asarray([c.is_equality for c in jax_constraints.nodal], dtype=bool)
+    cross_eq_mask = jnp.asarray([c.is_equality for c in jax_constraints.cross_node], dtype=bool)
+
     # Accept either a bare ``jax.jit`` callable or a ``jax.export`` wrapper.
     dis_continuous = dis_continuous.call if hasattr(dis_continuous, "call") else dis_continuous
     dis_impulsive = dis_impulsive.call if hasattr(dis_impulsive, "call") else dis_impulsive
@@ -311,9 +316,13 @@ def make_scp_iteration(
         VC = jnp.abs(inv_S_x @ solution.nu.T).T
         J_tr = jnp.sum(TR**2)
         J_vc = jnp.sum(VC)
-        J_vb = jnp.sum(jnp.maximum(0.0, solution.nu_vb)) + jnp.sum(
-            jnp.maximum(0.0, solution.nu_vb_cross)
+        nodal_vb = jnp.where(
+            nodal_eq_mask, jnp.abs(solution.nu_vb), jnp.maximum(0.0, solution.nu_vb)
         )
+        cross_vb = jnp.where(
+            cross_eq_mask, jnp.abs(solution.nu_vb_cross), jnp.maximum(0.0, solution.nu_vb_cross)
+        )
+        J_vb = jnp.sum(nodal_vb) + jnp.sum(cross_vb)
         state = state.replace(
             J_tr=jnp.asarray(J_tr, dtype=state.J_tr.dtype),
             J_vb=jnp.asarray(J_vb, dtype=state.J_vb.dtype),

--- a/openscvx/lowered/jax_constraints.py
+++ b/openscvx/lowered/jax_constraints.py
@@ -37,12 +37,19 @@ class LoweredNodalConstraint:
 
         nodes (Optional[List[int]]): List of node indices where this constraint applies.
             Set after lowering from NodalConstraint.
+
+        is_equality (bool): True if the source constraint was an ``Equality``
+            (``g == 0``), False for an ``Inequality`` (``g <= 0``). Controls the
+            virtual-buffer penalty shape downstream: equalities are penalized
+            two-sided (``|nu_vb|``), inequalities one-sided (``pos(nu_vb)``).
+            Defaults to False, preserving the inequality behavior.
     """
 
     func: Callable[[jnp.ndarray, jnp.ndarray], jnp.ndarray]
     grad_g_x: Optional[Callable[[jnp.ndarray, jnp.ndarray], jnp.ndarray]] = None
     grad_g_u: Optional[Callable[[jnp.ndarray, jnp.ndarray], jnp.ndarray]] = None
     nodes: Optional[List[int]] = None
+    is_equality: bool = False
 
 
 @dataclass
@@ -110,6 +117,7 @@ class LoweredCrossNodeConstraint:
     func: Callable[[jnp.ndarray, jnp.ndarray, dict], jnp.ndarray]
     grad_g_X: Callable[[jnp.ndarray, jnp.ndarray, dict], jnp.ndarray]
     grad_g_U: Callable[[jnp.ndarray, jnp.ndarray, dict], jnp.ndarray]
+    is_equality: bool = False
 
 
 @dataclass

--- a/openscvx/solvers/cvxpy_ptr_solver.py
+++ b/openscvx/solvers/cvxpy_ptr_solver.py
@@ -490,18 +490,21 @@ class CVXPyPTRSolver(PTRSolver):
         # Virtual Control Slack
         cost += sum(cp.sum(lam_vc[i - 1] * cp.abs(nu[i - 1])) for i in range(1, settings.sim.n))
 
-        # Virtual buffer penalty for nodal constraints (per-node weighting)
+        # Virtual buffer penalty for nodal constraints (per-node weighting).
+        # Equalities penalize |nu_vb|, inequalities penalize pos(nu_vb).
         idx_ncvx = 0
         if jax_constraints.nodal:
             for constraint in jax_constraints.nodal:
-                cost += lam_vb_nodal[:, idx_ncvx] @ cp.pos(nu_vb[idx_ncvx])
+                pen = cp.abs if constraint.is_equality else cp.pos
+                cost += lam_vb_nodal[:, idx_ncvx] @ pen(nu_vb[idx_ncvx])
                 idx_ncvx += 1
 
         # Virtual slack penalty for cross-node constraints
         idx_cross = 0
         if jax_constraints.cross_node:
             for constraint in jax_constraints.cross_node:
-                cost += lam_vb_cross[idx_cross] * cp.pos(nu_vb_cross[idx_cross])
+                pen = cp.abs if constraint.is_equality else cp.pos
+                cost += lam_vb_cross[idx_cross] * pen(nu_vb_cross[idx_cross])
                 idx_cross += 1
 
         return cost

--- a/openscvx/solvers/moreau_ptr_solver.py
+++ b/openscvx/solvers/moreau_ptr_solver.py
@@ -490,6 +490,12 @@ class MoreauPTRSolver(PTRSolver):
         self._c_u_j = jnp.asarray(self._c_u, dtype=f)
         self._jax_dtype = f
 
+        if any(c.is_equality for c in jax_constraints.nodal):
+            raise NotImplementedError(
+                "MoreauPTRSolver does not support L1-penalized equality "
+                "constraints. Use CVXPyPTRSolver."
+            )
+
         self.layout = _ConicLayout(N=N, n_x=n_x, n_u=n_u, n_nodal=len(jax_constraints.nodal))
         self._jax_constraints = jax_constraints
         self._x_unified = x_unified

--- a/openscvx/solvers/qpax_ptr_solver.py
+++ b/openscvx/solvers/qpax_ptr_solver.py
@@ -329,6 +329,12 @@ class QPAXPTRSolver(PTRSolver):
         self._c_u_j = jnp.asarray(self._c_u, dtype=f)
         self._jax_dtype = f
 
+        if any(c.is_equality for c in jax_constraints.nodal):
+            raise NotImplementedError(
+                "QPAXPTRSolver does not support L1-penalized equality "
+                "constraints. Use CVXPyPTRSolver."
+            )
+
         self.layout = _QPLayout(N=N, n_x=n_x, n_u=n_u, n_nodal=len(jax_constraints.nodal))
         self._jax_constraints = jax_constraints
         self._x_unified = x_unified

--- a/openscvx/symbolic/augmentation.py
+++ b/openscvx/symbolic/augmentation.py
@@ -75,30 +75,6 @@ from openscvx.symbolic.expr.state import State
 from openscvx.symbolic.expr.time import Time
 
 
-def _check_nonconvex_equality(constraint: Constraint, context: str) -> None:
-    """Raise a helpful error if constraint is a non-convex equality.
-
-    Non-convex equality constraints are not supported.
-
-    Args:
-        constraint: The constraint to check
-        context: Description of where this constraint appears (for error message)
-
-    Raises:
-        ValueError: If constraint is an Equality and not marked as convex
-    """
-    if isinstance(constraint, Equality) and not constraint.is_convex:
-        raise ValueError(
-            f"Non-convex equality constraint in {context}. "
-            f"Equality constraints must be affine (linear) and marked as convex "
-            f"using .convex(). For example:\n"
-            f"    (velocity.at(0) == velocity.at(n-1)).convex()\n"
-            f"If your equality constraint is nonlinear, consider reformulating it "
-            f"as two inequality constraints or using a different approach.\n"
-            f"Constraint: {constraint}"
-        )
-
-
 def sort_ctcs_constraints(
     constraints_ctcs: List[CTCS],
 ) -> Tuple[List[CTCS], List[Tuple[int, int]], int]:
@@ -265,9 +241,6 @@ def separate_constraints(constraint_set: ConstraintSet, n_nodes: int) -> Constra
                     f"Constraint: {c.constraint}"
                 )
 
-            # Check for non-convex equality constraints
-            _check_nonconvex_equality(c.constraint, "nodal constraint")
-
             # Regular nodal constraint - categorize by convexity
             if c.constraint.is_convex:
                 constraint_set.nodal_convex.append(c)
@@ -277,9 +250,6 @@ def separate_constraints(constraint_set: ConstraintSet, n_nodes: int) -> Constra
         elif isinstance(c, Constraint):
             # Bare constraint - check if it's a cross-node constraint
             if _contains_node_reference(c):
-                # Check for non-convex equality constraints
-                _check_nonconvex_equality(c, "cross-node constraint")
-
                 # Cross-node constraint: wrap in CrossNodeConstraint
                 cross_node = CrossNodeConstraint(c)
                 if c.is_convex:
@@ -287,9 +257,6 @@ def separate_constraints(constraint_set: ConstraintSet, n_nodes: int) -> Constra
                 else:
                     constraint_set.cross_node.append(cross_node)
             else:
-                # Check for non-convex equality constraints
-                _check_nonconvex_equality(c, "nodal constraint")
-
                 # Regular constraint: apply at all nodes
                 all_nodes = list(range(n_nodes))
                 nodal_constraint = NodalConstraint(c, all_nodes)
@@ -310,9 +277,6 @@ def separate_constraints(constraint_set: ConstraintSet, n_nodes: int) -> Constra
     # Add nodal constraints from CTCS constraints that have check_nodally=True
     ctcs_nodal_constraints = get_nodal_constraints_from_ctcs(constraint_set.ctcs)
     for constraint, interval in ctcs_nodal_constraints:
-        # Check for non-convex equality constraints
-        _check_nonconvex_equality(constraint, "CTCS check_nodally constraint")
-
         # CTCS check_nodally constraints cannot have NodeReferences (validated above)
         # Convert CTCS interval (start, end) to list of nodes [start, start+1, ..., end-1]
         interval_nodes = list(range(interval[0], interval[1]))

--- a/openscvx/symbolic/lower.py
+++ b/openscvx/symbolic/lower.py
@@ -73,7 +73,7 @@ from openscvx.lowered import (
     LoweredProblem,
 )
 from openscvx.symbolic.constraint_set import ConstraintSet
-from openscvx.symbolic.expr import Expr, NodeReference, traverse
+from openscvx.symbolic.expr import Equality, Expr, NodeReference, traverse
 from openscvx.symbolic.expr.control import Control
 from openscvx.symbolic.unified import unify_controls, unify_states
 
@@ -628,6 +628,7 @@ def _lower_jax_constraints(
                 grad_g_x=jax.vmap(jacfwd(fn, argnums=0), in_axes=(0, 0, None, None)),
                 grad_g_u=jax.vmap(jacfwd(fn, argnums=1), in_axes=(0, 0, None, None)),
                 nodes=constraints.nodal[i].nodes,
+                is_equality=isinstance(constraints.nodal[i].constraint, Equality),
             )
             lowered_nodal.append(constraint)
 
@@ -644,6 +645,7 @@ def _lower_jax_constraints(
             func=constraint_fn,
             grad_g_X=grad_g_X,
             grad_g_U=grad_g_U,
+            is_equality=isinstance(cross_node_constraint.constraint, Equality),
         )
         lowered_cross_node.append(cross_node_lowered)
 

--- a/tests/solvers/test_qpax_ptr_solver.py
+++ b/tests/solvers/test_qpax_ptr_solver.py
@@ -231,6 +231,46 @@ def test_qpax_rejects_user_convex_constraints():
         )
 
 
+def test_qpax_rejects_nodal_equality():
+    """L1-penalized nodal equalities need a two-sided slack penalty, which the
+    QPAX one-sided positive-part reformulation can't express; lowering must
+    raise ``NotImplementedError`` naming CVXPyPTRSolver."""
+    n = 5
+    pos = ox.State("pos", shape=(2,))
+    pos.min = np.array([-10.0, -10.0])
+    pos.max = np.array([10.0, 10.0])
+    pos.initial = np.array([0.0, 0.0])
+    pos.final = np.array([3.0, 3.0])
+    vel = ox.State("vel", shape=(2,))
+    vel.min = np.array([-5.0, -5.0])
+    vel.max = np.array([5.0, 5.0])
+    vel.initial = np.array([0.0, 0.0])
+    vel.final = [("free", 0.0), ("free", 0.0)]
+    u = ox.Control("u", shape=(2,))
+    u.min = np.array([-3.0, -3.0])
+    u.max = np.array([3.0, 3.0])
+    u.guess = np.zeros((n, 2))
+    dyn = {"pos": vel, "vel": u}
+    time = ox.Time(initial=0.0, final=("minimize", 2.0), min=0.0, max=10.0)
+
+    eq_constraint = (pos == np.array([1.0, 1.0])).at([2])
+
+    with pytest.raises(
+        NotImplementedError,
+        match=r"QPAXPTRSolver does not support L1-penalized equality",
+    ):
+        Problem(
+            dynamics=dyn,
+            states=[pos, vel],
+            controls=[u],
+            time=time,
+            constraints=[eq_constraint],
+            N=n,
+            float_dtype="float64",
+            solver={"backend": "qpax"},
+        )
+
+
 # ============================================================================
 # Round-trip parity with CVXPyPTRSolver
 # ============================================================================

--- a/tests/symbolic/test_augmentation.py
+++ b/tests/symbolic/test_augmentation.py
@@ -1442,28 +1442,21 @@ def test_regular_convex_constraint_without_node_reference_accepted():
 # =============================================================================
 
 
-def test_nonconvex_cross_node_equality_rejected():
-    """Test that non-convex cross-node equality constraints are rejected with helpful error."""
+def test_nonconvex_cross_node_equality_accepted():
+    """Non-convex cross-node equalities are accepted as soft L1-penalized constraints."""
     n_nodes = 10
     velocity = State("vel", shape=(3,))
 
-    # Create a non-convex cross-node equality (periodic boundary condition without .convex())
     cross_node_equality = velocity.at(0) == velocity.at(9)
-
-    # Verify it's an Equality and not marked convex
     assert isinstance(cross_node_equality, Equality)
     assert not cross_node_equality.is_convex
 
-    # Should raise a helpful error
     constraint_set = ConstraintSet(unsorted=[cross_node_equality])
-    with pytest.raises(ValueError) as exc_info:
-        separate_constraints(constraint_set, n_nodes=n_nodes)
+    result = separate_constraints(constraint_set, n_nodes=n_nodes)
 
-    # Check error message is helpful
-    msg = str(exc_info.value)
-    assert "Non-convex equality constraint" in msg
-    assert ".convex()" in msg
-    assert "cross-node" in msg
+    # Routed into the non-convex cross-node list (penalized), not the convex list
+    assert len(result.cross_node) == 1
+    assert len(result.cross_node_convex) == 0
 
 
 def test_convex_cross_node_equality_accepted():
@@ -1486,28 +1479,21 @@ def test_convex_cross_node_equality_accepted():
     assert len(result.cross_node) == 0
 
 
-def test_nonconvex_nodal_equality_rejected():
-    """Test that non-convex nodal equality constraints are rejected with helpful error."""
+def test_nonconvex_nodal_equality_accepted():
+    """Non-convex nodal equalities are accepted as soft L1-penalized constraints."""
     n_nodes = 10
     position = State("pos", shape=(3,))
 
-    # Create a non-convex nodal equality (without .convex())
     nodal_equality = (position == np.zeros(3)).at([0, 5, 9])
-
-    # Verify it's an Equality and not marked convex
     assert isinstance(nodal_equality.constraint, Equality)
     assert not nodal_equality.constraint.is_convex
 
-    # Should raise a helpful error
     constraint_set = ConstraintSet(unsorted=[nodal_equality])
-    with pytest.raises(ValueError) as exc_info:
-        separate_constraints(constraint_set, n_nodes=n_nodes)
+    result = separate_constraints(constraint_set, n_nodes=n_nodes)
 
-    # Check error message is helpful
-    msg = str(exc_info.value)
-    assert "Non-convex equality constraint" in msg
-    assert ".convex()" in msg
-    assert "nodal" in msg
+    # Routed into the non-convex nodal list (penalized), not the convex list
+    assert len(result.nodal) == 1
+    assert len(result.nodal_convex) == 0
 
 
 def test_ctcs_equality_rejected():

--- a/tests/test_autotuning.py
+++ b/tests/test_autotuning.py
@@ -435,6 +435,31 @@ def test_calculate_nonlinear_penalty_with_nodal_violations(
     assert nonlinear_penalty >= 0.0
 
 
+def test_calculate_nonlinear_penalty_equality_is_two_sided(settings):
+    """Equality nodal constraints penalize |g| (two-sided), inequalities use max(0, g)."""
+
+    def nodal_func(x, u, node, params):
+        return x[:, 0] - 1.5  # negative residual at x=0 (satisfied as inequality)
+
+    x_prop = np.array([[0.0, 0.0], [0.0, 0.0]])
+    x_bar = np.zeros((3, 2))
+    u_bar = np.zeros((3, 1))
+    args = (np.array([1.0, 1.0]), np.full((3, 1), 1.0), np.full(1, 1.0), 1.0)
+
+    eq = LoweredJaxConstraints(
+        nodal=[LoweredNodalConstraint(func=nodal_func, nodes=None, is_equality=True)],
+    )
+    ineq = LoweredJaxConstraints(
+        nodal=[LoweredNodalConstraint(func=nodal_func, nodes=None, is_equality=False)],
+    )
+
+    _, _, eq_pen = calculate_nonlinear_penalty(x_prop, x_bar, u_bar, *args, eq, {}, settings)
+    _, _, ineq_pen = calculate_nonlinear_penalty(x_prop, x_bar, u_bar, *args, ineq, {}, settings)
+
+    assert eq_pen > 0.0  # |−1.5| penalized
+    assert ineq_pen == 0.0  # max(0, −1.5) == 0
+
+
 def test_calculate_nonlinear_penalty_with_cross_node_violations(settings, cross_node_constraints):
     """Test penalty calculation with cross-node constraint violations."""
     x_prop = np.array([[0.5, 0.5], [1.5, 1.5]])

--- a/tests/test_brachistochrone.py
+++ b/tests/test_brachistochrone.py
@@ -536,6 +536,77 @@ def test_backend_float32_raises():
     jax.clear_caches()
 
 
+def test_nodal_equality_waypoint():
+    """Soft L1-penalized nodal equality drives an off-path waypoint to target."""
+    import jax.numpy as jnp
+
+    import openscvx as ox
+    from openscvx import Problem
+
+    n = 12
+    g = 9.81
+    mid = n // 2
+    # Natural (unconstrained) node-mid position is ~(2.62, 6.69); this is a
+    # deliberate off-path deviation the soft equality must pull the iterate to.
+    waypoint = np.array([3.0, 6.4])
+
+    position = ox.State("position", shape=(2,))
+    position.max = np.array([10.0, 10.0])
+    position.min = np.array([0.0, 0.0])
+    position.initial = np.array([0.0, 10.0])
+    position.final = [10.0, 5.0]
+
+    velocity = ox.State("velocity", shape=(1,))
+    velocity.max = np.array([15.0])
+    velocity.min = np.array([0.0])
+    velocity.initial = np.array([0.0])
+    velocity.final = [("free", 10.0)]
+
+    theta = ox.Control("theta", shape=(1,))
+    theta.max = np.array([179.0 * jnp.pi / 180])
+    theta.min = np.array([0.0])
+    theta.guess = np.linspace(5 * jnp.pi / 180, 100.5 * jnp.pi / 180, n).reshape(-1, 1)
+
+    states = [position, velocity]
+    dynamics = {
+        "position": ox.Concat(velocity[0] * ox.Sin(theta[0]), -velocity[0] * ox.Cos(theta[0])),
+        "velocity": g * ox.Cos(theta[0]),
+    }
+
+    constraint_exprs = []
+    for state in states:
+        constraint_exprs.extend([ox.ctcs(state <= state.max), ox.ctcs(state.min <= state)])
+    constraint_exprs.append((position == waypoint).at([mid]).weight(1e3))
+
+    time = ox.Time(initial=0.0, final=("minimize", 2.0), min=0.0, max=2.0, uniform_time_grid=True)
+
+    problem = Problem(
+        dynamics=dynamics,
+        states=states,
+        controls=[theta],
+        time=time,
+        constraints=constraint_exprs,
+        N=n,
+        licq_max=1e-8,
+        algorithm={"lam_prox": 1e0, "lam_cost": 1e-1, "lam_vc": 1e0, "k_max": 200},
+    )
+    problem.settings.prp.dt = 0.01
+    problem.solver.solver_args = {"abstol": 1e-8, "reltol": 1e-10}
+    problem.settings.sim.save_compiled = False
+    if hasattr(problem.settings, "dev"):
+        problem.settings.dev.printing = False
+
+    problem.initialize()
+    problem.solve()
+    result = problem.post_process()
+
+    assert result["converged"], "Soft-equality problem failed to converge"
+    err = np.linalg.norm(result.nodes["position"][mid] - waypoint)
+    assert err < 1e-4, f"Waypoint not satisfied at node {mid}: err={err:.4f}"
+
+    jax.clear_caches()
+
+
 @pytest.mark.parametrize("constraint_type", ["ctcs", "nodal", "convex", "over", "at"])
 def test_constraint_types(constraint_type):
     """


### PR DESCRIPTION
## Support nonconvex equality constraints as L1-penalized nodal/cross-node constraints

Previously, OpenSCvx rejected any nonconvex equality constraint at the symbolic
augmentation stage with an explicit `ValueError`, requiring users to manually
reformulate non-convex equalities as pairs of inequalities or restrict themselves
to convex (affine) equalities only.

With this PR, non-convex equalities are fully supported as penalty constraints.

- **Removed the hard block** in `augmentation.py` — `_check_nonconvex_equality`
  and all four call sites are gone; non-convex equalities now flow through the
  same lowering path as inequalities.
- **`is_equality` flag propagated through lowering** — `LoweredNodalConstraint`
  and `LoweredCrossNodeConstraint` each carry a new `is_equality: bool` field,
  set during JAX lowering by inspecting whether the source constraint is an
  `Equality` instance.
- **Two-sided L1 penalty for equalities** — wherever virtual-buffer violations
  were previously computed with `max(0, g)` (one-sided, for inequalities), they
  now branch on `is_equality`: equalities use `|g|` (two-sided), inequalities
  keep `max(0, g)`. This applies in both `penalty.py` (nonlinear penalty
  evaluation) and `iteration.py` (linearized `J_vb` inside the SCP loop).

### Effect

Users can now directly express non-convex equality constraints
(e.g. `f(x, u) == 0` where `f` is nonlinear) and have them handled correctly
by the L1 penalty machinery, without any manual reformulation.
