### PR TITLE
Feature/multi agent race

### DIFF
--- a/examples/race_cars/README.md
+++ b/examples/race_cars/README.md
@@ -23,7 +23,7 @@ progress, applied one node at a time in closed loop, mirroring the acados
 benchmark's NMPC formulation.
 
 `race_car_multi_agent.py` combines the two: a whole grid of the hybrid cars
-races wheel-to-wheel from an F1-style standing start. One symbolic problem
+races `M_LAPS` laps wheel-to-wheel from an F1-style standing start. One symbolic problem
 describes a single car's MPC horizon; each race step advances the entire
 field with a single `solve_batched` call, batching over per-car boundary
 pins, spec parameters (power, mass, battery size), and each car's forecast

--- a/examples/race_cars/README.md
+++ b/examples/race_cars/README.md
@@ -16,3 +16,19 @@ actively binds at the optimum. The example solves three power-unit variants — 
 MGU-K failure, and an unrestricted full-envelope ICE — as a single batched
 solve over the power-unit parameters, then races all three cars on one
 Viser track to make the electric system's lap-time worth directly visible.
+
+`race_car_mpc.py` swaps the single global minimum-time solve for a
+receding-horizon controller: a short fixed horizon that maximises arc-length
+progress, applied one node at a time in closed loop, mirroring the acados
+benchmark's NMPC formulation.
+
+`race_car_multi_agent.py` combines the two: a whole grid of the hybrid cars
+races wheel-to-wheel from an F1-style standing start. One symbolic problem
+describes a single car's MPC horizon; each race step advances the entire
+field with a single `solve_batched` call, batching over per-car boundary
+pins, spec parameters (power, mass, battery size), and each car's forecast
+of its opponents' trajectories. Cars keep an elliptical clearance in track
+coordinates from the plans their opponents published on the previous step —
+decentralized MPC with communicated plans — so overtakes and energy strategy
+emerge from the optimization. The `AGENTS` roster at the top of the file is
+the only thing to edit to grow the field or tweak a car's spec.

--- a/examples/race_cars/race_car_multi_agent.py
+++ b/examples/race_cars/race_car_multi_agent.py
@@ -82,7 +82,7 @@ AGENTS = [
     dict(
         name="down on power",
         color=(220, 35, 45),
-        power_scale=0.9,
+        power_scale=0.8,
         mass_scale=1.0,
         battery_scale=1.0,
     ),
@@ -97,15 +97,15 @@ AGENTS = [
         name="overweight",
         color=(240, 190, 50),
         power_scale=1.0,
-        mass_scale=1.15,
+        mass_scale=1.25,
         battery_scale=1.0,
     ),
     dict(
         name="reference P4",
         color=(120, 200, 120),
-        power_scale=1.0,
-        mass_scale=1.0,
-        battery_scale=1.0,
+        power_scale=1.1,
+        mass_scale=0.9,
+        battery_scale=1.1,
     ),
 ]
 K = len(AGENTS)
@@ -115,7 +115,7 @@ K = len(AGENTS)
 # published plan together — while counting laps and resetting the per-lap
 # recovery budget. Solver scaling, weights, and the curvature spline are
 # therefore all independent of race length.
-M_LAPS = 1
+M_LAPS = 3
 
 # ── Track data ─────────────────────────────────────────────────────────────────
 # 4x LMS kart track, as in race_car_hybrid.py: long enough that the cars are
@@ -440,8 +440,12 @@ problem = ox.Problem(
         # active set flutters there by ~1 cm no matter how many iterations run
         # (J_vc and J_vb sit at machine precision throughout). ep_tr sits just
         # above that structural jitter floor; the applied node-0 controls are
-        # stable well before it.
-        "ep_tr": 1e-2,
+        # stable well before it. The floor grows with the car's pace — a spec
+        # sweep (power 0.7–1.25, mass to 1.6, battery to 0.25) showed the
+        # reference car converging 95%+ at 1e-2 but a +25% power car only 86%
+        # — so size the tolerance for the hottest spec in the roster; no other
+        # weight needed retuning across the whole spread.
+        "ep_tr": 3e-2,
     },
     # The default integration atol (1e-3) is coarser than the battery states
     # (~0.1 J), and that linearization noise lands right at the ep_tr floor:
@@ -822,6 +826,7 @@ class RaceLog:
     dense_t: np.ndarray  # (Td,)
     dense_x: np.ndarray  # (K, Td, len(DRIVER_STATES))
     dense_u: np.ndarray  # (K, Td, 4)  [derD, derDelta, deploy, regen]
+    converged: np.ndarray  # (T, K) bool — per car, per MPC step
 
 
 def run_race(max_steps: int = MAX_STEPS) -> RaceLog:
@@ -942,6 +947,7 @@ def run_race(max_steps: int = MAX_STEPS) -> RaceLog:
         dense_t=np.concatenate(dense_t),
         dense_x=np.concatenate(dense_x, axis=1),
         dense_u=np.concatenate(dense_u, axis=1),
+        converged=np.stack(conv_flags),
     )
 
 

--- a/examples/race_cars/race_car_multi_agent.py
+++ b/examples/race_cars/race_car_multi_agent.py
@@ -161,10 +161,12 @@ R_LAP_MAX = 2.0 * E_BATT_MAX  # per-lap recovery cap [J] (a regulation: same for
 E_CAP_TOP = E_BATT_MAX * max(spec["battery_scale"] for spec in AGENTS)
 
 # ── Separation ellipse (track coordinates) ─────────────────────────────────────
-# Centre-to-centre keep-out around the ~0.07 x 0.03 m body: half a body of
+# Centre-to-centre keep-out around the ~0.07 x 0.03 m body: most of a body of
 # daylight each way, which also absorbs the one-step lag of opponent forecasts.
-SEP_LONG = 0.10  # semi-axis along the track [m]
-SEP_LAT = 0.05  # semi-axis across the track [m]
+# The ellipse must sit far enough outside the body that the huber penalty cannot
+# let grazing cars overlap on the propagated trajectory.
+SEP_LONG = 0.12  # semi-axis along the track [m]
+SEP_LAT = 0.06  # semi-axis across the track [m]
 
 # ── MPC horizon ────────────────────────────────────────────────────────────────
 # Long enough to plan a whole overtake (braking zone plus the next straight);
@@ -180,11 +182,11 @@ MAX_STEPS = int(np.ceil(RACE_TIME_MAX / DT_MPC))
 # finished cars keep driving until the last car crosses.
 S_OVERRUN = 4.0 * HORIZON_TF
 
-# Ceiling on SCP iterations per step — a guard against pathological steps, not
-# a real-time-iteration truncation: warm-started steps converge in a handful
-# of iterations in clean air and a few tens in wheel-to-wheel traffic, so 50
-# sits comfortably above both.
-SCP_ITERS_PER_STEP = 50
+# Ceiling on SCP iterations per step, in the spirit of a real-time iteration:
+# warm-started steps converge quickly in clean air, and the occasional
+# wheel-to-wheel step that wants more is cut off here and recovers on the next
+# step (per-step outcomes land in ``RaceLog.converged``).
+SCP_ITERS_PER_STEP = 10
 
 # ── States ─────────────────────────────────────────────────────────────────────
 # Boundary values and guesses below describe the pole slot only: every solve
@@ -401,21 +403,21 @@ problem = ox.Problem(
         # batch element). The progress reward must dominate the proximal
         # anchor or the field crawls glued to its warm start, and lam_vc must
         # dominate the reward or virtual control buys progress instead of
-        # driving. ep_tr sits just above the plan's structural jitter floor
-        # (the terminal reward flutters against the grip limit at the horizon
-        # tail by ~1 cm regardless of iterations); the floor grows with the
-        # car's pace, so size it for the hottest spec in the roster.
+        # driving. ep_tr sits just above the plan's structural jitter floor;
+        # that floor grows with the car's pace, so size it for the fastest
+        # spec in the roster.
         "lam_vc": 1e3,
         "lam_prox": 2e0,
         "lam_cost": {"s": 4e1},
         "autotuner": ox.ConstantProximalWeight(),
         "ep_tr": 3e-2,
     },
-    # Default integration tolerances (atol 1e-3) are coarser than the battery
-    # states and put linearization noise at the ep_tr floor; tight tolerances
-    # roughly halve the non-converged steps for ~15% more time per step.
+    # Integration tolerance sets the linearization-noise floor, which must sit
+    # below ep_tr — otherwise the trust region converges on integration noise
+    # rather than a real optimum. Tighter than this buys no accuracy and only
+    # spends integration time.
     discretizer={
-        "diffrax_kwargs": {"atol": 1e-8, "rtol": 1e-8},
+        "diffrax_kwargs": {"atol": 1e-6, "rtol": 1e-6},
     },
     solver=ox.MoreauPTRSolver(),
 )
@@ -750,8 +752,9 @@ class RaceLog:
     classification, audits. ``dense_*`` stitch each step's *propagated*
     executed interval together (``post_process_batched`` under the hood), so
     playback and plots see the continuous trajectories the cars actually
-    drove, not the node samples. ``s`` entries in both logs are cumulative
-    race distance.
+    drove, not the node samples; with ``run_race(dense=False)`` they instead
+    carry one node-rate sample per step. ``s`` entries in both logs are
+    cumulative race distance.
     """
 
     sim: np.ndarray  # (T, K, len(DRIVER_STATES)) at the MPC rate
@@ -763,12 +766,14 @@ class RaceLog:
     converged: np.ndarray  # (T, K) bool — per car, per MPC step
 
 
-def run_race(max_steps: int = MAX_STEPS) -> RaceLog:
+def run_race(max_steps: int = MAX_STEPS, dense: bool = True) -> RaceLog:
     """Race the roster to the flag and return the :class:`RaceLog`.
 
     One ``solve_batched`` call advances the whole field by one node
     (``DT_MPC``) per iteration; each step's executed interval is propagated
-    densely for the log.
+    densely for the log. ``dense=False`` skips that per-step propagation and
+    the ``dense_*`` fields fall back to one node-rate sample per step, so plots
+    and playback still work, just at the MPC rate.
     """
     x0 = initial_pins()
     x_guess, u_guess = cold_start_guesses()
@@ -811,20 +816,25 @@ def run_race(max_steps: int = MAX_STEPS) -> RaceLog:
         # game, not of any car's spec or the weights.
         conv_flags.append(np.asarray(results.converged).reshape(-1))
 
-        # Propagate the horizon and keep the executed interval [0, DT_MPC):
-        # stitched across steps this is the continuous closed-loop trajectory.
-        post = problem.post_process_batched(results)
-        t_prop = np.asarray(post.t_full)[0]  # horizon clock, shared by all cars
-        keep = t_prop < DT_MPC - 1e-9
-        seg_x = np.asarray(post.x_full)[:, keep, : len(DRIVER_STATES)].copy()
-        seg_x[:, :, COL["s"]] += laps[:, None] * pathlength
-        dense_t.append(t_now + t_prop[keep])
-        dense_x.append(seg_x)
-        dense_u.append(np.asarray(post.u_full)[:, keep, :4])
-
         nodes = {name: np.asarray(results.nodes[name]) for name in DRIVER_STATES}
         row = np.stack([nodes[name][:, 0, 0] for name in DRIVER_STATES], axis=1)  # (K, n)
         row[:, COL["s"]] += laps * pathlength  # the log carries cumulative race distance
+
+        if dense:
+            # Propagate the horizon and keep the executed interval [0, DT_MPC):
+            # stitched across steps this is the continuous closed-loop trajectory.
+            post = problem.post_process_batched(results)
+            t_prop = np.asarray(post.t_full)[0]  # horizon clock, shared by all cars
+            keep = t_prop < DT_MPC - 1e-9
+            seg_x = np.asarray(post.x_full)[:, keep, : len(DRIVER_STATES)].copy()
+            seg_x[:, :, COL["s"]] += laps[:, None] * pathlength
+            dense_t.append(t_now + t_prop[keep])
+            dense_x.append(seg_x)
+            dense_u.append(np.asarray(post.u_full)[:, keep, :4])
+        else:
+            dense_t.append(np.array([t_now]))
+            dense_x.append(row[:, None, :].copy())
+            dense_u.append(np.asarray(results.u)[:, :1, :4])
 
         # Finish detection: interpolate the flag crossing inside the last step.
         for i in range(K):

--- a/examples/race_cars/race_car_multi_agent.py
+++ b/examples/race_cars/race_car_multi_agent.py
@@ -180,13 +180,11 @@ MAX_STEPS = int(np.ceil(RACE_TIME_MAX / DT_MPC))
 # finished cars keep driving until the last car crosses.
 S_OVERRUN = 4.0 * HORIZON_TF
 
-# Real-time iteration: a fixed SCP budget per step instead of solving each
-# horizon to convergence — the shifted warm start carries optimality from one
-# step into the next, as in any SQP-style MPC. Expect the convergence rate to
-# dip in wheel-to-wheel traffic (~85% within 20 cm of an opponent vs ~100% in
-# clean air): opponents' published plans move between steps, which is a
-# property of the game, not of any car's spec or the weights.
-SCP_ITERS_PER_STEP = 10
+# Ceiling on SCP iterations per step — a guard against pathological steps, not
+# a real-time-iteration truncation: warm-started steps converge in a handful
+# of iterations in clean air and a few tens in wheel-to-wheel traffic, so 50
+# sits comfortably above both.
+SCP_ITERS_PER_STEP = 50
 
 # ── States ─────────────────────────────────────────────────────────────────────
 # Boundary values and guesses below describe the pole slot only: every solve
@@ -808,6 +806,9 @@ def run_race(max_steps: int = MAX_STEPS) -> RaceLog:
             max_iters=SCP_ITERS_PER_STEP,
         )
         solve_ms.append((_time.perf_counter() - tic) * 1e3)
+        # Non-converged steps concentrate in wheel-to-wheel traffic, where
+        # opponents' published plans move between steps — a property of the
+        # game, not of any car's spec or the weights.
         conv_flags.append(np.asarray(results.converged).reshape(-1))
 
         # Propagate the horizon and keep the executed interval [0, DT_MPC):
@@ -929,15 +930,12 @@ if __name__ == "__main__":
     if os.environ.get("OPENSCVX_NO_PLOT") is None:
         plot_race(log)
 
-        from race_car_viser import (
-            create_race_car_chase_viser_server,
-            create_race_car_comparison_viser_server,
-        )
+        from race_car_viser import create_race_car_comparison_viser_server
 
         # Trim each car's dense log at its own flag crossing so the replay
         # parks it at the line and the finishing gaps stay visible.
         cross = [crossing_index(log.dense_x[i, :, COL["s"]]) for i in range(K)]
-        comparison_server = create_race_car_comparison_viser_server(
+        server = create_race_car_comparison_viser_server(
             simX_list=[log.dense_x[i, : cross[i], :6] for i in range(K)],
             t_sim_list=[log.dense_t[: cross[i]] for i in range(K)],
             labels=[spec["name"] for spec in AGENTS],
@@ -949,14 +947,4 @@ if __name__ == "__main__":
             title="Multi-agent race",
             plot_panels=build_viser_panels(log),
         )
-        winner = order[0]
-        chase_server = create_race_car_chase_viser_server(
-            simX=log.dense_x[winner, : cross[winner], :6],
-            t_sim=log.dense_t[: cross[winner]],
-            track_file=TRACK_FILE,
-            lane_width=LANE_HALF_WIDTH,
-            trim_warmup=False,
-            title=f"Winner — {AGENTS[winner]['name']}",
-        )
-        print("Race replay and winner chase camera are on separate Viser ports.")
-        chase_server.sleep_forever()
+        server.sleep_forever()

--- a/examples/race_cars/race_car_multi_agent.py
+++ b/examples/race_cars/race_car_multi_agent.py
@@ -30,20 +30,14 @@ simple — "gap along the track, gap across it" is exactly the (s, n) state,
 with none of the reference-path bookkeeping an MPCC formulation needs
 (compare ``examples/mpc/double_integrator_drone_racing.py``).
 
-The race runs ``M_LAPS`` laps from a standing start on an F1-style grid:
-cars staggered by ``GRID_ROW_GAP`` down the track, alternating left and
-right of the centreline. As in the MPCC example, the ``s`` state lives on a
-single lap: the race loop wraps it at each line crossing (pin, warm start,
-and published plan together), counts laps, and resets the per-lap recovery
-budget ``R`` — so solver scaling and weights never depend on race length,
-and the separation gap is lap-periodic so a car being lapped is still an
-obstacle. The ``AGENTS`` roster is the single scaling knob — add an entry
-and the grid, the batch, the avoidance constraints, and the plots all grow
-with it. Spec differences are runtime parameters, so tweaking the field
-(a down-on-power engine, an oversize battery, ballast) never recompiles.
-The default roster puts a car that is 10% down on power on pole, a healthy
-reference car behind it, an overweight car in row two, and a second
-reference car charging from the back: every pass has to happen on track.
+The race runs ``M_LAPS`` laps from a standing start on an F1-style grid. As
+in the MPCC example, the ``s`` state lives on a single lap: the race loop
+wraps it at each line crossing, counts laps, and resets the per-lap recovery
+budget ``R``, so solver scaling and weights never depend on race length; the
+separation gap is lap-periodic so a car being lapped is still an obstacle.
+The ``AGENTS`` roster is the single scaling knob — add or tweak an entry
+(specs are runtime parameters, so no recompilation) and the grid, batch,
+constraints, and plots all follow.
 
 Run headless (no Plotly/Viser) with ``OPENSCVX_NO_PLOT=1``.
 """
@@ -73,10 +67,9 @@ from tracks.readDataFcn import getTrack
 import openscvx as ox
 
 # ── Roster ─────────────────────────────────────────────────────────────────────
-# One entry per car, in grid order (index 0 starts on pole). ``power_scale``
-# scales the whole drive-force envelope, ``mass_scale`` the chassis mass, and
-# ``battery_scale`` the energy store (the per-lap recovery cap is a regulation,
-# so it stays fixed). All three are runtime parameters of one compiled problem:
+# One entry per car, in grid order (index 0 on pole). The scales multiply the
+# drive-force envelope, chassis mass, and battery capacity (the per-lap
+# recovery cap is a regulation and stays fixed). All are runtime parameters:
 # edit or extend this list and everything downstream follows.
 AGENTS = [
     dict(
@@ -87,10 +80,10 @@ AGENTS = [
         battery_scale=1.0,
     ),
     dict(
-        name="reference spec",
+        name="miata",
         color=(90, 140, 235),
-        power_scale=1.0,
-        mass_scale=1.0,
+        power_scale=0.75,
+        mass_scale=0.75,
         battery_scale=1.0,
     ),
     dict(
@@ -110,11 +103,9 @@ AGENTS = [
 ]
 K = len(AGENTS)
 
-# Race length. As in the MPCC example, the s state lives on a single lap and
-# the race loop wraps it at each line crossing — pin, warm start, and
-# published plan together — while counting laps and resetting the per-lap
-# recovery budget. Solver scaling, weights, and the curvature spline are
-# therefore all independent of race length.
+# Race length. The s state lives on a single lap (wrapped at each crossing,
+# as in the MPCC example), so solver scaling and weights are independent of
+# race length.
 M_LAPS = 3
 
 # ── Track data ─────────────────────────────────────────────────────────────────
@@ -138,10 +129,8 @@ def grid_slot(i: int) -> tuple[float, float]:
     return -(i + 1) * GRID_ROW_GAP, 0.5 * LANE_HALF_WIDTH * (1.0 if i % 2 == 0 else -1.0)
 
 
-# κ is lap-periodic, so two tiled copies cover every horizon: s is wrapped
-# back to the first copy at each line crossing, long before it could reach
-# the second copy's end. The low pad covers the deepest grid slot (the track
-# is straight there, so the boundary value is right).
+# κ is lap-periodic: two tiled copies cover every horizon (s wraps back to the
+# first copy at each crossing), and the low pad covers the grid slots.
 _pad_lo = (K + 1) * GRID_ROW_GAP + 1.0
 _s_tiled = np.concatenate([sref_data[:-1], sref_data + pathlength])
 _kappa_tiled = np.concatenate([kapparef_data[:-1], kapparef_data])
@@ -172,37 +161,31 @@ R_LAP_MAX = 2.0 * E_BATT_MAX  # per-lap recovery cap [J] (a regulation: same for
 E_CAP_TOP = E_BATT_MAX * max(spec["battery_scale"] for spec in AGENTS)
 
 # ── Separation ellipse (track coordinates) ─────────────────────────────────────
-# Longer than it is wide, like the safe zone around a real car, and about as
-# tight as the bodywork allows: the 1:43 body is ~0.07 x 0.03 m, so these
-# centre-to-centre semi-axes leave roughly half a body of daylight in each
-# direction. Cars race nose-to-gearbox and wheel-to-wheel. The daylight is
-# also the robustness margin: each car avoids the plan its opponent published
-# one step earlier, so in a hard scrap the realized gap can sag a few percent
-# into the bubble — half a body absorbs that without bodywork contact.
+# Centre-to-centre keep-out around the ~0.07 x 0.03 m body: half a body of
+# daylight each way, which also absorbs the one-step lag of opponent forecasts.
 SEP_LONG = 0.10  # semi-axis along the track [m]
 SEP_LAT = 0.05  # semi-axis across the track [m]
 
 # ── MPC horizon ────────────────────────────────────────────────────────────────
-# Three seconds reaches through a braking zone and far enough down the next
-# straight to plan a whole overtake. A horizon study (2/3/4 s races on this
-# roster) shows the difference in kind: at 2 s the fastest car cannot plan
-# past a defender's bubble and the weakest car wins on track position; at
-# 3 s passes complete and the field finishes sorted by pace, ~1.2 s quicker.
-# 4 s adds cost but nothing further.
+# Long enough to plan a whole overtake (braking zone plus the next straight);
+# shorter horizons cannot see past a defender's bubble and track position
+# beats pace.
 N_MPC = 31  # horizon nodes
 HORIZON_TF = 3.0  # [s] prediction horizon
 DT_MPC = HORIZON_TF / (N_MPC - 1)  # time between consecutive nodes = one race step [s]
 RACE_TIME_MAX = 15.0 + 20.0 * M_LAPS  # [s] give up if the field has not finished by then
 MAX_STEPS = int(np.ceil(RACE_TIME_MAX / DT_MPC))
 
-# Overrun past the flag: finished cars keep driving until the last car
-# crosses, and every horizon looks this far beyond its own position, so the
-# margin scales with the lookahead (top speed ~3 m/s plus slack).
+# Overrun past the flag: horizons look this far beyond their own position and
+# finished cars keep driving until the last car crosses.
 S_OVERRUN = 4.0 * HORIZON_TF
 
 # Real-time iteration: a fixed SCP budget per step instead of solving each
 # horizon to convergence — the shifted warm start carries optimality from one
-# step into the next, as in any SQP-style MPC.
+# step into the next, as in any SQP-style MPC. Expect the convergence rate to
+# dip in wheel-to-wheel traffic (~85% within 20 cm of an opponent vs ~100% in
+# clean air): opponents' published plans move between steps, which is a
+# property of the game, not of any car's spec or the weights.
 SCP_ITERS_PER_STEP = 10
 
 # ── States ─────────────────────────────────────────────────────────────────────
@@ -383,16 +366,10 @@ a_long = Fxd / m_car
 
 constraints.append(ox.ctcs(a_lat**2 + a_long**2 <= A_MAX**2, penalty="huber"))
 
-# Opponent separation, continuous in time. The forecasts are only known at
-# the horizon nodes, but every car shares the same uniform clock, so hat
-# weights in the time state turn each opponent's forecast into a
-# piecewise-linear trajectory the CTCS penalty can evaluate *between* nodes
-# too — no gap for a car to slip through at a node boundary. The ``W_SEP``
-# scaling makes contact far dearer than any progress the reward could buy;
-# without it, driving through an opponent costs less than lifting, and the
-# solver ghost-passes. It also sets how crisply the soft huber penalty holds
-# the boundary — the bubble is barely half a body wide, so the few-percent
-# sag a lighter weight allows is already wheel-banging.
+# Opponent separation, continuous in time: hat weights in the time state turn
+# each opponent's node forecast into a piecewise-linear trajectory (all cars
+# share one uniform horizon clock), and W_SEP prices contact far above any
+# progress the reward could buy — an unweighted bubble gets driven through.
 W_SEP = 4e3
 
 if K > 1:
@@ -400,12 +377,9 @@ if K > 1:
     for j in range(K - 1):
         opp_s_t = ox.Sum(hat * opp_s[:, j])
         opp_n_t = ox.Sum(hat * opp_n[:, j])
-        # Plans are published in each car's own lap frame, so Δs can be off
-        # by whole laps (a freshly wrapped car vs. one still approaching the
-        # line, or a car being lapped). The gap is therefore lap-periodic:
-        # (L/π)·sin(π·Δs/L) matches Δs exactly near whole-lap multiples — the
-        # only place the bubble can bind — and stays harmlessly large in
-        # between.
+        # Plans live in per-car lap frames, so the gap must be lap-periodic:
+        # (L/π)·sin(π·Δs/L) matches Δs near whole-lap multiples — the only
+        # place the bubble can bind — and stays harmlessly large in between.
         ds = s[0] - opp_s_t
         ds_wrap = ox.Constant(pathlength / np.pi) * ox.Sin(ox.Constant(np.pi / pathlength) * ds)
         gap = (ds_wrap / SEP_LONG) ** 2 + ((n[0] - opp_n_t) / SEP_LAT) ** 2
@@ -425,37 +399,23 @@ problem = ox.Problem(
     N=N_MPC,
     float_dtype="float64",
     algorithm={
-        # The progress reward must dominate the proximal anchor (states are
-        # scaled by their ranges, and s spans the whole 4x track, so a metre
-        # of progress is a small scaled step) — too small and each solve
-        # "converges" glued to its warm start and the field crawls. lam_vc
-        # must in turn dominate the reward, or virtual control buys progress
-        # at the horizon's last node instead of driving there.
-        # lam_prox/ep_tr picked by a batched sweep (solve_batched over a
-        # lam_prox x ep_tr grid, one single-car lap per element): 2.0/1e-2 is
-        # the fastest lap with ~96% of steps converged. Heavier damping
-        # "converges" more often but to visibly worse plans — the car crawls.
+        # Weights from batched sweeps (one single-car closed-loop lap per
+        # batch element). The progress reward must dominate the proximal
+        # anchor or the field crawls glued to its warm start, and lam_vc must
+        # dominate the reward or virtual control buys progress instead of
+        # driving. ep_tr sits just above the plan's structural jitter floor
+        # (the terminal reward flutters against the grip limit at the horizon
+        # tail by ~1 cm regardless of iterations); the floor grows with the
+        # car's pace, so size it for the hottest spec in the roster.
         "lam_vc": 1e3,
         "lam_prox": 2e0,
         "lam_cost": {"s": 4e1},
         "autotuner": ox.ConstantProximalWeight(),
-        # Convergence for a receding horizon means the *plan* is stationary,
-        # not stationary to solver precision: the terminal progress reward
-        # works against the grip limit at the horizon tail, and the linearized
-        # active set flutters there by ~1 cm no matter how many iterations run
-        # (J_vc and J_vb sit at machine precision throughout). ep_tr sits just
-        # above that structural jitter floor; the applied node-0 controls are
-        # stable well before it. The floor grows with the car's pace — a spec
-        # sweep (power 0.7–1.25, mass to 1.6, battery to 0.25) showed the
-        # reference car converging 95%+ at 1e-2 but a +25% power car only 86%
-        # — so size the tolerance for the hottest spec in the roster; no other
-        # weight needed retuning across the whole spread.
         "ep_tr": 3e-2,
     },
-    # The default integration atol (1e-3) is coarser than the battery states
-    # (~0.1 J), and that linearization noise lands right at the ep_tr floor:
-    # with default tolerances only ~60% of car-steps converge within the
-    # iteration budget, with tight ones ~90%+, for ~15% more time per step.
+    # Default integration tolerances (atol 1e-3) are coarser than the battery
+    # states and put linearization noise at the ep_tr floor; tight tolerances
+    # roughly halve the non-converged steps for ~15% more time per step.
     discretizer={
         "diffrax_kwargs": {"atol": 1e-8, "rtol": 1e-8},
     },
@@ -494,11 +454,9 @@ def cold_start_guesses() -> tuple[np.ndarray, np.ndarray]:
 def shift_forecast(plan: np.ndarray) -> np.ndarray:
     """Advance published plans one node so they align with the next horizon.
 
-    Every car's horizon runs on the same uniform clock and moves forward one
-    node per race step, so node ``k`` of the *next* horizon is node ``k + 1``
-    of the plan an opponent just published. The freed final node is
-    extrapolated along the plan — holding it would forecast the opponent
-    parking for the last interval of every horizon.
+    All horizons share one uniform clock, so node ``k`` of the next horizon is
+    node ``k + 1`` of the plan just published; the freed final node is
+    extrapolated (a held node would forecast the opponent parking).
     """
     tail = 2.0 * plan[:, -1:] - plan[:, -2:-1]
     return np.concatenate([plan[:, 1:], tail], axis=1)
@@ -512,12 +470,10 @@ _X_HI = np.array([st.max[0] for st in states])
 def shifted_guesses(results) -> tuple[np.ndarray, np.ndarray]:
     """Warm starts for the next step: previous plans shifted one node.
 
-    The freed final node is *extrapolated* along the plan, not held — a held
-    tail is dynamically infeasible (the state freezes while carrying racing
-    speed), which hands every solve a built-in defect at the last interval
-    that virtual control must burn iterations repairing. Controls hold their
-    last value. The horizon clock and the CTCS violation integrators restart
-    from zero each solve, so those columns are reset rather than shifted.
+    The freed final state node is extrapolated, not held — a held tail is
+    dynamically infeasible and burns SCP iterations on virtual control.
+    Controls hold their last value; the horizon clock and CTCS integrators
+    restart from zero.
     """
     x = np.asarray(results.x)
     u = np.asarray(results.u)
@@ -922,13 +878,11 @@ def run_race(max_steps: int = MAX_STEPS) -> RaceLog:
         pred_s = nodes["s"][:, :, 0].copy()
         pred_n = nodes["n"][:, :, 0]
 
-        # Lap handling, as in the MPCC example: when a car takes the line its
-        # s frame wraps back one lap — pin, warm start, and published plan
-        # together — and its recovery budget R resets. Opponents only ever see
-        # the frame through the lap-periodic gap, which is invariant to the
-        # shift. A horizon straddling the line charges its first metres of
-        # new-lap harvesting to the old lap's budget: conservative by at most
-        # one horizon, exact again at the reset.
+        # Lap handling, as in the MPCC example: a car taking the line has its
+        # s frame wrapped back one lap — pin, warm start, and published plan
+        # together — and its recovery budget R reset. (A horizon straddling
+        # the line charges its first new-lap metres to the old lap's budget:
+        # conservative by at most one horizon.)
         for i in range(K):
             if x0[i, COL["s"]] >= pathlength:
                 laps[i] += 1

--- a/examples/race_cars/race_car_multi_agent.py
+++ b/examples/race_cars/race_car_multi_agent.py
@@ -20,14 +20,15 @@ MPC: at every step each car re-plans against the plans its opponents
 published on the previous step (shifted one node so the horizons stay
 aligned), keeping an elliptical clearance in track coordinates
 
-    ((s - s_j) / SEP_LONG)² + ((n - n_j) / SEP_LAT)² ≥ 1
+    ((s - s_j(t)) / SEP_LONG)² + ((n - n_j(t)) / SEP_LAT)² ≥ 1
 
-from every opponent j at every horizon node. All cars share one fixed,
-uniform horizon time grid, so node k of every plan refers to the same wall
-clock and node-wise separation is meaningful. The Frenet model makes the
-constraint this simple — "gap along the track, gap across it" is exactly
-the (s, n) state, with none of the reference-path bookkeeping an MPCC
-formulation needs (compare ``examples/mpc/double_integrator_drone_racing.py``).
+from every opponent j, enforced continuously in time (CTCS). All cars share
+one fixed, uniform horizon clock, so an opponent's forecast — known at the
+horizon nodes — interpolates to a trajectory s_j(t), n_j(t) the constraint
+can evaluate between nodes too. The Frenet model makes the constraint this
+simple — "gap along the track, gap across it" is exactly the (s, n) state,
+with none of the reference-path bookkeeping an MPCC formulation needs
+(compare ``examples/mpc/double_integrator_drone_racing.py``).
 
 The race is a standing start from an F1-style grid: cars staggered by
 ``GRID_ROW_GAP`` down the track, alternating left and right of the
@@ -101,7 +102,7 @@ LANE_HALF_WIDTH = 0.24
 
 # Overrun past the flag: finished cars keep driving until the last car crosses,
 # and every horizon looks this far beyond its own position.
-S_OVERRUN = 6.0
+S_OVERRUN = 8.0
 
 # ── Grid (F1 standing start) ───────────────────────────────────────────────────
 GRID_ROW_GAP = 0.5  # longitudinal stagger between consecutive grid slots [m]
@@ -151,8 +152,10 @@ SEP_LONG = 0.35  # semi-axis along the track [m]
 SEP_LAT = 0.12  # semi-axis across the track [m]
 
 # ── MPC horizon ────────────────────────────────────────────────────────────────
-N_MPC = 15  # horizon nodes
-HORIZON_TF = 1.0  # [s] prediction horizon — covers braking from top speed
+# Two seconds reaches through an entire braking zone and out the other side,
+# which is what lets a car weigh harvesting now against deploying later.
+N_MPC = 21  # horizon nodes
+HORIZON_TF = 2.0  # [s] prediction horizon
 DT_MPC = HORIZON_TF / (N_MPC - 1)  # time between consecutive nodes = one race step [s]
 RACE_TIME_MAX = 40.0  # [s] give up if the field has not finished by then
 MAX_STEPS = int(np.ceil(RACE_TIME_MAX / DT_MPC))
@@ -340,18 +343,23 @@ a_long = Fxd / m_car
 
 constraints.append(ox.ctcs(a_lat**2 + a_long**2 <= A_MAX**2, penalty="huber"))
 
-# Opponent separation: at horizon node k, stay outside every opponent's ellipse,
-# evaluated against their forecast position at that same node. Node 0 is the
-# pinned current state, so the constraint starts at node 1. The heavy
-# ``.weight`` makes the linearization's virtual buffer far dearer than any
-# progress the reward could buy — without it, driving through an opponent
-# costs less than lifting, and the solver ghost-passes.
+# Opponent separation, continuous in time. The forecasts are only known at
+# the horizon nodes, but every car shares the same uniform clock, so hat
+# weights in the time state turn each opponent's forecast into a
+# piecewise-linear trajectory the CTCS penalty can evaluate *between* nodes
+# too — no gap for a car to slip through at a node boundary. The ``W_SEP``
+# scaling makes contact far dearer than any progress the reward could buy;
+# without it, driving through an opponent costs less than lifting, and the
+# solver ghost-passes.
 W_SEP = 1e3
 
 if K > 1:
-    for k in range(1, N_MPC):
-        gap = ((s[0] - opp_s[k]) / SEP_LONG) ** 2 + ((n[0] - opp_n[k]) / SEP_LAT) ** 2
-        constraints.append((1.0 <= gap).at([k]).weight(W_SEP))
+    hat = ox.Max(1.0 - ox.Abs(time[0] / DT_MPC - np.arange(N_MPC, dtype=float)), 0.0)
+    for j in range(K - 1):
+        opp_s_t = ox.Sum(hat * opp_s[:, j])
+        opp_n_t = ox.Sum(hat * opp_n[:, j])
+        gap = ((s[0] - opp_s_t) / SEP_LONG) ** 2 + ((n[0] - opp_n_t) / SEP_LAT) ** 2
+        constraints.append(ox.ctcs(W_SEP * (1.0 - gap) <= 0.0, penalty="huber"))
 
 # ── Problem ────────────────────────────────────────────────────────────────────
 # One car's horizon problem; the race batches it over the roster. The default

--- a/examples/race_cars/race_car_multi_agent.py
+++ b/examples/race_cars/race_car_multi_agent.py
@@ -129,10 +129,6 @@ RACE_DISTANCE = M_LAPS * pathlength
 # side instead of the single-file 0.12 m of the one-car examples.
 LANE_HALF_WIDTH = 0.24
 
-# Overrun past the flag: finished cars keep driving until the last car crosses,
-# and every horizon looks this far beyond its own position.
-S_OVERRUN = 8.0
-
 # ── Grid (F1 standing start) ───────────────────────────────────────────────────
 GRID_ROW_GAP = 0.5  # longitudinal stagger between consecutive grid slots [m]
 
@@ -187,13 +183,22 @@ SEP_LONG = 0.10  # semi-axis along the track [m]
 SEP_LAT = 0.05  # semi-axis across the track [m]
 
 # ── MPC horizon ────────────────────────────────────────────────────────────────
-# Two seconds reaches through an entire braking zone and out the other side,
-# which is what lets a car weigh harvesting now against deploying later.
-N_MPC = 21  # horizon nodes
-HORIZON_TF = 2.0  # [s] prediction horizon
+# Three seconds reaches through a braking zone and far enough down the next
+# straight to plan a whole overtake. A horizon study (2/3/4 s races on this
+# roster) shows the difference in kind: at 2 s the fastest car cannot plan
+# past a defender's bubble and the weakest car wins on track position; at
+# 3 s passes complete and the field finishes sorted by pace, ~1.2 s quicker.
+# 4 s adds cost but nothing further.
+N_MPC = 31  # horizon nodes
+HORIZON_TF = 3.0  # [s] prediction horizon
 DT_MPC = HORIZON_TF / (N_MPC - 1)  # time between consecutive nodes = one race step [s]
 RACE_TIME_MAX = 15.0 + 20.0 * M_LAPS  # [s] give up if the field has not finished by then
 MAX_STEPS = int(np.ceil(RACE_TIME_MAX / DT_MPC))
+
+# Overrun past the flag: finished cars keep driving until the last car
+# crosses, and every horizon looks this far beyond its own position, so the
+# margin scales with the lookahead (top speed ~3 m/s plus slack).
+S_OVERRUN = 4.0 * HORIZON_TF
 
 # Real-time iteration: a fixed SCP budget per step instead of solving each
 # horizon to convergence — the shifted warm start carries optimality from one

--- a/examples/race_cars/race_car_multi_agent.py
+++ b/examples/race_cars/race_car_multi_agent.py
@@ -82,7 +82,7 @@ AGENTS = [
     dict(
         name="down on power",
         color=(220, 35, 45),
-        power_scale=0.7,
+        power_scale=0.9,
         mass_scale=1.0,
         battery_scale=1.0,
     ),
@@ -189,7 +189,7 @@ SEP_LAT = 0.05  # semi-axis across the track [m]
 # ── MPC horizon ────────────────────────────────────────────────────────────────
 # Two seconds reaches through an entire braking zone and out the other side,
 # which is what lets a car weigh harvesting now against deploying later.
-N_MPC = 41  # horizon nodes
+N_MPC = 21  # horizon nodes
 HORIZON_TF = 2.0  # [s] prediction horizon
 DT_MPC = HORIZON_TF / (N_MPC - 1)  # time between consecutive nodes = one race step [s]
 RACE_TIME_MAX = 15.0 + 20.0 * M_LAPS  # [s] give up if the field has not finished by then
@@ -431,7 +431,7 @@ problem = ox.Problem(
         "lam_cost": {"s": 4e1},
         "autotuner": ox.ConstantProximalWeight(),
     },
-    solver=ox.MoreauPTRSolver(),
+    # solver=ox.MoreauPTRSolver(),
 )
 problem.settings.dev.printing = False
 
@@ -694,14 +694,22 @@ def build_viser_panels(log: RaceLog) -> list[dict]:
     lap_car = [log.dense_x[i, : end[i], COL["s"]] / pathlength for i in range(K)]
 
     def compact(fig: go.Figure, title: str, xaxis: str, yaxis: str) -> go.Figure:
+        # Dark styling matched to viser's control-panel grey so the panels
+        # read as part of the sidebar rather than white cutouts.
+        panel_bg = "#1a1b1e"
         fig.update_layout(
-            title=dict(text=title, font=dict(size=13)),
+            template="plotly_dark",
+            paper_bgcolor=panel_bg,
+            plot_bgcolor=panel_bg,
+            title=dict(text=title, font=dict(size=13, color="#c1c2c5")),
             xaxis_title=xaxis,
             yaxis_title=yaxis,
             margin=dict(l=45, r=10, t=30, b=35),
-            font=dict(size=10),
+            font=dict(size=10, color="#909296"),
             showlegend=False,
         )
+        fig.update_xaxes(gridcolor="#2c2e33", zerolinecolor="#2c2e33")
+        fig.update_yaxes(gridcolor="#2c2e33", zerolinecolor="#2c2e33")
         return fig
 
     def stripline_panel(signal: list[np.ndarray], title: str, yaxis: str) -> dict:

--- a/examples/race_cars/race_car_multi_agent.py
+++ b/examples/race_cars/race_car_multi_agent.py
@@ -1,0 +1,692 @@
+"""Multi-agent race: K hybrid cars racing wheel-to-wheel via batched MPC.
+
+Puts a whole field of the F1 2026-style hybrid cars from
+``race_car_hybrid.py`` on the 4x LMS track at once. Each car runs the same
+receding-horizon controller as ``race_car_mpc.py`` — maximise arc-length
+progress over a short fixed horizon — and the cars interact only through
+collision-avoidance constraints, so overtakes, defence, and energy strategy
+all emerge from the optimization rather than being scripted.
+
+One symbolic ``Problem`` describes a single car. Everything that differs
+between cars enters through runtime inputs, so advancing the whole field one
+MPC step is a single ``solve_batched`` call with a leading agent axis:
+
+  * ``x_initial`` — each car's current state, as batched boundary pins;
+  * ``power_scale`` / ``mass_scale`` / ``battery_scale`` — the car's spec;
+  * ``opp_s`` / ``opp_n`` — the opponents' latest predicted trajectories.
+
+Cars negotiate by the *communicated plans* scheme standard in decentralized
+MPC: at every step each car re-plans against the plans its opponents
+published on the previous step (shifted one node so the horizons stay
+aligned), keeping an elliptical clearance in track coordinates
+
+    ((s - s_j) / SEP_LONG)² + ((n - n_j) / SEP_LAT)² ≥ 1
+
+from every opponent j at every horizon node. All cars share one fixed,
+uniform horizon time grid, so node k of every plan refers to the same wall
+clock and node-wise separation is meaningful. The Frenet model makes the
+constraint this simple — "gap along the track, gap across it" is exactly
+the (s, n) state, with none of the reference-path bookkeeping an MPCC
+formulation needs (compare ``examples/mpc/double_integrator_drone_racing.py``).
+
+The race is a standing start from an F1-style grid: cars staggered by
+``GRID_ROW_GAP`` down the track, alternating left and right of the
+centreline. The ``AGENTS`` roster is the single scaling knob — add an entry
+and the grid, the batch, the avoidance constraints, and the plots all grow
+with it. Spec differences are runtime parameters, so tweaking the field
+(a down-on-power engine, an oversize battery, ballast) never recompiles.
+The default roster puts a car that is 10% down on power on pole and a
+healthy one behind it: the chaser must find a way past on track.
+
+Run headless (no Plotly/Viser) with ``OPENSCVX_NO_PLOT=1``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time as _time
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+import jax.numpy as jnp
+import numpy as np
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+project_root = os.path.dirname(os.path.dirname(current_dir))
+if project_root not in sys.path:
+    sys.path.append(project_root)
+sys.path.insert(0, current_dir)
+
+from tracks.readDataFcn import getTrack
+
+import openscvx as ox
+
+# ── Roster ─────────────────────────────────────────────────────────────────────
+# One entry per car, in grid order (index 0 starts on pole). ``power_scale``
+# scales the whole drive-force envelope, ``mass_scale`` the chassis mass, and
+# ``battery_scale`` the energy store (the per-lap recovery cap is a regulation,
+# so it stays fixed). All three are runtime parameters of one compiled problem:
+# edit or extend this list and everything downstream follows.
+AGENTS = [
+    dict(
+        name="down on power",
+        color=(220, 35, 45),
+        power_scale=0.9,
+        mass_scale=1.0,
+        battery_scale=1.0,
+    ),
+    dict(
+        name="reference spec",
+        color=(90, 140, 235),
+        power_scale=1.0,
+        mass_scale=1.0,
+        battery_scale=1.0,
+    ),
+]
+K = len(AGENTS)
+
+# ── Track data ─────────────────────────────────────────────────────────────────
+# 4x LMS kart track, as in race_car_hybrid.py: long enough that the cars are
+# power-limited on the straights and the energy strategy matters.
+TRACK_FILE = "LMS_Track_x4.txt"
+sref_data, _, _, _, kapparef_data = getTrack(TRACK_FILE)
+pathlength = float(sref_data[-1])  # ≈ 34.84 m
+
+# Two cars racing side by side need room: open the lane to two car-widths per
+# side instead of the single-file 0.12 m of the one-car examples.
+LANE_HALF_WIDTH = 0.24
+
+# Overrun past the flag: finished cars keep driving until the last car crosses,
+# and every horizon looks this far beyond its own position.
+S_OVERRUN = 6.0
+
+# ── Grid (F1 standing start) ───────────────────────────────────────────────────
+GRID_ROW_GAP = 0.5  # longitudinal stagger between consecutive grid slots [m]
+
+
+def grid_slot(i: int) -> tuple[float, float]:
+    """(s, n) of grid slot ``i``: one row gap per car, alternating sides."""
+    return -(i + 1) * GRID_ROW_GAP, 0.5 * LANE_HALF_WIDTH * (1.0 if i % 2 == 0 else -1.0)
+
+
+# Pad the curvature spline so it never extrapolates: below 0 it must cover the
+# deepest grid slot, above pathlength the post-finish overrun.
+_pad_lo = (K + 1) * GRID_ROW_GAP + 1.0
+_pad_hi = S_OVERRUN + 1.0
+s_interp = np.concatenate([[sref_data[0] - _pad_lo], sref_data, [pathlength + _pad_hi]])
+kappa_interp = np.concatenate([[kapparef_data[0]], kapparef_data, [kapparef_data[-1]]])
+
+# ── Vehicle parameters (Kloeser et al. 2020, Table I) ─────────────────────────
+m = 0.043  # vehicle mass [kg]
+C1 = 0.5  # front-axle normalised position
+C2 = 15.5  # lateral slip-force parameter [1/m]
+Cm1 = 0.28  # drive-force coefficient 1 [N]
+Cm2 = 0.05  # drive-force coefficient 2 [N·s/m]
+Cr0 = 0.011  # rolling-resistance constant [N]
+Cr2 = 0.006  # rolling-resistance quadratic [N·s²/m²]
+A_MAX = 4.0  # tyre grip limit — friction-ellipse radius [m/s²]
+
+# ── Hybrid power unit (F1 2026 ratios, RC-car scale — see race_car_hybrid.py) ──
+ICE_SHARE = 0.55  # combustion share of the drive-force envelope
+ELEC_SHARE = 0.45  # electric (MGU-K) share of the drive-force envelope
+ETA_BATT = 0.90  # battery round-trip efficiency, charged on the harvest side
+
+T_LAP_KART = 6.0  # power-unit sizing reference: lap of the unscaled track [s]
+P_PEAK = Cm1**2 / (4.0 * Cm2)  # peak envelope wheel power ≈ 0.39 W
+P_ELEC_PEAK = ELEC_SHARE * P_PEAK  # peak MGU-K wheel power ≈ 0.18 W
+
+E_BATT_MAX = 0.13 * T_LAP_KART * P_ELEC_PEAK  # reference battery capacity [J]
+R_LAP_MAX = 2.0 * E_BATT_MAX  # per-lap recovery cap [J] (a regulation: same for all)
+E_CAP_TOP = E_BATT_MAX * max(spec["battery_scale"] for spec in AGENTS)
+
+# ── Separation ellipse (track coordinates) ─────────────────────────────────────
+# Longer than it is wide, like the safe zone around a real car: SEP_LONG covers
+# a car length plus a braking margin, SEP_LAT one car width of daylight. Two
+# cars can run side by side (|Δn| = 2·|grid n| = LANE_HALF_WIDTH ≥ SEP_LAT) but
+# never nose-to-tail closer than SEP_LONG.
+SEP_LONG = 0.35  # semi-axis along the track [m]
+SEP_LAT = 0.12  # semi-axis across the track [m]
+
+# ── MPC horizon ────────────────────────────────────────────────────────────────
+N_MPC = 15  # horizon nodes
+HORIZON_TF = 1.0  # [s] prediction horizon — covers braking from top speed
+DT_MPC = HORIZON_TF / (N_MPC - 1)  # time between consecutive nodes = one race step [s]
+RACE_TIME_MAX = 40.0  # [s] give up if the field has not finished by then
+MAX_STEPS = int(np.ceil(RACE_TIME_MAX / DT_MPC))
+
+# Real-time iteration: a fixed SCP budget per step instead of solving each
+# horizon to convergence — the shifted warm start carries optimality from one
+# step into the next, as in any SQP-style MPC.
+SCP_ITERS_PER_STEP = 10
+
+# ── States ─────────────────────────────────────────────────────────────────────
+# Boundary values and guesses below describe the pole slot only: every solve
+# overrides them per car through the batched ``x_initial`` pins and guesses.
+S_POLE, N_POLE = grid_slot(0)
+S_MIN = grid_slot(K - 1)[0] - 0.1
+
+s = ox.State("s", shape=(1,))
+s.min = [S_MIN]
+s.max = [pathlength + S_OVERRUN]
+s.initial = [S_POLE]
+s.final = [ox.Maximize(0.0)]  # maximise arc-length progress each horizon
+s.guess = np.full((N_MPC, 1), S_POLE)
+
+n = ox.State("n", shape=(1,))
+n.min = [-LANE_HALF_WIDTH]
+n.max = [LANE_HALF_WIDTH]
+n.initial = [N_POLE]
+n.final = [ox.Free(0.0)]
+n.guess = np.full((N_MPC, 1), N_POLE)
+
+alpha = ox.State("alpha", shape=(1,))
+alpha.min = [-np.pi / 2]
+alpha.max = [np.pi / 2]
+alpha.initial = [0.0]
+alpha.final = [ox.Free(0.0)]
+alpha.guess = np.zeros((N_MPC, 1))
+
+v = ox.State("v", shape=(1,))
+v.min = [0.0]
+v.max = [6.0]
+v.initial = [0.0]  # standing start
+v.final = [ox.Free(0.0)]
+v.guess = np.zeros((N_MPC, 1))
+
+D_throt = ox.State("D", shape=(1,))
+D_throt.min = [-1.0]
+D_throt.max = [1.0]
+D_throt.initial = [0.0]
+D_throt.final = [ox.Free(0.0)]
+D_throt.guess = np.zeros((N_MPC, 1))
+
+delta = ox.State("delta", shape=(1,))
+delta.min = [-0.40]
+delta.max = [0.40]
+delta.initial = [0.0]
+delta.final = [ox.Free(0.0)]
+delta.guess = np.zeros((N_MPC, 1))
+
+E_batt = ox.State("E", shape=(1,))
+E_batt.min = [0.0]
+E_batt.max = [E_CAP_TOP]  # scaling bound; the binding capacity is per-car below
+E_batt.initial = [E_BATT_MAX]  # lights out on a full charge
+E_batt.final = [ox.Free(0.0)]
+E_batt.guess = np.full((N_MPC, 1), E_BATT_MAX)
+
+E_rec = ox.State("R", shape=(1,))
+E_rec.min = [0.0]
+E_rec.max = [R_LAP_MAX]
+E_rec.initial = [0.0]
+E_rec.final = [ox.Free(0.0)]
+E_rec.guess = np.zeros((N_MPC, 1))
+
+# Unified state layout: the driver states above in declared order, then the
+# time state, then the CTCS integrators appended by constraint augmentation.
+DRIVER_STATES = ("s", "n", "alpha", "v", "D", "delta", "E", "R")
+COL = {name: i for i, name in enumerate(DRIVER_STATES)}
+TIME_COL = len(DRIVER_STATES)
+
+# ── Controls ───────────────────────────────────────────────────────────────────
+derD = ox.Control("derD", shape=(1,), parameterization="ZOH")
+derD.min = [-10.0]
+derD.max = [10.0]
+derD.guess = np.zeros((N_MPC, 1))
+
+derDelta = ox.Control("derDelta", shape=(1,), parameterization="ZOH")
+derDelta.min = [-2.0]
+derDelta.max = [2.0]
+derDelta.guess = np.zeros((N_MPC, 1))
+
+deploy = ox.Control("deploy", shape=(1,), parameterization="FOH")
+deploy.min = [0.0]
+deploy.max = [1.0]
+deploy.guess = 0.3 * np.ones((N_MPC, 1))
+
+regen = ox.Control("regen", shape=(1,), parameterization="FOH")
+regen.min = [0.0]
+regen.max = [1.0]
+regen.guess = 0.1 * np.ones((N_MPC, 1))
+
+# ── Time: fixed horizon, uniform grid ─────────────────────────────────────────
+# Every car's horizon runs on this same clock, which is what lets node k of one
+# car's plan be checked against node k of an opponent's.
+time = ox.Time(
+    initial=0.0,
+    final=HORIZON_TF,
+    min=0.0,
+    max=HORIZON_TF,
+    uniform_time_grid=True,
+)
+
+# ── Parameters: car spec and opponent plans ────────────────────────────────────
+power_scale = ox.Parameter("power_scale", shape=(), value=1.0)
+mass_scale = ox.Parameter("mass_scale", shape=(), value=1.0)
+battery_scale = ox.Parameter("battery_scale", shape=(), value=1.0)
+
+# Opponent (s, n) forecasts, one row per horizon node, one column per opponent.
+# Refreshed every race step from the other cars' previous plans; parameters are
+# hashed by shape, so the updates never recompile. Initialised far behind the
+# grid so the constraints start inactive.
+if K > 1:
+    opp_s = ox.Parameter("opp_s", shape=(N_MPC, K - 1), value=np.full((N_MPC, K - 1), S_MIN - 10.0))
+    opp_n = ox.Parameter("opp_n", shape=(N_MPC, K - 1), value=np.zeros((N_MPC, K - 1)))
+
+# ── Dynamics (hybrid spatial bicycle model, per-car spec via parameters) ───────
+kappa = ox.Cinterp(s[0], s_interp, kappa_interp, method="pchip")
+m_car = ox.Constant(m) * mass_scale
+
+# Drive-force envelope, scaled by engine health and split ICE / MGU-K
+F_env = power_scale * (ox.Constant(Cm1) - ox.Constant(Cm2) * v[0])
+F_ice = ox.Constant(ICE_SHARE) * F_env * D_throt[0]
+F_elec = ox.Constant(ELEC_SHARE) * F_env * (deploy[0] - regen[0])
+
+# Longitudinal tyre force [N]
+Fxd = (
+    F_ice
+    + F_elec
+    - ox.Constant(Cr2) * v[0] ** 2
+    - ox.Constant(Cr0) * ox.Tanh(ox.Constant(5.0) * v[0])
+)
+
+# Battery power flows: deployment drains at wheel power, harvesting charges
+# through the round-trip efficiency and counts against the recovery cap.
+P_deploy = ox.Constant(ELEC_SHARE) * F_env * deploy[0] * v[0]
+P_harvest = ox.Constant(ETA_BATT) * ox.Constant(ELEC_SHARE) * F_env * regen[0] * v[0]
+
+slip_angle = alpha[0] + ox.Constant(C1) * delta[0]
+sdot = (v[0] * ox.Cos(slip_angle)) / (ox.Constant(1.0) - kappa * n[0])
+
+dynamics = {
+    "s": sdot,
+    "n": v[0] * ox.Sin(slip_angle),
+    "alpha": v[0] * ox.Constant(C2) * delta[0] - kappa * sdot,
+    "v": (Fxd / m_car) * ox.Cos(ox.Constant(C1) * delta[0]),
+    "D": derD[0],
+    "delta": derDelta[0],
+    "E": P_harvest - P_deploy,
+    "R": P_harvest,
+}
+
+# ── Constraints ────────────────────────────────────────────────────────────────
+states = [s, n, alpha, v, D_throt, delta, E_batt, E_rec]
+controls = [derD, derDelta, deploy, regen]
+
+constraints: list = []
+
+# Track limits and path constraints, continuous between nodes.
+for state in [s, n, alpha, v, D_throt, delta, E_rec]:
+    constraints.extend(
+        [
+            ox.ctcs(state <= state.max, penalty="huber"),
+            ox.ctcs(state.min <= state, penalty="huber"),
+        ]
+    )
+
+# Battery: the box bound above only scales; the capacity that binds is the car's.
+constraints.extend(
+    [
+        ox.ctcs(E_batt[0] <= battery_scale * ox.Constant(E_BATT_MAX), penalty="huber"),
+        ox.ctcs(0.0 <= E_batt[0], penalty="huber"),
+    ]
+)
+
+# Friction ellipse: lateral and longitudinal grip share one tyre.
+a_lat = ox.Constant(C2) * v[0] ** 2 * delta[0] + Fxd * ox.Sin(ox.Constant(C1) * delta[0]) / m_car
+a_long = Fxd / m_car
+
+constraints.append(ox.ctcs(a_lat**2 + a_long**2 <= A_MAX**2, penalty="huber"))
+
+# Opponent separation: at horizon node k, stay outside every opponent's ellipse,
+# evaluated against their forecast position at that same node. Node 0 is the
+# pinned current state, so the constraint starts at node 1. The heavy
+# ``.weight`` makes the linearization's virtual buffer far dearer than any
+# progress the reward could buy — without it, driving through an opponent
+# costs less than lifting, and the solver ghost-passes.
+W_SEP = 1e3
+
+if K > 1:
+    for k in range(1, N_MPC):
+        gap = ((s[0] - opp_s[k]) / SEP_LONG) ** 2 + ((n[0] - opp_n[k]) / SEP_LAT) ** 2
+        constraints.append((1.0 <= gap).at([k]).weight(W_SEP))
+
+# ── Problem ────────────────────────────────────────────────────────────────────
+# One car's horizon problem; the race batches it over the roster. The default
+# CVXPy backend solves the K subproblems sequentially; a JAX-native backend
+# (e.g. solver={"backend": "qpax"}) vectorizes the whole field into one XLA
+# program.
+problem = ox.Problem(
+    dynamics=dynamics,
+    states=states,
+    controls=controls,
+    time=time,
+    constraints=constraints,
+    N=N_MPC,
+    float_dtype="float64",
+    algorithm={
+        # The progress reward must dominate the proximal anchor (states are
+        # scaled by their ranges, and s spans the whole 4x track, so a metre
+        # of progress is a small scaled step) — too small and each solve
+        # "converges" glued to its warm start and the field crawls. lam_vc
+        # must in turn dominate the reward, or virtual control buys progress
+        # at the horizon's last node instead of driving there.
+        "lam_vc": 1e3,
+        "lam_prox": 4e0,
+        "lam_cost": {"s": 4e1},
+        "autotuner": ox.ConstantProximalWeight(),
+    },
+)
+problem.settings.dev.printing = False
+
+
+# ── Race-loop helpers ──────────────────────────────────────────────────────────
+
+
+def initial_pins() -> np.ndarray:
+    """(K, n_x) boundary pins: every car parked in its grid slot, battery full."""
+    pin = np.asarray(problem.state.x_init_pin)
+    x0 = np.broadcast_to(pin, (K, pin.size)).copy()
+    for i, spec in enumerate(AGENTS):
+        s0, n0 = grid_slot(i)
+        x0[i, COL["s"]] = s0
+        x0[i, COL["n"]] = n0
+        x0[i, COL["E"]] = spec["battery_scale"] * E_BATT_MAX
+    return x0
+
+
+def cold_start_guesses() -> tuple[np.ndarray, np.ndarray]:
+    """Per-car copies of the default guess, relocated to the grid slots."""
+    x = np.repeat(np.asarray(problem.state.x)[None], K, axis=0)
+    u = np.repeat(np.asarray(problem.state.u)[None], K, axis=0)
+    for i, spec in enumerate(AGENTS):
+        s0, n0 = grid_slot(i)
+        x[i, :, COL["s"]] = s0
+        x[i, :, COL["n"]] = n0
+        x[i, :, COL["E"]] = spec["battery_scale"] * E_BATT_MAX
+    return x, u
+
+
+def shift_horizon(plan: np.ndarray) -> np.ndarray:
+    """Advance a horizon one node: drop node 0, hold the last node."""
+    return np.concatenate([plan[:, 1:], plan[:, -1:]], axis=1)
+
+
+def shifted_guesses(results) -> tuple[np.ndarray, np.ndarray]:
+    """Warm starts for the next step: previous plans shifted one node.
+
+    The horizon clock and the CTCS violation integrators restart from zero
+    each solve, so those columns are reset rather than shifted.
+    """
+    x = shift_horizon(np.asarray(results.x))
+    u = shift_horizon(np.asarray(results.u))
+    x[:, :, TIME_COL] = np.linspace(0.0, HORIZON_TF, N_MPC)
+    x[:, :, TIME_COL + 1 :] = 0.0
+    return x, u
+
+
+def opponent_view(pred: np.ndarray) -> np.ndarray:
+    """Each car's view of the others' plans: (K, N) → (K, N, K-1)."""
+    return np.stack([np.delete(pred, i, axis=0).T for i in range(K)])
+
+
+# ── Plotly visualisation ───────────────────────────────────────────────────────
+
+
+def plot_race(sim: np.ndarray, t_sim: np.ndarray) -> None:
+    """Track projection per car, pairwise separation vs the limit, speed and
+    battery histories — all from the closed-loop log ``sim`` (T, K, 8)."""
+    import plotly.graph_objects as go
+    from plotly.subplots import make_subplots
+    from time2spatial import transformProj2Orig
+
+    css = [f"rgb{spec['color']}" for spec in AGENTS]
+
+    # ── Track projection ───────────────────────────────────────────────────────
+    sref_d, xref_d, yref_d, psiref_d, _ = getTrack(TRACK_FILE)
+    fig1 = go.Figure()
+    fig1.add_trace(
+        go.Scatter(
+            x=xref_d,
+            y=yref_d,
+            mode="lines",
+            line=dict(color="black", dash="dash", width=1),
+            name="centreline",
+        )
+    )
+    for sign in (-1.0, 1.0):
+        fig1.add_trace(
+            go.Scatter(
+                x=xref_d + sign * LANE_HALF_WIDTH * np.sin(psiref_d),
+                y=yref_d - sign * LANE_HALF_WIDTH * np.cos(psiref_d),
+                mode="lines",
+                line=dict(color="black", width=1.5),
+                showlegend=False,
+            )
+        )
+    for i, spec in enumerate(AGENTS):
+        cart_x, cart_y, _, _ = transformProj2Orig(
+            sim[:, i, COL["s"]],
+            sim[:, i, COL["n"]],
+            sim[:, i, COL["alpha"]],
+            sim[:, i, COL["v"]],
+            TRACK_FILE,
+        )
+        fig1.add_trace(
+            go.Scatter(
+                x=cart_x,
+                y=cart_y,
+                mode="lines",
+                line=dict(color=css[i], width=2),
+                name=spec["name"],
+            )
+        )
+        fig1.add_trace(
+            go.Scatter(
+                x=cart_x[:1],
+                y=cart_y[:1],
+                mode="markers",
+                marker=dict(color=css[i], size=10, symbol="square"),
+                name=f"{spec['name']} grid slot",
+                showlegend=False,
+            )
+        )
+    fig1.update_layout(
+        title=f"Multi-agent race — closed-loop trajectories  ({len(sim)} steps)",
+        xaxis=dict(title="x [m]", scaleanchor="y"),
+        yaxis=dict(title="y [m]"),
+        height=600,
+    )
+    fig1.show()
+
+    # ── Pairwise separation vs the ellipse limit ───────────────────────────────
+    fig2 = go.Figure()
+    for i in range(K):
+        for j in range(i + 1, K):
+            gap = np.sqrt(
+                ((sim[:, i, COL["s"]] - sim[:, j, COL["s"]]) / SEP_LONG) ** 2
+                + ((sim[:, i, COL["n"]] - sim[:, j, COL["n"]]) / SEP_LAT) ** 2
+            )
+            fig2.add_trace(
+                go.Scatter(x=t_sim, y=gap, name=f"{AGENTS[i]['name']} ↔ {AGENTS[j]['name']}")
+            )
+    fig2.add_hline(y=1.0, line=dict(color="black", dash="dash", width=1), annotation_text="contact")
+    fig2.update_layout(
+        title="Separation (ellipse metric — below 1 is contact)",
+        xaxis_title="t [s]",
+        yaxis_title="normalised gap",
+        height=400,
+    )
+    fig2.show()
+
+    # ── Speed and battery ──────────────────────────────────────────────────────
+    fig3 = make_subplots(rows=2, cols=1, shared_xaxes=True, subplot_titles=["v [m/s]", "E [J]"])
+    for i, spec in enumerate(AGENTS):
+        fig3.add_trace(
+            go.Scatter(x=t_sim, y=sim[:, i, COL["v"]], line=dict(color=css[i]), name=spec["name"]),
+            row=1,
+            col=1,
+        )
+        fig3.add_trace(
+            go.Scatter(
+                x=t_sim,
+                y=sim[:, i, COL["E"]],
+                line=dict(color=css[i]),
+                name=spec["name"],
+                showlegend=False,
+            ),
+            row=2,
+            col=1,
+        )
+        fig3.add_hline(
+            y=spec["battery_scale"] * E_BATT_MAX,
+            line=dict(color=css[i], dash="dash", width=1),
+            row=2,
+            col=1,
+        )
+    fig3.update_xaxes(title_text="t [s]", row=2, col=1)
+    fig3.update_layout(title="Speed and battery state of charge", height=600)
+    fig3.show()
+
+
+# ── Race loop ──────────────────────────────────────────────────────────────────
+
+
+def run_race(max_steps: int = MAX_STEPS) -> tuple[np.ndarray, np.ndarray, list]:
+    """Race the roster to the flag; returns ``(sim, t_sim, finish_time)``.
+
+    ``sim`` is the closed-loop log, shape ``(T, K, len(DRIVER_STATES))``;
+    ``finish_time`` holds each car's flag-crossing time (``None`` if the time
+    cap expired first). One ``solve_batched`` call advances the whole field by
+    one node (``DT_MPC``) per iteration.
+    """
+    x0 = initial_pins()
+    x_guess, u_guess = cold_start_guesses()
+    # Published plans; before lights out every car assumes the field holds station.
+    pred_s = x_guess[:, :, COL["s"]].copy()
+    pred_n = x_guess[:, :, COL["n"]].copy()
+
+    spec_params = {
+        key: np.array([spec[key] for spec in AGENTS])
+        for key in ("power_scale", "mass_scale", "battery_scale")
+    }
+
+    sim_rows: list[np.ndarray] = []
+    finish_time: list = [None] * K
+    t_now = 0.0
+    solve_ms: list[float] = []
+
+    for step in range(max_steps):
+        params = dict(spec_params)
+        if K > 1:
+            params["opp_s"] = opponent_view(shift_horizon(pred_s))
+            params["opp_n"] = opponent_view(shift_horizon(pred_n))
+
+        tic = _time.perf_counter()
+        results = problem.solve_batched(
+            x_initial=jnp.asarray(x0),
+            parameters=params,
+            x_guess=jnp.asarray(x_guess),
+            u_guess=jnp.asarray(u_guess),
+            max_iters=SCP_ITERS_PER_STEP,
+        )
+        solve_ms.append((_time.perf_counter() - tic) * 1e3)
+
+        nodes = {name: np.asarray(results.nodes[name]) for name in DRIVER_STATES}
+        row = np.stack([nodes[name][:, 0, 0] for name in DRIVER_STATES], axis=1)  # (K, n)
+
+        # Finish detection: interpolate the flag crossing inside the last step.
+        for i in range(K):
+            if finish_time[i] is None and row[i, COL["s"]] >= pathlength:
+                s_prev = sim_rows[-1][i, COL["s"]] if sim_rows else grid_slot(i)[0]
+                frac = (pathlength - s_prev) / max(row[i, COL["s"]] - s_prev, 1e-9)
+                finish_time[i] = t_now - DT_MPC * (1.0 - frac)
+
+        sim_rows.append(row)
+        status = "  |  ".join(
+            f"{AGENTS[i]['name']}: s={row[i, COL['s']]:6.2f} v={row[i, COL['v']]:.2f}"
+            f" E={row[i, COL['E']]:.3f}"
+            for i in range(K)
+        )
+        print(f"step {step:4d}  t={t_now:6.2f} s  {status}  ({solve_ms[-1]:.0f} ms)")
+
+        if all(t is not None for t in finish_time):
+            break
+
+        # Advance the field one node and publish this step's plans.
+        for name in DRIVER_STATES:
+            x0[:, COL[name]] = nodes[name][:, 1, 0]
+        x_guess, u_guess = shifted_guesses(results)
+        pred_s = nodes["s"][:, :, 0]
+        pred_n = nodes["n"][:, :, 0]
+        t_now += DT_MPC
+
+    print(f"mean solve {np.mean(solve_ms):.0f} ms, max {np.max(solve_ms):.0f} ms")
+    return np.stack(sim_rows), np.arange(len(sim_rows)) * DT_MPC, finish_time
+
+
+def crossing_index(sim: np.ndarray, i: int) -> int:
+    """Number of log rows up to and including car ``i``'s flag crossing."""
+    return min(int(np.searchsorted(sim[:, i, COL["s"]], pathlength)) + 1, len(sim))
+
+
+def print_classification(sim: np.ndarray, finish_time: list) -> list[int]:
+    """Print the final order and per-car energy summary; returns the order."""
+    order = sorted(range(K), key=lambda i: np.inf if finish_time[i] is None else finish_time[i])
+    print("\n=== Race classification ===")
+    for place, i in enumerate(order, start=1):
+        spec = AGENTS[i]
+        if finish_time[i] is None:
+            print(f"  P{place}  {spec['name']:<20s}  DNF (time cap)")
+            continue
+        at_flag = sim[crossing_index(sim, i) - 1, i]
+        gap = "" if place == 1 else f"  +{finish_time[i] - finish_time[order[0]]:.3f} s"
+        print(f"  P{place}  {spec['name']:<20s}  {finish_time[i]:7.3f} s{gap}")
+        print(
+            f"       battery {sim[0, i, COL['E']]:.3f} → {at_flag[COL['E']]:.3f} J,"
+            f" recovered {at_flag[COL['R']]:.3f} J (cap {R_LAP_MAX:.3f} J)"
+        )
+    return order
+
+
+# ── Main: run the race ─────────────────────────────────────────────────────────
+if __name__ == "__main__":
+    problem.initialize()
+    sim, t_sim, finish_time = run_race()
+    order = print_classification(sim, finish_time)
+
+    if os.environ.get("OPENSCVX_NO_PLOT") is None:
+        plot_race(sim, t_sim)
+
+        from race_car_viser import (
+            create_race_car_chase_viser_server,
+            create_race_car_comparison_viser_server,
+        )
+
+        # Trim each car's log at its own flag crossing so the replay parks it
+        # at the line and the finishing gaps stay visible.
+        cross = [crossing_index(sim, i) for i in range(K)]
+        comparison_server = create_race_car_comparison_viser_server(
+            simX_list=[sim[: cross[i], i, :6] for i in range(K)],
+            t_sim_list=[t_sim[: cross[i]] for i in range(K)],
+            labels=[spec["name"] for spec in AGENTS],
+            colors=[spec["color"] for spec in AGENTS],
+            track_file=TRACK_FILE,
+            lane_width=LANE_HALF_WIDTH,
+            trim_warmup=False,
+            distance_marker_step=None,
+            title="Multi-agent race",
+        )
+        winner = order[0]
+        chase_server = create_race_car_chase_viser_server(
+            simX=sim[: cross[winner], winner, :6],
+            t_sim=t_sim[: cross[winner]],
+            track_file=TRACK_FILE,
+            lane_width=LANE_HALF_WIDTH,
+            trim_warmup=False,
+            title=f"Winner — {AGENTS[winner]['name']}",
+        )
+        print("Race replay and winner chase camera are on separate Viser ports.")
+        chase_server.sleep_forever()

--- a/examples/race_cars/race_car_multi_agent.py
+++ b/examples/race_cars/race_car_multi_agent.py
@@ -73,32 +73,32 @@ import openscvx as ox
 # edit or extend this list and everything downstream follows.
 AGENTS = [
     dict(
-        name="down on power",
+        name="red",  # pole sitter, slightly down on power — must defend
         color=(220, 35, 45),
-        power_scale=0.8,
+        power_scale=0.9,
         mass_scale=1.0,
         battery_scale=1.0,
     ),
     dict(
-        name="miata",
+        name="blue",  # the reference car
         color=(90, 140, 235),
-        power_scale=0.75,
-        mass_scale=0.75,
+        power_scale=1.0,
+        mass_scale=1.0,
         battery_scale=1.0,
     ),
     dict(
-        name="overweight",
+        name="yellow",  # carrying ballast
         color=(240, 190, 50),
         power_scale=1.0,
-        mass_scale=1.25,
+        mass_scale=1.15,
         battery_scale=1.0,
     ),
     dict(
-        name="reference P4",
+        name="green",  # hot engine, starting from the back
         color=(120, 200, 120),
         power_scale=1.1,
-        mass_scale=0.9,
-        battery_scale=1.1,
+        mass_scale=1.0,
+        battery_scale=1.0,
     ),
 ]
 K = len(AGENTS)
@@ -106,7 +106,7 @@ K = len(AGENTS)
 # Race length. The s state lives on a single lap (wrapped at each crossing,
 # as in the MPCC example), so solver scaling and weights are independent of
 # race length.
-M_LAPS = 3
+M_LAPS = 2
 
 # ── Track data ─────────────────────────────────────────────────────────────────
 # 4x LMS kart track, as in race_car_hybrid.py: long enough that the cars are
@@ -419,7 +419,7 @@ problem = ox.Problem(
     discretizer={
         "diffrax_kwargs": {"atol": 1e-8, "rtol": 1e-8},
     },
-    # solver=ox.MoreauPTRSolver(),
+    solver=ox.MoreauPTRSolver(),
 )
 problem.settings.dev.printing = False
 

--- a/examples/race_cars/race_car_multi_agent.py
+++ b/examples/race_cars/race_car_multi_agent.py
@@ -53,6 +53,7 @@ from __future__ import annotations
 import os
 import sys
 import time as _time
+from dataclasses import dataclass
 
 import jax
 
@@ -81,7 +82,7 @@ AGENTS = [
     dict(
         name="down on power",
         color=(220, 35, 45),
-        power_scale=0.9,
+        power_scale=0.7,
         mass_scale=1.0,
         battery_scale=1.0,
     ),
@@ -114,7 +115,7 @@ K = len(AGENTS)
 # published plan together — while counting laps and resetting the per-lap
 # recovery budget. Solver scaling, weights, and the curvature spline are
 # therefore all independent of race length.
-M_LAPS = 2
+M_LAPS = 1
 
 # ── Track data ─────────────────────────────────────────────────────────────────
 # 4x LMS kart track, as in race_car_hybrid.py: long enough that the cars are
@@ -188,7 +189,7 @@ SEP_LAT = 0.05  # semi-axis across the track [m]
 # ── MPC horizon ────────────────────────────────────────────────────────────────
 # Two seconds reaches through an entire braking zone and out the other side,
 # which is what lets a car weigh harvesting now against deploying later.
-N_MPC = 21  # horizon nodes
+N_MPC = 41  # horizon nodes
 HORIZON_TF = 2.0  # [s] prediction horizon
 DT_MPC = HORIZON_TF / (N_MPC - 1)  # time between consecutive nodes = one race step [s]
 RACE_TIME_MAX = 15.0 + 20.0 * M_LAPS  # [s] give up if the field has not finished by then
@@ -485,17 +486,43 @@ def opponent_view(pred: np.ndarray) -> np.ndarray:
     return np.stack([np.delete(pred, i, axis=0).T for i in range(K)])
 
 
+def accelerations(x: np.ndarray, u: np.ndarray, spec: dict) -> tuple[np.ndarray, np.ndarray]:
+    """(a_lat, a_long) [m/s²] along one car's dense log slice.
+
+    Mirrors the symbolic tyre-force model with the car's spec parameters, so
+    the returned points live on the same friction ellipse the solver saw.
+    """
+    v, D, delta = x[:, COL["v"]], x[:, COL["D"]], x[:, COL["delta"]]
+    deploy, regen = u[:, 2], u[:, 3]
+    F_env = spec["power_scale"] * (Cm1 - Cm2 * v)
+    Fxd = (
+        ICE_SHARE * F_env * D
+        + ELEC_SHARE * F_env * (deploy - regen)
+        - Cr2 * v**2
+        - Cr0 * np.tanh(5.0 * v)
+    )
+    m_car = m * spec["mass_scale"]
+    a_lat = C2 * v**2 * delta + Fxd * np.sin(C1 * delta) / m_car
+    a_long = Fxd / m_car
+    return a_lat, a_long
+
+
 # ── Plotly visualisation ───────────────────────────────────────────────────────
 
 
-def plot_race(sim: np.ndarray, t_sim: np.ndarray) -> None:
-    """Track projection per car, pairwise separation vs the limit, speed and
-    battery histories — all from the closed-loop log ``sim`` (T, K, 8)."""
+def plot_race(log: RaceLog) -> None:
+    """Track projection, separation, speed/battery striplines, and g-g diagrams.
+
+    Everything is drawn from the dense propagated log; the striplines run
+    against race distance in laps rather than time, so the same corner lines
+    up vertically across cars and laps.
+    """
     import plotly.graph_objects as go
     from plotly.subplots import make_subplots
     from time2spatial import transformProj2Orig
 
     css = [f"rgb{spec['color']}" for spec in AGENTS]
+    laps_x = log.dense_x[:, :, COL["s"]] / pathlength  # (K, Td) race distance in laps
 
     # ── Track projection ───────────────────────────────────────────────────────
     sref_d, xref_d, yref_d, psiref_d, _ = getTrack(TRACK_FILE)
@@ -520,12 +547,9 @@ def plot_race(sim: np.ndarray, t_sim: np.ndarray) -> None:
             )
         )
     for i, spec in enumerate(AGENTS):
+        x_i = log.dense_x[i]
         cart_x, cart_y, _, _ = transformProj2Orig(
-            sim[:, i, COL["s"]],
-            sim[:, i, COL["n"]],
-            sim[:, i, COL["alpha"]],
-            sim[:, i, COL["v"]],
-            TRACK_FILE,
+            x_i[:, COL["s"]], x_i[:, COL["n"]], x_i[:, COL["alpha"]], x_i[:, COL["v"]], TRACK_FILE
         )
         fig1.add_trace(
             go.Scatter(
@@ -547,46 +571,55 @@ def plot_race(sim: np.ndarray, t_sim: np.ndarray) -> None:
             )
         )
     fig1.update_layout(
-        title=f"Multi-agent race — closed-loop trajectories  ({len(sim)} steps)",
+        title=f"Multi-agent race — propagated closed-loop trajectories  ({len(log.sim)} steps)",
         xaxis=dict(title="x [m]", scaleanchor="y"),
         yaxis=dict(title="y [m]"),
         height=600,
     )
     fig1.show()
 
-    # ── Pairwise separation vs the ellipse limit ───────────────────────────────
+    # ── Pairwise separation vs the ellipse limit, against race distance ───────
     fig2 = go.Figure()
     for i in range(K):
         for j in range(i + 1, K):
-            ds = sim[:, i, COL["s"]] - sim[:, j, COL["s"]]
+            ds = log.dense_x[i, :, COL["s"]] - log.dense_x[j, :, COL["s"]]
             ds = (pathlength / np.pi) * np.sin(np.pi * ds / pathlength)  # lap-periodic gap
-            gap = np.sqrt(
-                (ds / SEP_LONG) ** 2 + ((sim[:, i, COL["n"]] - sim[:, j, COL["n"]]) / SEP_LAT) ** 2
-            )
+            dn = log.dense_x[i, :, COL["n"]] - log.dense_x[j, :, COL["n"]]
+            gap = np.sqrt((ds / SEP_LONG) ** 2 + (dn / SEP_LAT) ** 2)
             fig2.add_trace(
-                go.Scatter(x=t_sim, y=gap, name=f"{AGENTS[i]['name']} ↔ {AGENTS[j]['name']}")
+                go.Scatter(
+                    x=0.5 * (laps_x[i] + laps_x[j]),
+                    y=gap,
+                    name=f"{AGENTS[i]['name']} ↔ {AGENTS[j]['name']}",
+                )
             )
     fig2.add_hline(y=1.0, line=dict(color="black", dash="dash", width=1), annotation_text="contact")
     fig2.update_layout(
         title="Separation (ellipse metric — below 1 is contact)",
-        xaxis_title="t [s]",
+        xaxis_title="race distance [laps]",
         yaxis_title="normalised gap",
+        yaxis_type="log",
         height=400,
     )
     fig2.show()
 
-    # ── Speed and battery ──────────────────────────────────────────────────────
+    # ── Speed and battery striplines against race distance ────────────────────
     fig3 = make_subplots(rows=2, cols=1, shared_xaxes=True, subplot_titles=["v [m/s]", "E [J]"])
     for i, spec in enumerate(AGENTS):
         fig3.add_trace(
-            go.Scatter(x=t_sim, y=sim[:, i, COL["v"]], line=dict(color=css[i]), name=spec["name"]),
+            go.Scatter(
+                x=laps_x[i],
+                y=log.dense_x[i, :, COL["v"]],
+                line=dict(color=css[i]),
+                name=spec["name"],
+            ),
             row=1,
             col=1,
         )
         fig3.add_trace(
             go.Scatter(
-                x=t_sim,
-                y=sim[:, i, COL["E"]],
+                x=laps_x[i],
+                y=log.dense_x[i, :, COL["E"]],
                 line=dict(color=css[i]),
                 name=spec["name"],
                 showlegend=False,
@@ -600,21 +633,190 @@ def plot_race(sim: np.ndarray, t_sim: np.ndarray) -> None:
             row=2,
             col=1,
         )
-    fig3.update_xaxes(title_text="t [s]", row=2, col=1)
+    for lap in range(1, M_LAPS):
+        fig3.add_vline(x=float(lap), line=dict(color="black", dash="dot", width=1))
+    fig3.update_xaxes(title_text="race distance [laps]", row=2, col=1)
     fig3.update_layout(title="Speed and battery state of charge", height=600)
     fig3.show()
+
+    # ── g-g diagrams: one traction circle per car ──────────────────────────────
+    n_cols = 2
+    n_rows = (K + n_cols - 1) // n_cols
+    fig4 = make_subplots(rows=n_rows, cols=n_cols, subplot_titles=[spec["name"] for spec in AGENTS])
+    theta = np.linspace(0.0, 2.0 * np.pi, 120)
+    for i, spec in enumerate(AGENTS):
+        row, col = divmod(i, n_cols)
+        a_lat, a_long = accelerations(log.dense_x[i], log.dense_u[i], spec)
+        fig4.add_trace(
+            go.Scatter(
+                x=A_MAX * np.cos(theta),
+                y=A_MAX * np.sin(theta),
+                mode="lines",
+                line=dict(color="black", dash="dash", width=1),
+                showlegend=False,
+            ),
+            row=row + 1,
+            col=col + 1,
+        )
+        fig4.add_trace(
+            go.Scatter(
+                x=a_lat[::3],
+                y=a_long[::3],
+                mode="markers",
+                marker=dict(color=css[i], size=3, opacity=0.4),
+                showlegend=False,
+            ),
+            row=row + 1,
+            col=col + 1,
+        )
+        fig4.update_xaxes(title_text="a_lat [m/s²]", row=row + 1, col=col + 1)
+        fig4.update_yaxes(
+            title_text="a_long [m/s²]", scaleanchor=f"x{i + 1}", row=row + 1, col=col + 1
+        )
+    fig4.update_layout(title="g-g diagrams vs the friction ellipse", height=450 * n_rows)
+    fig4.show()
+
+
+def build_viser_panels(log: RaceLog) -> list[dict]:
+    """Live plot panels for the race replay: speed, battery, and g-g.
+
+    Each panel is a compact Plotly figure whose last ``K`` traces are
+    one-point markers, plus an ``update(t)`` closure that moves those markers
+    to the cars' state at race time ``t``. The striplines run against race
+    distance in laps; every car's series is trimmed at its own flag crossing
+    so its marker parks with the car.
+    """
+    import plotly.graph_objects as go
+
+    css = [f"rgb{spec['color']}" for spec in AGENTS]
+    end = [crossing_index(log.dense_x[i, :, COL["s"]]) for i in range(K)]
+    t_car = [log.dense_t[: end[i]] for i in range(K)]
+    lap_car = [log.dense_x[i, : end[i], COL["s"]] / pathlength for i in range(K)]
+
+    def compact(fig: go.Figure, title: str, xaxis: str, yaxis: str) -> go.Figure:
+        fig.update_layout(
+            title=dict(text=title, font=dict(size=13)),
+            xaxis_title=xaxis,
+            yaxis_title=yaxis,
+            margin=dict(l=45, r=10, t=30, b=35),
+            font=dict(size=10),
+            showlegend=False,
+        )
+        return fig
+
+    def stripline_panel(signal: list[np.ndarray], title: str, yaxis: str) -> dict:
+        fig = go.Figure()
+        for i in range(K):
+            stride = max(1, len(t_car[i]) // 500)
+            fig.add_trace(
+                go.Scatter(
+                    x=lap_car[i][::stride],
+                    y=signal[i][::stride],
+                    mode="lines",
+                    line=dict(color=css[i], width=1.5),
+                )
+            )
+        for i in range(K):
+            fig.add_trace(
+                go.Scatter(
+                    x=lap_car[i][:1],
+                    y=signal[i][:1],
+                    mode="markers",
+                    marker=dict(color=css[i], size=10, line=dict(color="white", width=1)),
+                )
+            )
+        compact(fig, title, "race distance [laps]", yaxis)
+
+        def update(t: float) -> None:
+            for i in range(K):
+                fig.data[K + i].x = (float(np.interp(t, t_car[i], lap_car[i])),)
+                fig.data[K + i].y = (float(np.interp(t, t_car[i], signal[i])),)
+
+        return {"figure": fig, "update": update, "aspect": 1.9}
+
+    v_car = [log.dense_x[i, : end[i], COL["v"]] for i in range(K)]
+    e_car = [log.dense_x[i, : end[i], COL["E"]] for i in range(K)]
+    gg_car = [
+        accelerations(log.dense_x[i, : end[i]], log.dense_u[i, : end[i]], spec)
+        for i, spec in enumerate(AGENTS)
+    ]
+
+    # g-g panel: friction circle, a faint cloud per car, and one live dot each.
+    theta = np.linspace(0.0, 2.0 * np.pi, 90)
+    gg_fig = go.Figure()
+    gg_fig.add_trace(
+        go.Scatter(
+            x=A_MAX * np.cos(theta),
+            y=A_MAX * np.sin(theta),
+            mode="lines",
+            line=dict(color="gray", dash="dash", width=1),
+        )
+    )
+    for i in range(K):
+        a_lat, a_long = gg_car[i]
+        stride = max(1, len(a_lat) // 200)
+        gg_fig.add_trace(
+            go.Scatter(
+                x=a_lat[::stride],
+                y=a_long[::stride],
+                mode="markers",
+                marker=dict(color=css[i], size=3, opacity=0.2),
+            )
+        )
+    for i in range(K):
+        gg_fig.add_trace(
+            go.Scatter(
+                x=gg_car[i][0][:1],
+                y=gg_car[i][1][:1],
+                mode="markers",
+                marker=dict(color=css[i], size=10, line=dict(color="white", width=1)),
+            )
+        )
+    compact(gg_fig, "g-g vs friction ellipse", "a_lat [m/s²]", "a_long [m/s²]")
+    gg_fig.update_yaxes(scaleanchor="x")
+
+    def update_gg(t: float) -> None:
+        for i in range(K):
+            gg_fig.data[1 + K + i].x = (float(np.interp(t, t_car[i], gg_car[i][0])),)
+            gg_fig.data[1 + K + i].y = (float(np.interp(t, t_car[i], gg_car[i][1])),)
+
+    return [
+        stripline_panel(v_car, "speed", "v [m/s]"),
+        stripline_panel(e_car, "battery", "E [J]"),
+        {"figure": gg_fig, "update": update_gg, "aspect": 1.0},
+    ]
 
 
 # ── Race loop ──────────────────────────────────────────────────────────────────
 
 
-def run_race(max_steps: int = MAX_STEPS) -> tuple[np.ndarray, np.ndarray, list]:
-    """Race the roster to the flag; returns ``(sim, t_sim, finish_time)``.
+@dataclass
+class RaceLog:
+    """Closed-loop record of one race.
 
-    ``sim`` is the closed-loop log, shape ``(T, K, len(DRIVER_STATES))``;
-    ``finish_time`` holds each car's flag-crossing time (``None`` if the time
-    cap expired first). One ``solve_batched`` call advances the whole field by
-    one node (``DT_MPC``) per iteration.
+    ``sim`` samples the driver states at the MPC rate (``T`` steps of
+    ``DT_MPC``) and is what the race logic consumes — finish detection,
+    classification, audits. ``dense_*`` stitch each step's *propagated*
+    executed interval together (``post_process_batched`` under the hood), so
+    playback and plots see the continuous trajectories the cars actually
+    drove, not the node samples. ``s`` entries in both logs are cumulative
+    race distance.
+    """
+
+    sim: np.ndarray  # (T, K, len(DRIVER_STATES)) at the MPC rate
+    t_sim: np.ndarray  # (T,)
+    finish_time: list  # per car; None if the time cap expired first
+    dense_t: np.ndarray  # (Td,)
+    dense_x: np.ndarray  # (K, Td, len(DRIVER_STATES))
+    dense_u: np.ndarray  # (K, Td, 4)  [derD, derDelta, deploy, regen]
+
+
+def run_race(max_steps: int = MAX_STEPS) -> RaceLog:
+    """Race the roster to the flag and return the :class:`RaceLog`.
+
+    One ``solve_batched`` call advances the whole field by one node
+    (``DT_MPC``) per iteration; each step's executed interval is propagated
+    densely for the log.
     """
     x0 = initial_pins()
     x_guess, u_guess = cold_start_guesses()
@@ -628,6 +830,9 @@ def run_race(max_steps: int = MAX_STEPS) -> tuple[np.ndarray, np.ndarray, list]:
     }
 
     sim_rows: list[np.ndarray] = []
+    dense_t: list[np.ndarray] = []
+    dense_x: list[np.ndarray] = []
+    dense_u: list[np.ndarray] = []
     finish_time: list = [None] * K
     laps = np.zeros(K)  # completed line crossings per car
     t_now = 0.0
@@ -648,6 +853,17 @@ def run_race(max_steps: int = MAX_STEPS) -> tuple[np.ndarray, np.ndarray, list]:
             max_iters=SCP_ITERS_PER_STEP,
         )
         solve_ms.append((_time.perf_counter() - tic) * 1e3)
+
+        # Propagate the horizon and keep the executed interval [0, DT_MPC):
+        # stitched across steps this is the continuous closed-loop trajectory.
+        post = problem.post_process_batched(results)
+        t_prop = np.asarray(post.t_full)[0]  # horizon clock, shared by all cars
+        keep = t_prop < DT_MPC - 1e-9
+        seg_x = np.asarray(post.x_full)[:, keep, : len(DRIVER_STATES)].copy()
+        seg_x[:, :, COL["s"]] += laps[:, None] * pathlength
+        dense_t.append(t_now + t_prop[keep])
+        dense_x.append(seg_x)
+        dense_u.append(np.asarray(post.u_full)[:, keep, :4])
 
         nodes = {name: np.asarray(results.nodes[name]) for name in DRIVER_STATES}
         row = np.stack([nodes[name][:, 0, 0] for name in DRIVER_STATES], axis=1)  # (K, n)
@@ -698,7 +914,14 @@ def run_race(max_steps: int = MAX_STEPS) -> tuple[np.ndarray, np.ndarray, list]:
         t_now += DT_MPC
 
     print(f"mean solve {np.mean(solve_ms):.0f} ms, max {np.max(solve_ms):.0f} ms")
-    return np.stack(sim_rows), np.arange(len(sim_rows)) * DT_MPC, finish_time
+    return RaceLog(
+        sim=np.stack(sim_rows),
+        t_sim=np.arange(len(sim_rows)) * DT_MPC,
+        finish_time=finish_time,
+        dense_t=np.concatenate(dense_t),
+        dense_x=np.concatenate(dense_x, axis=1),
+        dense_u=np.concatenate(dense_u, axis=1),
+    )
 
 
 def lap_of(s_cum: float) -> int:
@@ -706,13 +929,14 @@ def lap_of(s_cum: float) -> int:
     return int(min(max(s_cum, 0.0) // pathlength + 1, M_LAPS))
 
 
-def crossing_index(sim: np.ndarray, i: int) -> int:
-    """Number of log rows up to and including car ``i``'s flag crossing."""
-    return min(int(np.searchsorted(sim[:, i, COL["s"]], RACE_DISTANCE)) + 1, len(sim))
+def crossing_index(s_cum: np.ndarray) -> int:
+    """Number of samples of a cumulative-distance log up to the flag crossing."""
+    return min(int(np.searchsorted(s_cum, RACE_DISTANCE)) + 1, len(s_cum))
 
 
-def print_classification(sim: np.ndarray, finish_time: list) -> list[int]:
+def print_classification(log: RaceLog) -> list[int]:
     """Print the final order and per-car energy summary; returns the order."""
+    sim, finish_time = log.sim, log.finish_time
     order = sorted(range(K), key=lambda i: np.inf if finish_time[i] is None else finish_time[i])
     print("\n=== Race classification ===")
     for place, i in enumerate(order, start=1):
@@ -720,10 +944,11 @@ def print_classification(sim: np.ndarray, finish_time: list) -> list[int]:
         if finish_time[i] is None:
             print(f"  P{place}  {spec['name']:<20s}  DNF (time cap)")
             continue
-        at_flag = sim[crossing_index(sim, i) - 1, i]
+        cross = crossing_index(sim[:, i, COL["s"]])
+        at_flag = sim[cross - 1, i]
         # R saws per lap (reset at each line crossing); the race total is the
         # final value plus everything the resets discarded.
-        rec = sim[: crossing_index(sim, i), i, COL["R"]]
+        rec = sim[:cross, i, COL["R"]]
         recovered = rec[-1] - np.diff(rec)[np.diff(rec) < 0.0].sum()
         gap = "" if place == 1 else f"  +{finish_time[i] - finish_time[order[0]]:.3f} s"
         print(f"  P{place}  {spec['name']:<20s}  {finish_time[i]:7.3f} s{gap}")
@@ -737,23 +962,23 @@ def print_classification(sim: np.ndarray, finish_time: list) -> list[int]:
 # ── Main: run the race ─────────────────────────────────────────────────────────
 if __name__ == "__main__":
     problem.initialize()
-    sim, t_sim, finish_time = run_race()
-    order = print_classification(sim, finish_time)
+    log = run_race()
+    order = print_classification(log)
 
     if os.environ.get("OPENSCVX_NO_PLOT") is None:
-        plot_race(sim, t_sim)
+        plot_race(log)
 
         from race_car_viser import (
             create_race_car_chase_viser_server,
             create_race_car_comparison_viser_server,
         )
 
-        # Trim each car's log at its own flag crossing so the replay parks it
-        # at the line and the finishing gaps stay visible.
-        cross = [crossing_index(sim, i) for i in range(K)]
+        # Trim each car's dense log at its own flag crossing so the replay
+        # parks it at the line and the finishing gaps stay visible.
+        cross = [crossing_index(log.dense_x[i, :, COL["s"]]) for i in range(K)]
         comparison_server = create_race_car_comparison_viser_server(
-            simX_list=[sim[: cross[i], i, :6] for i in range(K)],
-            t_sim_list=[t_sim[: cross[i]] for i in range(K)],
+            simX_list=[log.dense_x[i, : cross[i], :6] for i in range(K)],
+            t_sim_list=[log.dense_t[: cross[i]] for i in range(K)],
             labels=[spec["name"] for spec in AGENTS],
             colors=[spec["color"] for spec in AGENTS],
             track_file=TRACK_FILE,
@@ -761,11 +986,12 @@ if __name__ == "__main__":
             trim_warmup=False,
             distance_marker_step=None,
             title="Multi-agent race",
+            plot_panels=build_viser_panels(log),
         )
         winner = order[0]
         chase_server = create_race_car_chase_viser_server(
-            simX=sim[: cross[winner], winner, :6],
-            t_sim=t_sim[: cross[winner]],
+            simX=log.dense_x[winner, : cross[winner], :6],
+            t_sim=log.dense_t[: cross[winner]],
             track_file=TRACK_FILE,
             lane_width=LANE_HALF_WIDTH,
             trim_warmup=False,

--- a/examples/race_cars/race_car_multi_agent.py
+++ b/examples/race_cars/race_car_multi_agent.py
@@ -30,9 +30,14 @@ simple — "gap along the track, gap across it" is exactly the (s, n) state,
 with none of the reference-path bookkeeping an MPCC formulation needs
 (compare ``examples/mpc/double_integrator_drone_racing.py``).
 
-The race is a standing start from an F1-style grid: cars staggered by
-``GRID_ROW_GAP`` down the track, alternating left and right of the
-centreline. The ``AGENTS`` roster is the single scaling knob — add an entry
+The race runs ``M_LAPS`` laps from a standing start on an F1-style grid:
+cars staggered by ``GRID_ROW_GAP`` down the track, alternating left and
+right of the centreline. As in the MPCC example, the ``s`` state lives on a
+single lap: the race loop wraps it at each line crossing (pin, warm start,
+and published plan together), counts laps, and resets the per-lap recovery
+budget ``R`` — so solver scaling and weights never depend on race length,
+and the separation gap is lap-periodic so a car being lapped is still an
+obstacle. The ``AGENTS`` roster is the single scaling knob — add an entry
 and the grid, the batch, the avoidance constraints, and the plots all grow
 with it. Spec differences are runtime parameters, so tweaking the field
 (a down-on-power engine, an oversize battery, ballast) never recompiles.
@@ -89,12 +94,20 @@ AGENTS = [
 ]
 K = len(AGENTS)
 
+# Race length. As in the MPCC example, the s state lives on a single lap and
+# the race loop wraps it at each line crossing — pin, warm start, and
+# published plan together — while counting laps and resetting the per-lap
+# recovery budget. Solver scaling, weights, and the curvature spline are
+# therefore all independent of race length.
+M_LAPS = 2
+
 # ── Track data ─────────────────────────────────────────────────────────────────
 # 4x LMS kart track, as in race_car_hybrid.py: long enough that the cars are
 # power-limited on the straights and the energy strategy matters.
 TRACK_FILE = "LMS_Track_x4.txt"
 sref_data, _, _, _, kapparef_data = getTrack(TRACK_FILE)
 pathlength = float(sref_data[-1])  # ≈ 34.84 m
+RACE_DISTANCE = M_LAPS * pathlength
 
 # Two cars racing side by side need room: open the lane to two car-widths per
 # side instead of the single-file 0.12 m of the one-car examples.
@@ -113,12 +126,15 @@ def grid_slot(i: int) -> tuple[float, float]:
     return -(i + 1) * GRID_ROW_GAP, 0.5 * LANE_HALF_WIDTH * (1.0 if i % 2 == 0 else -1.0)
 
 
-# Pad the curvature spline so it never extrapolates: below 0 it must cover the
-# deepest grid slot, above pathlength the post-finish overrun.
+# κ is lap-periodic, so two tiled copies cover every horizon: s is wrapped
+# back to the first copy at each line crossing, long before it could reach
+# the second copy's end. The low pad covers the deepest grid slot (the track
+# is straight there, so the boundary value is right).
 _pad_lo = (K + 1) * GRID_ROW_GAP + 1.0
-_pad_hi = S_OVERRUN + 1.0
-s_interp = np.concatenate([[sref_data[0] - _pad_lo], sref_data, [pathlength + _pad_hi]])
-kappa_interp = np.concatenate([[kapparef_data[0]], kapparef_data, [kapparef_data[-1]]])
+_s_tiled = np.concatenate([sref_data[:-1], sref_data + pathlength])
+_kappa_tiled = np.concatenate([kapparef_data[:-1], kapparef_data])
+s_interp = np.concatenate([[_s_tiled[0] - _pad_lo], _s_tiled])
+kappa_interp = np.concatenate([[_kappa_tiled[0]], _kappa_tiled])
 
 # ── Vehicle parameters (Kloeser et al. 2020, Table I) ─────────────────────────
 m = 0.043  # vehicle mass [kg]
@@ -144,12 +160,11 @@ R_LAP_MAX = 2.0 * E_BATT_MAX  # per-lap recovery cap [J] (a regulation: same for
 E_CAP_TOP = E_BATT_MAX * max(spec["battery_scale"] for spec in AGENTS)
 
 # ── Separation ellipse (track coordinates) ─────────────────────────────────────
-# Longer than it is wide, like the safe zone around a real car: SEP_LONG covers
-# a car length plus a braking margin, SEP_LAT one car width of daylight. Two
-# cars can run side by side (|Δn| = 2·|grid n| = LANE_HALF_WIDTH ≥ SEP_LAT) but
-# never nose-to-tail closer than SEP_LONG.
-SEP_LONG = 0.35  # semi-axis along the track [m]
-SEP_LAT = 0.12  # semi-axis across the track [m]
+# Longer than it is wide, like the safe zone around a real car, and deliberately
+# tight — about a car length nose-to-tail and a car width of daylight — so cars
+# can race in close company rather than orbiting each other at a distance.
+SEP_LONG = 0.15  # semi-axis along the track [m]
+SEP_LAT = 0.06  # semi-axis across the track [m]
 
 # ── MPC horizon ────────────────────────────────────────────────────────────────
 # Two seconds reaches through an entire braking zone and out the other side,
@@ -157,7 +172,7 @@ SEP_LAT = 0.12  # semi-axis across the track [m]
 N_MPC = 21  # horizon nodes
 HORIZON_TF = 2.0  # [s] prediction horizon
 DT_MPC = HORIZON_TF / (N_MPC - 1)  # time between consecutive nodes = one race step [s]
-RACE_TIME_MAX = 40.0  # [s] give up if the field has not finished by then
+RACE_TIME_MAX = 15.0 + 20.0 * M_LAPS  # [s] give up if the field has not finished by then
 MAX_STEPS = int(np.ceil(RACE_TIME_MAX / DT_MPC))
 
 # Real-time iteration: a fixed SCP budget per step instead of solving each
@@ -358,7 +373,15 @@ if K > 1:
     for j in range(K - 1):
         opp_s_t = ox.Sum(hat * opp_s[:, j])
         opp_n_t = ox.Sum(hat * opp_n[:, j])
-        gap = ((s[0] - opp_s_t) / SEP_LONG) ** 2 + ((n[0] - opp_n_t) / SEP_LAT) ** 2
+        # Plans are published in each car's own lap frame, so Δs can be off
+        # by whole laps (a freshly wrapped car vs. one still approaching the
+        # line, or a car being lapped). The gap is therefore lap-periodic:
+        # (L/π)·sin(π·Δs/L) matches Δs exactly near whole-lap multiples — the
+        # only place the bubble can bind — and stays harmlessly large in
+        # between.
+        ds = s[0] - opp_s_t
+        ds_wrap = ox.Constant(pathlength / np.pi) * ox.Sin(ox.Constant(np.pi / pathlength) * ds)
+        gap = (ds_wrap / SEP_LONG) ** 2 + ((n[0] - opp_n_t) / SEP_LAT) ** 2
         constraints.append(ox.ctcs(W_SEP * (1.0 - gap) <= 0.0, penalty="huber"))
 
 # ── Problem ────────────────────────────────────────────────────────────────────
@@ -513,9 +536,10 @@ def plot_race(sim: np.ndarray, t_sim: np.ndarray) -> None:
     fig2 = go.Figure()
     for i in range(K):
         for j in range(i + 1, K):
+            ds = sim[:, i, COL["s"]] - sim[:, j, COL["s"]]
+            ds = (pathlength / np.pi) * np.sin(np.pi * ds / pathlength)  # lap-periodic gap
             gap = np.sqrt(
-                ((sim[:, i, COL["s"]] - sim[:, j, COL["s"]]) / SEP_LONG) ** 2
-                + ((sim[:, i, COL["n"]] - sim[:, j, COL["n"]]) / SEP_LAT) ** 2
+                (ds / SEP_LONG) ** 2 + ((sim[:, i, COL["n"]] - sim[:, j, COL["n"]]) / SEP_LAT) ** 2
             )
             fig2.add_trace(
                 go.Scatter(x=t_sim, y=gap, name=f"{AGENTS[i]['name']} ↔ {AGENTS[j]['name']}")
@@ -583,6 +607,7 @@ def run_race(max_steps: int = MAX_STEPS) -> tuple[np.ndarray, np.ndarray, list]:
 
     sim_rows: list[np.ndarray] = []
     finish_time: list = [None] * K
+    laps = np.zeros(K)  # completed line crossings per car
     t_now = 0.0
     solve_ms: list[float] = []
 
@@ -604,17 +629,19 @@ def run_race(max_steps: int = MAX_STEPS) -> tuple[np.ndarray, np.ndarray, list]:
 
         nodes = {name: np.asarray(results.nodes[name]) for name in DRIVER_STATES}
         row = np.stack([nodes[name][:, 0, 0] for name in DRIVER_STATES], axis=1)  # (K, n)
+        row[:, COL["s"]] += laps * pathlength  # the log carries cumulative race distance
 
         # Finish detection: interpolate the flag crossing inside the last step.
         for i in range(K):
-            if finish_time[i] is None and row[i, COL["s"]] >= pathlength:
+            if finish_time[i] is None and row[i, COL["s"]] >= RACE_DISTANCE:
                 s_prev = sim_rows[-1][i, COL["s"]] if sim_rows else grid_slot(i)[0]
-                frac = (pathlength - s_prev) / max(row[i, COL["s"]] - s_prev, 1e-9)
+                frac = (RACE_DISTANCE - s_prev) / max(row[i, COL["s"]] - s_prev, 1e-9)
                 finish_time[i] = t_now - DT_MPC * (1.0 - frac)
 
         sim_rows.append(row)
         status = "  |  ".join(
-            f"{AGENTS[i]['name']}: s={row[i, COL['s']]:6.2f} v={row[i, COL['v']]:.2f}"
+            f"{AGENTS[i]['name']}: L{lap_of(row[i, COL['s']])}"
+            f" s={row[i, COL['s']]:6.2f} v={row[i, COL['v']]:.2f}"
             f" E={row[i, COL['E']]:.3f}"
             for i in range(K)
         )
@@ -627,17 +654,39 @@ def run_race(max_steps: int = MAX_STEPS) -> tuple[np.ndarray, np.ndarray, list]:
         for name in DRIVER_STATES:
             x0[:, COL[name]] = nodes[name][:, 1, 0]
         x_guess, u_guess = shifted_guesses(results)
-        pred_s = nodes["s"][:, :, 0]
+        pred_s = nodes["s"][:, :, 0].copy()
         pred_n = nodes["n"][:, :, 0]
+
+        # Lap handling, as in the MPCC example: when a car takes the line its
+        # s frame wraps back one lap — pin, warm start, and published plan
+        # together — and its recovery budget R resets. Opponents only ever see
+        # the frame through the lap-periodic gap, which is invariant to the
+        # shift. A horizon straddling the line charges its first metres of
+        # new-lap harvesting to the old lap's budget: conservative by at most
+        # one horizon, exact again at the reset.
+        for i in range(K):
+            if x0[i, COL["s"]] >= pathlength:
+                laps[i] += 1
+                x0[i, COL["s"]] -= pathlength
+                x_guess[i, :, COL["s"]] -= pathlength
+                pred_s[i] -= pathlength
+                x_guess[i, :, COL["R"]] = np.maximum(x_guess[i, :, COL["R"]] - x0[i, COL["R"]], 0.0)
+                x0[i, COL["R"]] = 0.0
+
         t_now += DT_MPC
 
     print(f"mean solve {np.mean(solve_ms):.0f} ms, max {np.max(solve_ms):.0f} ms")
     return np.stack(sim_rows), np.arange(len(sim_rows)) * DT_MPC, finish_time
 
 
+def lap_of(s_cum: float) -> int:
+    """Current lap number (1-based) at cumulative race distance ``s_cum``."""
+    return int(min(max(s_cum, 0.0) // pathlength + 1, M_LAPS))
+
+
 def crossing_index(sim: np.ndarray, i: int) -> int:
     """Number of log rows up to and including car ``i``'s flag crossing."""
-    return min(int(np.searchsorted(sim[:, i, COL["s"]], pathlength)) + 1, len(sim))
+    return min(int(np.searchsorted(sim[:, i, COL["s"]], RACE_DISTANCE)) + 1, len(sim))
 
 
 def print_classification(sim: np.ndarray, finish_time: list) -> list[int]:
@@ -650,11 +699,15 @@ def print_classification(sim: np.ndarray, finish_time: list) -> list[int]:
             print(f"  P{place}  {spec['name']:<20s}  DNF (time cap)")
             continue
         at_flag = sim[crossing_index(sim, i) - 1, i]
+        # R saws per lap (reset at each line crossing); the race total is the
+        # final value plus everything the resets discarded.
+        rec = sim[: crossing_index(sim, i), i, COL["R"]]
+        recovered = rec[-1] - np.diff(rec)[np.diff(rec) < 0.0].sum()
         gap = "" if place == 1 else f"  +{finish_time[i] - finish_time[order[0]]:.3f} s"
         print(f"  P{place}  {spec['name']:<20s}  {finish_time[i]:7.3f} s{gap}")
         print(
             f"       battery {sim[0, i, COL['E']]:.3f} → {at_flag[COL['E']]:.3f} J,"
-            f" recovered {at_flag[COL['R']]:.3f} J (cap {R_LAP_MAX:.3f} J)"
+            f" recovered {recovered:.3f} J (cap {R_LAP_MAX:.3f} J/lap)"
         )
     return order
 

--- a/examples/race_cars/race_car_multi_agent.py
+++ b/examples/race_cars/race_car_multi_agent.py
@@ -517,7 +517,7 @@ def accelerations(x: np.ndarray, u: np.ndarray, spec: dict) -> tuple[np.ndarray,
 
 
 def plot_race(log: RaceLog) -> None:
-    """Track projection, separation, and speed/battery striplines.
+    """Track projection and speed/battery striplines.
 
     Everything is drawn from the dense propagated log; the striplines run
     against race distance in laps rather than time, so the same corner lines
@@ -585,35 +585,10 @@ def plot_race(log: RaceLog) -> None:
     )
     fig1.show()
 
-    # ── Pairwise separation vs the ellipse limit, against race distance ───────
-    fig2 = go.Figure()
-    for i in range(K):
-        for j in range(i + 1, K):
-            ds = log.dense_x[i, :, COL["s"]] - log.dense_x[j, :, COL["s"]]
-            ds = (pathlength / np.pi) * np.sin(np.pi * ds / pathlength)  # lap-periodic gap
-            dn = log.dense_x[i, :, COL["n"]] - log.dense_x[j, :, COL["n"]]
-            gap = np.sqrt((ds / SEP_LONG) ** 2 + (dn / SEP_LAT) ** 2)
-            fig2.add_trace(
-                go.Scatter(
-                    x=0.5 * (laps_x[i] + laps_x[j]),
-                    y=gap,
-                    name=f"{AGENTS[i]['name']} ↔ {AGENTS[j]['name']}",
-                )
-            )
-    fig2.add_hline(y=1.0, line=dict(color="black", dash="dash", width=1), annotation_text="contact")
-    fig2.update_layout(
-        title="Separation (ellipse metric — below 1 is contact)",
-        xaxis_title="race distance [laps]",
-        yaxis_title="normalised gap",
-        yaxis_type="log",
-        height=400,
-    )
-    fig2.show()
-
     # ── Speed and battery striplines against race distance ────────────────────
-    fig3 = make_subplots(rows=2, cols=1, shared_xaxes=True, subplot_titles=["v [m/s]", "E [J]"])
+    fig2 = make_subplots(rows=2, cols=1, shared_xaxes=True, subplot_titles=["v [m/s]", "E [J]"])
     for i, spec in enumerate(AGENTS):
-        fig3.add_trace(
+        fig2.add_trace(
             go.Scatter(
                 x=laps_x[i],
                 y=log.dense_x[i, :, COL["v"]],
@@ -623,7 +598,7 @@ def plot_race(log: RaceLog) -> None:
             row=1,
             col=1,
         )
-        fig3.add_trace(
+        fig2.add_trace(
             go.Scatter(
                 x=laps_x[i],
                 y=log.dense_x[i, :, COL["E"]],
@@ -634,17 +609,17 @@ def plot_race(log: RaceLog) -> None:
             row=2,
             col=1,
         )
-        fig3.add_hline(
+        fig2.add_hline(
             y=spec["battery_scale"] * E_BATT_MAX,
             line=dict(color=css[i], dash="dash", width=1),
             row=2,
             col=1,
         )
     for lap in range(1, M_LAPS):
-        fig3.add_vline(x=float(lap), line=dict(color="black", dash="dot", width=1))
-    fig3.update_xaxes(title_text="race distance [laps]", row=2, col=1)
-    fig3.update_layout(title="Speed and battery state of charge", height=600)
-    fig3.show()
+        fig2.add_vline(x=float(lap), line=dict(color="black", dash="dot", width=1))
+    fig2.update_xaxes(title_text="race distance [laps]", row=2, col=1)
+    fig2.update_layout(title="Speed and battery state of charge", height=600)
+    fig2.show()
 
 
 def build_viser_panels(log: RaceLog) -> list[dict]:

--- a/examples/race_cars/race_car_multi_agent.py
+++ b/examples/race_cars/race_car_multi_agent.py
@@ -41,8 +41,9 @@ obstacle. The ``AGENTS`` roster is the single scaling knob — add an entry
 and the grid, the batch, the avoidance constraints, and the plots all grow
 with it. Spec differences are runtime parameters, so tweaking the field
 (a down-on-power engine, an oversize battery, ballast) never recompiles.
-The default roster puts a car that is 10% down on power on pole and a
-healthy one behind it: the chaser must find a way past on track.
+The default roster puts a car that is 10% down on power on pole, a healthy
+reference car behind it, an overweight car in row two, and a second
+reference car charging from the back: every pass has to happen on track.
 
 Run headless (no Plotly/Viser) with ``OPENSCVX_NO_PLOT=1``.
 """
@@ -87,6 +88,20 @@ AGENTS = [
     dict(
         name="reference spec",
         color=(90, 140, 235),
+        power_scale=1.0,
+        mass_scale=1.0,
+        battery_scale=1.0,
+    ),
+    dict(
+        name="overweight",
+        color=(240, 190, 50),
+        power_scale=1.0,
+        mass_scale=1.15,
+        battery_scale=1.0,
+    ),
+    dict(
+        name="reference P4",
+        color=(120, 200, 120),
         power_scale=1.0,
         mass_scale=1.0,
         battery_scale=1.0,
@@ -160,11 +175,15 @@ R_LAP_MAX = 2.0 * E_BATT_MAX  # per-lap recovery cap [J] (a regulation: same for
 E_CAP_TOP = E_BATT_MAX * max(spec["battery_scale"] for spec in AGENTS)
 
 # ── Separation ellipse (track coordinates) ─────────────────────────────────────
-# Longer than it is wide, like the safe zone around a real car, and deliberately
-# tight — about a car length nose-to-tail and a car width of daylight — so cars
-# can race in close company rather than orbiting each other at a distance.
-SEP_LONG = 0.15  # semi-axis along the track [m]
-SEP_LAT = 0.06  # semi-axis across the track [m]
+# Longer than it is wide, like the safe zone around a real car, and about as
+# tight as the bodywork allows: the 1:43 body is ~0.07 x 0.03 m, so these
+# centre-to-centre semi-axes leave roughly half a body of daylight in each
+# direction. Cars race nose-to-gearbox and wheel-to-wheel. The daylight is
+# also the robustness margin: each car avoids the plan its opponent published
+# one step earlier, so in a hard scrap the realized gap can sag a few percent
+# into the bubble — half a body absorbs that without bodywork contact.
+SEP_LONG = 0.10  # semi-axis along the track [m]
+SEP_LAT = 0.05  # semi-axis across the track [m]
 
 # ── MPC horizon ────────────────────────────────────────────────────────────────
 # Two seconds reaches through an entire braking zone and out the other side,
@@ -365,8 +384,10 @@ constraints.append(ox.ctcs(a_lat**2 + a_long**2 <= A_MAX**2, penalty="huber"))
 # too — no gap for a car to slip through at a node boundary. The ``W_SEP``
 # scaling makes contact far dearer than any progress the reward could buy;
 # without it, driving through an opponent costs less than lifting, and the
-# solver ghost-passes.
-W_SEP = 1e3
+# solver ghost-passes. It also sets how crisply the soft huber penalty holds
+# the boundary — the bubble is barely half a body wide, so the few-percent
+# sag a lighter weight allows is already wheel-banging.
+W_SEP = 4e3
 
 if K > 1:
     hat = ox.Max(1.0 - ox.Abs(time[0] / DT_MPC - np.arange(N_MPC, dtype=float)), 0.0)
@@ -409,6 +430,7 @@ problem = ox.Problem(
         "lam_cost": {"s": 4e1},
         "autotuner": ox.ConstantProximalWeight(),
     },
+    solver=ox.MoreauPTRSolver(),
 )
 problem.settings.dev.printing = False
 

--- a/examples/race_cars/race_car_multi_agent.py
+++ b/examples/race_cars/race_car_multi_agent.py
@@ -426,10 +426,29 @@ problem = ox.Problem(
         # "converges" glued to its warm start and the field crawls. lam_vc
         # must in turn dominate the reward, or virtual control buys progress
         # at the horizon's last node instead of driving there.
+        # lam_prox/ep_tr picked by a batched sweep (solve_batched over a
+        # lam_prox x ep_tr grid, one single-car lap per element): 2.0/1e-2 is
+        # the fastest lap with ~96% of steps converged. Heavier damping
+        # "converges" more often but to visibly worse plans — the car crawls.
         "lam_vc": 1e3,
-        "lam_prox": 4e0,
+        "lam_prox": 2e0,
         "lam_cost": {"s": 4e1},
         "autotuner": ox.ConstantProximalWeight(),
+        # Convergence for a receding horizon means the *plan* is stationary,
+        # not stationary to solver precision: the terminal progress reward
+        # works against the grip limit at the horizon tail, and the linearized
+        # active set flutters there by ~1 cm no matter how many iterations run
+        # (J_vc and J_vb sit at machine precision throughout). ep_tr sits just
+        # above that structural jitter floor; the applied node-0 controls are
+        # stable well before it.
+        "ep_tr": 1e-2,
+    },
+    # The default integration atol (1e-3) is coarser than the battery states
+    # (~0.1 J), and that linearization noise lands right at the ep_tr floor:
+    # with default tolerances only ~60% of car-steps converge within the
+    # iteration budget, with tight ones ~90%+, for ~15% more time per step.
+    discretizer={
+        "diffrax_kwargs": {"atol": 1e-8, "rtol": 1e-8},
     },
     # solver=ox.MoreauPTRSolver(),
 )
@@ -463,19 +482,41 @@ def cold_start_guesses() -> tuple[np.ndarray, np.ndarray]:
     return x, u
 
 
-def shift_horizon(plan: np.ndarray) -> np.ndarray:
-    """Advance a horizon one node: drop node 0, hold the last node."""
-    return np.concatenate([plan[:, 1:], plan[:, -1:]], axis=1)
+def shift_forecast(plan: np.ndarray) -> np.ndarray:
+    """Advance published plans one node so they align with the next horizon.
+
+    Every car's horizon runs on the same uniform clock and moves forward one
+    node per race step, so node ``k`` of the *next* horizon is node ``k + 1``
+    of the plan an opponent just published. The freed final node is
+    extrapolated along the plan — holding it would forecast the opponent
+    parking for the last interval of every horizon.
+    """
+    tail = 2.0 * plan[:, -1:] - plan[:, -2:-1]
+    return np.concatenate([plan[:, 1:], tail], axis=1)
+
+
+# Driver-state box, for keeping the extrapolated warm-start tail physical.
+_X_LO = np.array([st.min[0] for st in states])
+_X_HI = np.array([st.max[0] for st in states])
 
 
 def shifted_guesses(results) -> tuple[np.ndarray, np.ndarray]:
     """Warm starts for the next step: previous plans shifted one node.
 
-    The horizon clock and the CTCS violation integrators restart from zero
-    each solve, so those columns are reset rather than shifted.
+    The freed final node is *extrapolated* along the plan, not held — a held
+    tail is dynamically infeasible (the state freezes while carrying racing
+    speed), which hands every solve a built-in defect at the last interval
+    that virtual control must burn iterations repairing. Controls hold their
+    last value. The horizon clock and the CTCS violation integrators restart
+    from zero each solve, so those columns are reset rather than shifted.
     """
-    x = shift_horizon(np.asarray(results.x))
-    u = shift_horizon(np.asarray(results.u))
+    x = np.asarray(results.x)
+    u = np.asarray(results.u)
+    n_d = len(DRIVER_STATES)
+    tail = x[:, -1:].copy()
+    tail[:, :, :n_d] = np.clip(2.0 * x[:, -1:, :n_d] - x[:, -2:-1, :n_d], _X_LO, _X_HI)
+    x = np.concatenate([x[:, 1:], tail], axis=1)
+    u = np.concatenate([u[:, 1:], u[:, -1:]], axis=1)
     x[:, :, TIME_COL] = np.linspace(0.0, HORIZON_TF, N_MPC)
     x[:, :, TIME_COL + 1 :] = 0.0
     return x, u
@@ -511,11 +552,12 @@ def accelerations(x: np.ndarray, u: np.ndarray, spec: dict) -> tuple[np.ndarray,
 
 
 def plot_race(log: RaceLog) -> None:
-    """Track projection, separation, speed/battery striplines, and g-g diagrams.
+    """Track projection, separation, and speed/battery striplines.
 
     Everything is drawn from the dense propagated log; the striplines run
     against race distance in laps rather than time, so the same corner lines
-    up vertically across cars and laps.
+    up vertically across cars and laps. The g-g diagrams live in the Viser
+    telemetry panels, where they play back with the race.
     """
     import plotly.graph_objects as go
     from plotly.subplots import make_subplots
@@ -638,43 +680,6 @@ def plot_race(log: RaceLog) -> None:
     fig3.update_xaxes(title_text="race distance [laps]", row=2, col=1)
     fig3.update_layout(title="Speed and battery state of charge", height=600)
     fig3.show()
-
-    # ── g-g diagrams: one traction circle per car ──────────────────────────────
-    n_cols = 2
-    n_rows = (K + n_cols - 1) // n_cols
-    fig4 = make_subplots(rows=n_rows, cols=n_cols, subplot_titles=[spec["name"] for spec in AGENTS])
-    theta = np.linspace(0.0, 2.0 * np.pi, 120)
-    for i, spec in enumerate(AGENTS):
-        row, col = divmod(i, n_cols)
-        a_lat, a_long = accelerations(log.dense_x[i], log.dense_u[i], spec)
-        fig4.add_trace(
-            go.Scatter(
-                x=A_MAX * np.cos(theta),
-                y=A_MAX * np.sin(theta),
-                mode="lines",
-                line=dict(color="black", dash="dash", width=1),
-                showlegend=False,
-            ),
-            row=row + 1,
-            col=col + 1,
-        )
-        fig4.add_trace(
-            go.Scatter(
-                x=a_lat[::3],
-                y=a_long[::3],
-                mode="markers",
-                marker=dict(color=css[i], size=3, opacity=0.4),
-                showlegend=False,
-            ),
-            row=row + 1,
-            col=col + 1,
-        )
-        fig4.update_xaxes(title_text="a_lat [m/s²]", row=row + 1, col=col + 1)
-        fig4.update_yaxes(
-            title_text="a_long [m/s²]", scaleanchor=f"x{i + 1}", row=row + 1, col=col + 1
-        )
-    fig4.update_layout(title="g-g diagrams vs the friction ellipse", height=450 * n_rows)
-    fig4.show()
 
 
 def build_viser_panels(log: RaceLog) -> list[dict]:
@@ -845,12 +850,13 @@ def run_race(max_steps: int = MAX_STEPS) -> RaceLog:
     laps = np.zeros(K)  # completed line crossings per car
     t_now = 0.0
     solve_ms: list[float] = []
+    conv_flags: list[np.ndarray] = []
 
     for step in range(max_steps):
         params = dict(spec_params)
         if K > 1:
-            params["opp_s"] = opponent_view(shift_horizon(pred_s))
-            params["opp_n"] = opponent_view(shift_horizon(pred_n))
+            params["opp_s"] = opponent_view(shift_forecast(pred_s))
+            params["opp_n"] = opponent_view(shift_forecast(pred_n))
 
         tic = _time.perf_counter()
         results = problem.solve_batched(
@@ -861,6 +867,7 @@ def run_race(max_steps: int = MAX_STEPS) -> RaceLog:
             max_iters=SCP_ITERS_PER_STEP,
         )
         solve_ms.append((_time.perf_counter() - tic) * 1e3)
+        conv_flags.append(np.asarray(results.converged).reshape(-1))
 
         # Propagate the horizon and keep the executed interval [0, DT_MPC):
         # stitched across steps this is the continuous closed-loop trajectory.
@@ -891,7 +898,9 @@ def run_race(max_steps: int = MAX_STEPS) -> RaceLog:
             f" E={row[i, COL['E']]:.3f}"
             for i in range(K)
         )
-        print(f"step {step:4d}  t={t_now:6.2f} s  {status}  ({solve_ms[-1]:.0f} ms)")
+        n_conv = int(conv_flags[-1].sum())
+        conv_note = "" if n_conv == K else f", conv {n_conv}/{K}"
+        print(f"step {step:4d}  t={t_now:6.2f} s  {status}  ({solve_ms[-1]:.0f} ms{conv_note})")
 
         if all(t is not None for t in finish_time):
             break
@@ -921,7 +930,11 @@ def run_race(max_steps: int = MAX_STEPS) -> RaceLog:
 
         t_now += DT_MPC
 
-    print(f"mean solve {np.mean(solve_ms):.0f} ms, max {np.max(solve_ms):.0f} ms")
+    conv_rate = float(np.mean(np.concatenate(conv_flags)))
+    print(
+        f"mean solve {np.mean(solve_ms):.0f} ms, max {np.max(solve_ms):.0f} ms, "
+        f"converged within {SCP_ITERS_PER_STEP} iters: {100 * conv_rate:.0f}% of car-steps"
+    )
     return RaceLog(
         sim=np.stack(sim_rows),
         t_sim=np.arange(len(sim_rows)) * DT_MPC,

--- a/examples/race_cars/race_car_viser.py
+++ b/examples/race_cars/race_car_viser.py
@@ -675,7 +675,6 @@ def create_race_car_comparison_viser_server(
     loop_animation: bool = True,
     trim_warmup: bool = True,
     distance_marker_step: float | str | None = "auto",
-    trail_fade_s: float | None = 6.0,
     plot_panels: list[dict] | None = None,
     title: str = "Race Comparison",
 ) -> "viser.ViserServer":
@@ -696,9 +695,6 @@ def create_race_car_comparison_viser_server(
         colors: Body RGB per car (defaults cycle a small palette).
         distance_marker_step: Metres between "x m" track labels; ``"auto"``
             picks ~9 per lap, ``None`` hides them.
-        trail_fade_s: Bright trail behind each car fades out over this many
-            seconds of playback (the faint full ghost stays). ``None`` keeps
-            the whole trail at full strength.
         plot_panels: Optional live plots for the GUI sidebar: dicts with a
             Plotly ``"figure"``, an ``"update"`` callable taking the current
             playback time in seconds (mutate the figure's marker traces), and
@@ -763,17 +759,9 @@ def create_race_car_comparison_viser_server(
             line_width=4.0,
         )
         handles = _add_race_car(server, base_path=f"/cars/{slug}", body_color=color)
-        cars.append({"lap": lap, "label": label, "trace": trace_line, "color": color, **handles})
+        cars.append({"lap": lap, "label": label, "trace": trace_line, **handles})
 
     hud = {"markdown": None}
-
-    # Bright trail fade: keep only the last ``trail_fade_s`` seconds of trail,
-    # blending each segment from the canvas background up to the car colour —
-    # the faint ghost above keeps the full history without the clutter.
-    fade_frames = None
-    if trail_fade_s is not None and len(t_common) > 1:
-        fade_frames = max(2, int(round(trail_fade_s / float(t_common[1] - t_common[0]))))
-    _canvas_bg = np.array([16.0, 17.0, 19.0])
 
     def update_frame(frame_idx: int) -> None:
         status_lines = []
@@ -790,13 +778,9 @@ def create_race_car_comparison_viser_server(
 
             idx = min(frame_idx + 1, len(lap["pos"]))
             if idx >= 2:
-                lo = 0 if fade_frames is None else max(0, idx - fade_frames)
-                seg = np.stack([lap["pos"][lo : idx - 1], lap["pos"][lo + 1 : idx]], axis=1)
-                car["trace"].points = seg.astype(np.float32)
-                if fade_frames is not None:
-                    w = np.linspace(0.0, 1.0, len(seg) + 1)[1:, None] ** 1.5
-                    shade = _canvas_bg * (1.0 - w) + np.asarray(car["color"], dtype=float) * w
-                    car["trace"].colors = np.repeat(shade.astype(np.uint8)[:, None, :], 2, axis=1)
+                car["trace"].points = np.stack(
+                    [lap["pos"][: idx - 1], lap["pos"][1:idx]], axis=1
+                ).astype(np.float32)
 
             finished = t_common[frame_idx] >= lap["lap_time"]
             state = "FINISHED" if finished else f"{lap['speed'][frame_idx]:.2f} m/s"
@@ -809,13 +793,17 @@ def create_race_car_comparison_viser_server(
 
     # Live GUI plots: each panel owns its figure; we hand it the playback time
     # and push the mutated figure to the client, rate-limited because every
-    # push re-serializes the whole figure.
+    # push re-serializes the whole figure. The large ``order`` keeps the
+    # telemetry folder below the Animation and race-status folders, which are
+    # created later with default (insertion-order) positions.
     panel_handles = []
-    for panel in plot_panels or []:
-        handle = server.gui.add_plotly(
-            figure=panel["figure"], aspect=float(panel.get("aspect", 1.6))
-        )
-        panel_handles.append((panel, handle))
+    if plot_panels:
+        with server.gui.add_folder("Telemetry", order=1000):
+            for panel in plot_panels:
+                handle = server.gui.add_plotly(
+                    figure=panel["figure"], aspect=float(panel.get("aspect", 1.6))
+                )
+                panel_handles.append((panel, handle))
     _panel_clock = {"last_t": -np.inf}
 
     def update_panels(frame_idx: int) -> None:

--- a/examples/race_cars/race_car_viser.py
+++ b/examples/race_cars/race_car_viser.py
@@ -664,9 +664,11 @@ def _resample_to_common_time(
 
 
 def create_race_car_comparison_viser_server(
-    results_list,
+    results_list=None,
     labels: list[str] | None = None,
     *,
+    simX_list: list[np.ndarray] | None = None,
+    t_sim_list: list[np.ndarray] | None = None,
     colors: list[tuple[int, int, int]] | None = None,
     track_file: str = "LMS_Track.txt",
     lane_width: float = 0.12,
@@ -680,11 +682,15 @@ def create_race_car_comparison_viser_server(
     All cars launch together at the start line; each holds at the finish once
     its own lap is done, so the winning margin is visible on screen. Intended
     for A/B comparisons such as the hybrid vs ICE-only laps of
-    ``race_car_hybrid.py``.
+    ``race_car_hybrid.py``, or multi-car MPC races via ``simX_list``.
 
     Args:
         results_list: Post-processed ``OptimizationResults``, one per car.
         labels: Display name per car (default ``car 0``, ``car 1``, ...).
+        simX_list: Alternative to ``results_list``: closed-loop MPC logs, one
+            ``(N, 6)`` array per car with columns ``[s, n, α, v, D, δ]`` (same
+            layout as :func:`extract_race_trajectory_from_sim`).
+        t_sim_list: Time vector per car; required with ``simX_list``.
         colors: Body RGB per car (defaults cycle a small palette).
         distance_marker_step: Metres between "x m" track labels; ``"auto"``
             picks ~9 per lap, ``None`` hides them.
@@ -694,16 +700,28 @@ def create_race_car_comparison_viser_server(
 
     from openscvx.plotting.viser import add_animation_controls
 
+    if simX_list is not None:
+        if t_sim_list is None:
+            raise ValueError("t_sim_list is required when simX_list is provided")
+        datas = [
+            extract_race_trajectory_from_sim(
+                simX, t_sim, track_file=track_file, trim_warmup=trim_warmup
+            )
+            for simX, t_sim in zip(simX_list, t_sim_list)
+        ]
+    elif results_list is not None:
+        datas = [
+            extract_race_trajectory(results, track_file=track_file, trim_warmup=trim_warmup)
+            for results in results_list
+        ]
+    else:
+        raise ValueError("Provide results_list, or simX_list and t_sim_list")
+
     if labels is None:
-        labels = [f"car {i}" for i in range(len(results_list))]
+        labels = [f"car {i}" for i in range(len(datas))]
     if colors is None:
         palette = [(220, 35, 45), (90, 140, 235), (240, 190, 50), (120, 200, 120)]
-        colors = [palette[i % len(palette)] for i in range(len(results_list))]
-
-    datas = [
-        extract_race_trajectory(results, track_file=track_file, trim_warmup=trim_warmup)
-        for results in results_list
-    ]
+        colors = [palette[i % len(palette)] for i in range(len(datas))]
     t_common, laps = _resample_to_common_time(datas)
 
     server = viser.ViserServer()

--- a/examples/race_cars/race_car_viser.py
+++ b/examples/race_cars/race_car_viser.py
@@ -675,6 +675,8 @@ def create_race_car_comparison_viser_server(
     loop_animation: bool = True,
     trim_warmup: bool = True,
     distance_marker_step: float | str | None = "auto",
+    trail_fade_s: float | None = 6.0,
+    plot_panels: list[dict] | None = None,
     title: str = "Race Comparison",
 ) -> "viser.ViserServer":
     """Replay several laps side by side on one track with a shared clock.
@@ -694,6 +696,14 @@ def create_race_car_comparison_viser_server(
         colors: Body RGB per car (defaults cycle a small palette).
         distance_marker_step: Metres between "x m" track labels; ``"auto"``
             picks ~9 per lap, ``None`` hides them.
+        trail_fade_s: Bright trail behind each car fades out over this many
+            seconds of playback (the faint full ghost stays). ``None`` keeps
+            the whole trail at full strength.
+        plot_panels: Optional live plots for the GUI sidebar: dicts with a
+            Plotly ``"figure"``, an ``"update"`` callable taking the current
+            playback time in seconds (mutate the figure's marker traces), and
+            an optional ``"aspect"`` ratio. Updates are throttled — Plotly
+            panels re-serialize on every assignment.
     """
     import viser
     import viser.transforms as vtf
@@ -753,9 +763,17 @@ def create_race_car_comparison_viser_server(
             line_width=4.0,
         )
         handles = _add_race_car(server, base_path=f"/cars/{slug}", body_color=color)
-        cars.append({"lap": lap, "label": label, "trace": trace_line, **handles})
+        cars.append({"lap": lap, "label": label, "trace": trace_line, "color": color, **handles})
 
     hud = {"markdown": None}
+
+    # Bright trail fade: keep only the last ``trail_fade_s`` seconds of trail,
+    # blending each segment from the canvas background up to the car colour —
+    # the faint ghost above keeps the full history without the clutter.
+    fade_frames = None
+    if trail_fade_s is not None and len(t_common) > 1:
+        fade_frames = max(2, int(round(trail_fade_s / float(t_common[1] - t_common[0]))))
+    _canvas_bg = np.array([16.0, 17.0, 19.0])
 
     def update_frame(frame_idx: int) -> None:
         status_lines = []
@@ -772,9 +790,13 @@ def create_race_car_comparison_viser_server(
 
             idx = min(frame_idx + 1, len(lap["pos"]))
             if idx >= 2:
-                car["trace"].points = np.stack(
-                    [lap["pos"][: idx - 1], lap["pos"][1:idx]], axis=1
-                ).astype(np.float32)
+                lo = 0 if fade_frames is None else max(0, idx - fade_frames)
+                seg = np.stack([lap["pos"][lo : idx - 1], lap["pos"][lo + 1 : idx]], axis=1)
+                car["trace"].points = seg.astype(np.float32)
+                if fade_frames is not None:
+                    w = np.linspace(0.0, 1.0, len(seg) + 1)[1:, None] ** 1.5
+                    shade = _canvas_bg * (1.0 - w) + np.asarray(car["color"], dtype=float) * w
+                    car["trace"].colors = np.repeat(shade.astype(np.uint8)[:, None, :], 2, axis=1)
 
             finished = t_common[frame_idx] >= lap["lap_time"]
             state = "FINISHED" if finished else f"{lap['speed'][frame_idx]:.2f} m/s"
@@ -784,6 +806,26 @@ def create_race_car_comparison_viser_server(
             hud["markdown"].content = f"**t:** {t_common[frame_idx]:.3f} s  \n" + "  \n".join(
                 status_lines
             )
+
+    # Live GUI plots: each panel owns its figure; we hand it the playback time
+    # and push the mutated figure to the client, rate-limited because every
+    # push re-serializes the whole figure.
+    panel_handles = []
+    for panel in plot_panels or []:
+        handle = server.gui.add_plotly(
+            figure=panel["figure"], aspect=float(panel.get("aspect", 1.6))
+        )
+        panel_handles.append((panel, handle))
+    _panel_clock = {"last_t": -np.inf}
+
+    def update_panels(frame_idx: int) -> None:
+        t = float(t_common[frame_idx])
+        if abs(t - _panel_clock["last_t"]) < 0.15:
+            return
+        _panel_clock["last_t"] = t
+        for panel, handle in panel_handles:
+            panel["update"](t)
+            handle.figure = panel["figure"]
 
     centre = np.mean(np.concatenate([lap["pos"] for lap in laps]), axis=0)
     span_xy = (
@@ -795,7 +837,8 @@ def create_race_car_comparison_viser_server(
     server.initial_camera.look_at = tuple(float(x) for x in centre)
     server.initial_camera.up = (0.0, 0.0, 1.0)
 
-    add_animation_controls(server, t_common, [update_frame], loop=loop_animation)
+    callbacks = [update_frame] + ([update_panels] if panel_handles else [])
+    add_animation_controls(server, t_common, callbacks, loop=loop_animation)
     update_frame(0)
 
     lap_times = sorted((lap["lap_time"], label) for lap, label in zip(laps, labels))


### PR DESCRIPTION
## What

Adds `examples/race_cars/race_car_multi_agent.py`: a field of four F1-2026-style hybrid cars (from `race_car_hybrid.py`) racing wheel-to-wheel on the 4x LMS track, plus race-replay support in `race_car_viser.py` and a README entry.

## Design

- **One symbolic `Problem`, one `solve_batched` call per race step.** Everything that differs between cars enters through runtime inputs: batched boundary pins for state, `power_scale`/`mass_scale`/`battery_scale` parameters for the spec, and `opp_s`/`opp_n` parameters for opponent forecasts. The `AGENTS` roster is the single scaling knob — no recompilation to change the field.
- **Decentralized MPC with communicated plans.** Each car re-plans against the plans its opponents published on the previous step, shifted one node so all horizons share one uniform clock. Separation is an elliptical keep-out in Frenet coordinates, enforced continuously in time (CTCS) by interpolating opponent forecasts with a hat basis in the time state; the gap is lap-periodic so a car being lapped is still an obstacle.
- **Standing start, multi-lap race.** The `s` state lives on a single lap and is wrapped at each crossing (pin, warm start, and published plan together), with the per-lap recovery budget reset — solver scaling is independent of race length. Overtakes, defence, and energy strategy emerge from the optimization; nothing is scripted.
- **Race log at two rates.** `RaceLog.sim` samples at the MPC rate for race logic (finish detection, classification); `dense_*` stitch each step's propagated executed interval for playback and plots, with `run_race(dense=False)` available to skip the per-step propagation on quick runs.

## Tuning

Configuration was swept in closed loop, single-car first (all four specs, one lap per batch element), then validated on full four-car races: integration tolerances at 1e-6 hold lap times and convergence at the 1e-8 reference at a fraction of the per-step cost; the 0.12/0.06 separation ellipse keeps grazing cars apart on the propagated trajectory while converging more wheel-to-wheel steps; a 10-iteration RTI-style cap per step, with per-step outcomes logged in `RaceLog.converged`. Weight regime follows the MPCC drone example: progress reward dominates the proximal anchor, `lam_vc` dominates the reward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)