### PR TITLE
Fix/batched-postprocess-tau-clamp

### DIFF
--- a/openscvx/problem.py
+++ b/openscvx/problem.py
@@ -63,7 +63,11 @@ from openscvx.lowered.jax_constraints import (
     LoweredJaxConstraints,
     LoweredNodalConstraint,
 )
-from openscvx.propagation import get_propagation_solver, propagate_trajectory_results
+from openscvx.propagation import (
+    get_propagation_solver,
+    propagate_trajectory_results,
+    s_to_t,
+)
 from openscvx.solvers import ConvexSolver, resolve_solver_config
 from openscvx.symbolic.builder import preprocess_symbolic_problem
 from openscvx.symbolic.expr import CTCS, Constraint
@@ -2074,7 +2078,12 @@ class Problem:
                 ``ceil(T_max / settings.prp.dt) + 1`` where ``T_max`` is the
                 longest terminal time across the batch.  All ``B`` elements are
                 interpolated to the **same** ``n_times`` so the output arrays
-                have uniform shape.
+                have uniform shape.  The requested (or default) value is capped
+                so no single segment of any element receives more dense samples
+                than the propagation solver's compiled per-segment capacity
+                (``settings.prp.max_tau_len``); the cap binds on the largest
+                segment-duration fraction across the batch, so trajectories with
+                near-uniform segments are left untouched.
 
         Returns:
             The same ``results`` object with ``t_full``, ``x_full``, ``u_full``,
@@ -2095,10 +2104,24 @@ class Problem:
             n_times = max(int(np.ceil(T_max / self.settings.prp.dt)) + 1, 2)
 
         # The propagation solver is compiled with a per-segment tau capacity of
-        # ``max_tau_len``.  A uniform ``linspace`` grid sized from the batch
-        # ``T_max`` can place more output times into one normalized segment than
-        # that capacity when shorter trajectories are padded to the same count.
-        n_times = min(n_times, self.settings.prp.max_tau_len)
+        # ``max_tau_len`` — the *per-segment* buffer width, not a total-point
+        # budget.  A uniform ``linspace`` grid over an element's real time span
+        # drops about ``(n_times - 1) * seg_dur / span`` points into each
+        # segment, so the binding quantity is the largest segment-duration
+        # fraction across the batch, not the total point count.  Bound
+        # ``n_times`` so the busiest segment of any element — plus the endpoint
+        # sample ``simulate_nonlinear_time`` appends — stays within
+        # ``max_tau_len``:
+        #     (n_times - 1) * frac_max + 2 <= max_tau_len.
+        u_batch = np.asarray(results.U[-1])  # (B, N, n_u)
+        frac_max = 0.0
+        for b in range(B):
+            t_b = np.asarray(
+                s_to_t(x_batch[b], u_batch[b], self.settings, self._discretizer)
+            ).reshape(-1)
+            frac_max = max(frac_max, float(np.diff(t_b).max() / (t_b[-1] - t_b[0])))
+        per_segment_bound = max(int((self.settings.prp.max_tau_len - 2) / frac_max) + 1, 2)
+        n_times = min(n_times, per_segment_bound)
 
         t_fulls: List[np.ndarray] = []
         x_fulls: List[np.ndarray] = []

--- a/tests/test_post_process_batched_tau_clamp.py
+++ b/tests/test_post_process_batched_tau_clamp.py
@@ -1,0 +1,104 @@
+"""``post_process_batched`` sizes its dense grid per-segment, not per-total.
+
+The propagation solver is compiled with a *per-segment* tau buffer of width
+``settings.prp.max_tau_len``.  ``post_process_batched`` used to clamp the
+*total* number of dense output points to that per-segment width, collapsing
+trajectories that would otherwise carry hundreds of samples down to a handful.
+These tests pin the fixed behaviour: the dense grid may far exceed
+``max_tau_len`` in total, yet no single segment of any batch element ever
+overfills the per-segment buffer.
+"""
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from openscvx.propagation import s_to_t
+from tests.solvers._iteration_callback_helpers import build_brachistochrone
+
+
+def _x_initial_stack(prob, shifts=(0.0, 0.3, -0.3)):
+    """Stack a few initial pins by shifting the starting x-coordinate."""
+    default_pin = prob.state.x_init_pin
+    return jnp.stack([default_pin.at[0].set(default_pin[0] + s) for s in shifts])
+
+
+def _worst_segment_occupancy(prob, results):
+    """Largest per-segment dense-sample count across the batch.
+
+    Mirrors the binning ``simulate_nonlinear_time`` performs: each dense time
+    falls into the node-time segment ``[t_nodal[k], t_nodal[k + 1])``.  Returns
+    the maximum count over all segments and all batch elements.
+    """
+    x_batch = np.asarray(results.X[-1])
+    u_batch = np.asarray(results.U[-1])
+    worst = 0
+    for b in range(x_batch.shape[0]):
+        t_nodal = np.asarray(
+            s_to_t(x_batch[b], u_batch[b], prob.settings, prob._discretizer)
+        ).reshape(-1)
+        seg = np.clip(
+            np.searchsorted(t_nodal, results.t_full[b], side="right") - 1,
+            0,
+            len(t_nodal) - 2,
+        )
+        counts = np.bincount(seg, minlength=len(t_nodal) - 1)
+        worst = max(worst, int(counts.max()))
+    return worst
+
+
+# === Dense grid is sized by the total, capped only per-segment ===
+
+
+def test_batched_dense_grid_exceeds_per_segment_capacity():
+    """The default grid carries far more total points than one segment holds.
+
+    ``ceil(T_max / prp.dt) + 1`` comfortably exceeds ``max_tau_len`` here, and
+    with near-uniform segments each segment stays well within the per-segment
+    buffer — so the total-count clamp was pure loss.  Before the fix the dense
+    grid came out at exactly ``max_tau_len`` samples.
+    """
+    pytest.importorskip("qpax")
+
+    prob = build_brachistochrone("qpax", n=8, k_max=20)
+    prob.initialize()
+    max_tau_len = prob.settings.prp.max_tau_len
+
+    batched = prob.solve_batched(x_initial=_x_initial_stack(prob))
+    results = prob.post_process_batched(batched)
+
+    # The dense grid dwarfs the per-segment buffer — the old clamp would have
+    # pinned it to exactly ``max_tau_len``.
+    assert results.t_full.shape[-1] > max_tau_len
+    # ...and the per-segment safety still holds: nothing overfills the buffer.
+    assert _worst_segment_occupancy(prob, results) + 1 <= max_tau_len
+
+
+# === Per-segment capacity is still enforced ===
+
+
+def test_batched_large_n_times_request_is_clamped_to_per_segment_capacity():
+    """An absurd explicit ``n_times`` is capped, and no segment overfills.
+
+    Requesting far more points than the per-segment buffer could ever absorb
+    forces the bound to bind.  A naive ``linspace`` of this size would drop
+    thousands of samples into each segment and blow past ``max_tau_len`` — the
+    propagation solver would crash on the negative pad.  The per-segment-aware
+    bound reduces ``n_times`` just enough that every segment fits, so the call
+    both returns a smaller grid and completes without error.
+    """
+    pytest.importorskip("qpax")
+
+    prob = build_brachistochrone("qpax", n=8, k_max=20)
+    prob.initialize()
+    max_tau_len = prob.settings.prp.max_tau_len
+
+    batched = prob.solve_batched(x_initial=_x_initial_stack(prob))
+    huge = 100_000
+    results = prob.post_process_batched(batched, n_times=huge)
+
+    # The request was clamped well below what was asked for...
+    assert results.t_full.shape[-1] < huge
+    # ...precisely so that the busiest segment plus its endpoint sample stays
+    # within the compiled per-segment buffer.
+    assert _worst_segment_occupancy(prob, results) + 1 <= max_tau_len


### PR DESCRIPTION
## Summary

`post_process_batched` clamped the **total** dense-grid size to `settings.prp.max_tau_len` — but `initialize()` sizes `max_tau_len` as the propagation solver's **per-segment** tau buffer width. Applying a per-segment capacity to the total point count over-clamps by roughly the number of segments: batched dense trajectories collapsed to ~80 samples where the sequential `post_process()` path produces ~1500 for the same problem.

This replaces the total-count clamp with a per-segment-aware bound. A uniform `linspace` grid drops about `(n_times − 1) · seg_dur / span` points into each segment, plus the endpoint sample `simulate_nonlinear_time` appends, so the bound solves

```
(n_times − 1) · frac_max + 2 ≤ max_tau_len
```

where `frac_max` is the largest segment-duration fraction across every segment of every batch element (from each element's node times via `s_to_t`). Near-uniform batches (`frac_max ≈ 1/(N−1)`) now pass through effectively unclamped; genuinely tight per-segment cases are still reduced enough that no segment can overfill the compiled buffer (verified empirically: a 100k-point request clamps to a grid whose busiest segment fills the buffer with one slot to spare).

## Context

Found while converting the race-car hybrid example (on `Chore/comparison` / `feature/f1-2026-energy`) to `solve_batched` + `post_process_batched` (built on #547): the three-car batch came out with 77-sample trajectories vs ~1500 sequentially, making the Viser replay visibly coarse. No caller-side workaround exists — `max_tau_len` is also the compiled pad width, so overriding it crashes with a shape mismatch.

## Tests

New `tests/test_post_process_batched_tau_clamp.py`:
- `test_batched_dense_grid_exceeds_per_segment_capacity` — default grid exceeds `max_tau_len` in total while every segment stays within capacity (fails before the fix: grid pinned to exactly `max_tau_len`).
- `test_batched_large_n_times_request_is_clamped_to_per_segment_capacity` — an absurd `n_times=100_000` is clamped and no segment overfills.

Full batched suites pass (57 tests across `test_post_process_batched_tau_clamp`, `test_solve_batched_brachistochrone`, `test_results_parameters`, `test_solve_batched_inference`, `test_solve_batched_cvxpy_export_errors`, `test_solve_batched_export_roundtrip`), plus `ruff check` / `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RmUa9YhgoAidsUFm36DZTY