### PR TITLE
Memoize canonicalize and JAX lowering by node identity

### DIFF
--- a/openscvx/symbolic/expr/expr.py
+++ b/openscvx/symbolic/expr/expr.py
@@ -63,14 +63,50 @@ Example:
         canonical = expr.canonicalize()  # Simplifies to: x + x
 """
 
+import functools
 import hashlib
 import struct
+import threading
 from typing import TYPE_CHECKING, Callable, List, Tuple, Union
 
 if TYPE_CHECKING:
     from .linalg import Transpose
 
 import numpy as np
+
+# Per-thread memo for canonicalize(). The memo canonicalizes each node once and
+# returns the same object to every parent, preserving sharing.
+_canon_state = threading.local()
+
+
+def _memoized_canonicalize(fn: Callable) -> Callable:
+    """Wrap a subclass ``canonicalize`` so shared subexpressions are reused.
+
+    Keyed by ``id(self)``; the node is held alive in the memo for the duration of
+    the pass so its id cannot be recycled, with an identity guard on lookup. The
+    top-level call owns the memo and clears it on exit, so each independent
+    canonicalize pass starts fresh.
+    """
+
+    @functools.wraps(fn)
+    def wrapper(self):
+        memo = getattr(_canon_state, "memo", None)
+        owns = memo is None
+        if owns:
+            memo = {}
+            _canon_state.memo = memo
+        try:
+            entry = memo.get(id(self))
+            if entry is not None and entry[0] is self:
+                return entry[1]
+            result = fn(self)
+            memo[id(self)] = (self, result)
+            return result
+        finally:
+            if owns:
+                _canon_state.memo = None
+
+    return wrapper
 
 
 class Expr:
@@ -100,6 +136,13 @@ class Expr:
 
     # Give Expr objects higher priority than numpy arrays in operations
     __array_priority__ = 1000
+
+    def __init_subclass__(cls, **kwargs):
+        # Wrap each subclass's own canonicalize() with identity memoization so a
+        # shared DAG node is canonicalized once rather than re-expanded per parent.
+        super().__init_subclass__(**kwargs)
+        if "canonicalize" in cls.__dict__:
+            cls.canonicalize = _memoized_canonicalize(cls.__dict__["canonicalize"])
 
     def __le__(self, other):
         from .constraint import Inequality

--- a/openscvx/symbolic/lowerers/jax/_lowerer.py
+++ b/openscvx/symbolic/lowerers/jax/_lowerer.py
@@ -7,8 +7,57 @@ The visitor methods that populate the registry live in sibling modules
 
 from typing import Callable
 
+import jax
+
 from openscvx.symbolic.expr import Expr
 from openscvx.symbolic.lowerers.jax._registry import dispatch
+
+_MISSING = object()
+
+# Value-memoization is only valid within a single JAX trace. Visitors bracket
+# their nested trace with :func:`pause_memo` / :func:`resume_memo` so the wrapped
+# closures recompute instead of returning a cross-trace value.
+_memo_paused = [0]
+
+
+def pause_memo() -> None:
+    """Disable value-memoization for the duration of a nested sub-trace."""
+    _memo_paused[0] += 1
+
+
+def resume_memo() -> None:
+    """Re-enable value-memoization after a nested sub-trace finishes tracing."""
+    _memo_paused[0] -= 1
+
+
+def _memoize_call(fn: Callable) -> Callable:
+    """Cache a lowered closure's result so it emits its subgraph once per trace.
+
+    Within a trace every node receives the same argument objects, so caching on
+    argument identity (``is``) lets a shared subexpression emit its subgraph once
+    instead of once per consumer. The cache only applies while tracing (at least
+    one positional argument is a JAX tracer); eager calls, keyword-argument
+    calls, and paused sections (nested sub-traces, see module note) bypass it.
+    """
+    last_args = None
+    last_val = _MISSING
+
+    def wrapped(*args, **kwargs):
+        nonlocal last_args, last_val
+        if kwargs or _memo_paused[0] or not any(isinstance(a, jax.core.Tracer) for a in args):
+            return fn(*args, **kwargs)
+        if (
+            last_val is not _MISSING
+            and last_args is not None
+            and len(last_args) == len(args)
+            and all(a is b for a, b in zip(last_args, args))
+        ):
+            return last_val
+        last_val = fn(*args)
+        last_args = args
+        return last_val
+
+    return wrapped
 
 
 class JaxLowerer:
@@ -22,8 +71,9 @@ class JaxLowerer:
     first, then composes them into a JAX operation. All lowered functions have
     a standardized signature (x, u, node, params) -> result.
 
-    Note:
-        This is a stateless lowerer - all state is in the expression tree.
+    Shared subexpressions are lowered once: :meth:`lower` caches the closure for
+    each AST node by object identity, and each closure is wrapped so it emits its
+    subgraph only once per trace (see :func:`_memoize_call`).
 
     Example:
         Set up the JaxLowerer and lower an expression to a JAX function::
@@ -34,14 +84,24 @@ class JaxLowerer:
             result = f(x_val, u_val, node=0, params={})
 
     Note:
-        The lowerer is stateless and can be reused for multiple expressions.
+        A fresh lowerer is created per lowering pass; its node cache is keyed by
+        ``id(expr)`` and is valid only while the expression tree is alive.
     """
+
+    def __init__(self) -> None:
+        # Maps id(expr) -> (expr, lowered closure) so each node is lowered once,
+        # no matter how many parents share it. Storing the expr itself keeps it
+        # alive: if it were garbage-collected, Python could reuse its id for a
+        # new node and the cache would return the wrong closure. The identity
+        # check on lookup guards against exactly that.
+        self._node_cache: dict[int, tuple[Expr, Callable]] = {}
 
     def lower(self, expr: Expr) -> Callable:
         """Lower a symbolic expression to a JAX function.
 
         Main entry point for lowering. Delegates to dispatch() which looks up
-        the appropriate visitor method based on the expression type.
+        the appropriate visitor method based on the expression type. Results are
+        memoized by node identity so shared subexpressions are lowered once.
 
         Args:
             expr: Symbolic expression to lower (any Expr subclass)
@@ -53,4 +113,10 @@ class JaxLowerer:
             NotImplementedError: If no visitor exists for the expression type
             ValueError: If the expression is malformed (e.g., State without slice)
         """
-        return dispatch(self, expr)
+        eid = id(expr)
+        cached = self._node_cache.get(eid)
+        if cached is not None and cached[0] is expr:
+            return cached[1]
+        fn = _memoize_call(dispatch(self, expr))
+        self._node_cache[eid] = (expr, fn)
+        return fn

--- a/openscvx/symbolic/lowerers/jax/logic.py
+++ b/openscvx/symbolic/lowerers/jax/logic.py
@@ -8,6 +8,7 @@ from jax.lax import cond
 
 # Expression types to handle — uncomment as you paste visitors:
 from openscvx.symbolic.expr.logic import All, Any, Cond
+from openscvx.symbolic.lowerers.jax._lowerer import pause_memo, resume_memo
 from openscvx.symbolic.lowerers.jax._registry import visitor  # noqa: F401
 
 # Module-level default dtype for conditional branches
@@ -189,11 +190,20 @@ def _visit_cond(lowerer, node: Cond):
         def _false_branch(_):
             return jnp.asarray(false_fn(x, u, node_arg, params), dtype=default_dtype)
 
-        return cond(
-            pred_bool,
-            _true_branch,
-            _false_branch,
-            operand=None,
-        )
+        # lax.cond traces each branch separately, but both branch closures see
+        # the same captured (x, u, node, params). Pause the memo so shared
+        # subexpressions are recomputed inside each branch: a value cached in
+        # one trace is not valid in another.
+        pause_memo()
+        try:
+            result = cond(
+                pred_bool,
+                _true_branch,
+                _false_branch,
+                operand=None,
+            )
+        finally:
+            resume_memo()
+        return result
 
     return cond_fn

--- a/openscvx/symbolic/lowerers/jax/vmap.py
+++ b/openscvx/symbolic/lowerers/jax/vmap.py
@@ -8,6 +8,7 @@ import jax.numpy as jnp
 
 # Expression types to handle — uncomment as you paste visitors:
 from openscvx.symbolic.expr.vmap import Vmap, _Placeholder
+from openscvx.symbolic.lowerers.jax._lowerer import pause_memo, resume_memo
 from openscvx.symbolic.lowerers.jax._registry import visitor  # noqa: F401
 
 
@@ -129,9 +130,14 @@ def _visit_vmap(lowerer, node: Vmap):
                     new_params[key] = v
                 return inner_fn(x, u, node_idx, new_params)
 
-            # vmap over all batch arguments along the same axis
+            # Nested sub-trace reusing captured (x, u, node_idx): pause
+            # value-memo so no cached tracer crosses the trace boundary.
             in_axes = tuple(axis for _ in range(num_batches))
-            return jax.vmap(inner, in_axes=in_axes)(*data_arrays)
+            pause_memo()
+            try:
+                return jax.vmap(inner, in_axes=in_axes)(*data_arrays)
+            finally:
+                resume_memo()
 
     else:
         # All Constants: bake all data into closure at lowering time
@@ -145,8 +151,12 @@ def _visit_vmap(lowerer, node: Vmap):
                     new_params[key] = v
                 return inner_fn(x, u, node_idx, new_params)
 
-            # vmap over all batch arguments along the same axis
+            # Nested sub-trace: pause value-memo (see runtime branch above).
             in_axes = tuple(axis for _ in range(num_batches))
-            return jax.vmap(inner, in_axes=in_axes)(*baked_data)
+            pause_memo()
+            try:
+                return jax.vmap(inner, in_axes=in_axes)(*baked_data)
+            finally:
+                resume_memo()
 
     return vmapped_fn


### PR DESCRIPTION
## Memoize canonicalize and JAX lowering by node identity

### What changed (high level)

Symbolic expressions form a DAG: a reused intermediate (a DCM, a forward-kinematics transform, an aero force) is a single node with many parents. Both `canonicalize()` and the JAX lowerer used to walk this structure as a *tree*, re-processing every shared node once per path from the root — waste that compounds multiplicatively with nesting depth. This PR memoizes both traversals by node identity, so every node is processed exactly once regardless of how many parents share it. Same results, strictly less work; no user-facing API changes.

### How it works (low level)

Four pieces, in three files:

- **`canonicalize()` memo** (`openscvx/symbolic/expr/expr.py`): `Expr.__init_subclass__` wraps each subclass's `canonicalize()` with a per-thread, per-pass memo keyed on `id(self)`. A shared node is canonicalized once and the same object is returned to every parent, preserving sharing in the output. The top-level call owns the memo and clears it on exit; nodes are held alive in the memo so their `id` can't be recycled mid-pass, with an identity check on lookup.
- **Node cache** (`openscvx/symbolic/lowerers/jax/_lowerer.py`): `JaxLowerer.lower()` caches the lowered closure per AST node (`id(expr) → (expr, closure)`), so a shared node is lowered once instead of once per parent.
- **Per-trace value memo** (`_memoize_call`, same file): each lowered closure caches its last result on argument identity. Within a JAX trace every node receives the same argument objects, so a shared subexpression emits its jaxpr subgraph once instead of once per consumer. The cache only engages while tracing (an argument is a JAX tracer); eager calls and keyword-argument calls bypass it.
- **Trace-boundary guards** (`openscvx/symbolic/lowerers/jax/logic.py`, `openscvx/symbolic/lowerers/jax/vmap.py`): `lax.cond` branches and `vmap` bodies are traced as nested sub-traces while reusing the captured `(x, u, node, params)`. The visitors bracket these with `pause_memo()`/`resume_memo()` so a value cached in one trace is never returned inside another.

### Performance

Node counts (dynamics + constraints; "tree-expanded" is what the un-memoized traversal effectively processes, "DAG" is unique nodes):

| Example | Stage | Tree-expanded (before) | DAG (after) | Reduction |
|---|---|---|---|---|
| 7_dof_arm | raw | 1,192 | **113** | **10.5×** |
| 7_dof_arm | after canonicalize | 1,220 | 497 | 2.5× |
| 6DoF_pdg | raw | 1,600 | **340** | **4.7×** |
| 6DoF_pdg | after canonicalize | 1,617 | 441 | 3.7× |

Initialization time (import through `problem.initialize()`, two fresh-process runs each, CPU JAX):

| Example | Phase | After | Before | Speedup |
|---|---|---|---|---|
| 7_dof_arm | `initialize()` | **39.9 s** | 53.2–56.9 s | **~1.35×** |
| 6DoF_pdg | `initialize()` | **4.9–5.1 s** | 8.2–8.3 s | **~1.7×** |

Symbolic build time is unchanged (the fix affects traversals, not expression construction), and the remaining `initialize()` cost is dominated by XLA compilation.