### PR TITLE
Per-constraint licq_max overrides, remove licq_min

### DIFF
--- a/examples/spacecraft/relative_loitering.py
+++ b/examples/spacecraft/relative_loitering.py
@@ -353,7 +353,6 @@ def build_relative_loitering_problem(
         time=time,
         constraints=constraints,
         N=n_nodes,
-        licq_min=0.0,
         licq_max=1e-8,
         discretizer={
             "ode_solver": "Dopri8",

--- a/openscvx/problem.py
+++ b/openscvx/problem.py
@@ -340,8 +340,7 @@ class Problem:
         dynamics_prop: Optional[dict] = None,
         states_prop: Optional[List[State]] = None,
         algebraic_prop: Optional[dict] = None,
-        licq_min: Union[float, Dict[int, float]] = 0.0,
-        licq_max: Union[float, Dict[int, float]] = 1e-4,
+        licq_max: float = 1e-4,
         algorithm: Optional[Union[Algorithm, dict]] = None,
         discretizer: Optional[Union[Discretizer, dict]] = None,
         solver: Optional[Union[ConvexSolver, dict]] = None,
@@ -373,12 +372,11 @@ class Problem:
                 Only specify additional states beyond optimization states. Used with dynamics_prop.
             algebraic_prop (dict, optional): Dictionary mapping names to symbolic expressions
                 for outputs evaluated (not integrated) during propagation.
-            licq_min: Minimum LICQ constraint value. Defaults to 0.0.
-                Either a scalar (applied to all CTCS groups) or a dict
-                mapping CTCS group ``idx`` to per-group bounds.
-            licq_max: Maximum LICQ constraint value. Defaults to 1e-4.
-                Either a scalar (applied to all CTCS groups) or a dict
-                mapping CTCS group ``idx`` to per-group bounds.
+            licq_max: Problem-wide upper bound for CTCS augmented states
+                (default: 1e-4). Serves as the default for all constraint
+                groups; a ``licq_max`` set on an individual constraint (via
+                ``ctcs(...)`` or ``.over(...)``) overrides it for that
+                constraint's augmented state.
             algorithm: SCP algorithm configuration. Accepts:
 
                 - ``None`` — uses ``PenalizedTrustRegion()`` with defaults.
@@ -539,7 +537,6 @@ class Problem:
             controls=controls,
             N=N,
             time=time,
-            licq_min=licq_min,
             licq_max=licq_max,
             dynamics_prop_extra=dynamics_prop,
             states_prop_extra=states_prop,

--- a/openscvx/symbolic/augmentation.py
+++ b/openscvx/symbolic/augmentation.py
@@ -54,7 +54,7 @@ Example:
         # controls_aug includes original controls + time dilation
 """
 
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 
@@ -448,8 +448,7 @@ def augment_dynamics_with_ctcs(
     N: int,
     xdelta: Optional[Expr] = None,
     *,
-    licq_min: Union[float, Dict[int, float]] = 0.0,
-    licq_max: Union[float, Dict[int, float]] = 1e-4,
+    licq_max: float = 1e-4,
 ) -> Tuple[Expr, Optional[Expr], List[State], List[Control]]:
     """Augment dynamics with continuous-time constraint satisfaction states.
 
@@ -467,18 +466,20 @@ def augment_dynamics_with_ctcs(
         aug_dot = penalty(g(x, u))  # For each constraint group
         time_dot = 1.0
 
+    Each augmented state is bounded to [0, licq_max], where the group's bound
+    is taken from its member constraints' ``licq_max`` attribute (constraints in
+    a group must agree) and falls back to the problem-wide ``licq_max`` when no
+    member specifies one.
+
     Args:
         xdot: Original dynamics expression for states
         states: List of state variables (must include a state named "time")
         controls: List of control variables
         constraints_ctcs: List of CTCS constraints (should be sorted and grouped)
         N: Number of discretization nodes
-        licq_min: Minimum bound for augmented states (default: 0.0).
-            Either a scalar (applied to all groups) or a dict mapping
-            CTCS group ``idx`` to per-group bounds.
-        licq_max: Maximum bound for augmented states (default: 1e-4).
-            Either a scalar (applied to all groups) or a dict mapping
-            CTCS group ``idx`` to per-group bounds.
+        licq_max: Problem-wide default upper bound for augmented states
+            (default: 1e-4). Per-constraint ``licq_max`` values override it
+            for their group.
 
     Returns:
         Tuple of:
@@ -489,6 +490,8 @@ def augment_dynamics_with_ctcs(
 
     Raises:
         ValueError: If no state named "time" is found in the states list
+        ValueError: If constraints sharing an augmented state specify
+            conflicting ``licq_max`` values
 
     Example:
         Augment dynamics with CTCS penalty states:
@@ -509,6 +512,9 @@ def augment_dynamics_with_ctcs(
         states_aug includes x, time, and _ctcs_aug_0,
         controls_aug includes u and _time_dilation
     """
+    if licq_max <= 0:
+        raise ValueError(f"licq_max must be a positive number, got {licq_max!r}")
+
     # Save if discrete dynamics is null
     discrete_dynamics_set = xdelta is not None
 
@@ -535,24 +541,6 @@ def augment_dynamics_with_ctcs(
                 penalty_groups[ctcs.idx] = []
             penalty_groups[ctcs.idx].append(ctcs)
 
-        # Validate dict-valued licq_min / licq_max keys against actual groups.
-        valid_ids = set(penalty_groups.keys())
-        for name, val in [("licq_min", licq_min), ("licq_max", licq_max)]:
-            if isinstance(val, dict):
-                unknown = set(val.keys()) - valid_ids
-                if unknown:
-                    raise ValueError(
-                        f"{name} dict contains unknown CTCS group idx: {unknown}. "
-                        f"Valid idx values: {sorted(valid_ids)}"
-                    )
-                missing = valid_ids - set(val.keys())
-                if missing:
-                    raise ValueError(
-                        f"{name} dict is missing entries for CTCS group idx: "
-                        f"{sorted(missing)}. When using a dict, all groups must "
-                        f"have an entry. Valid idx values: {sorted(valid_ids)}"
-                    )
-
         # Create augmented state expressions for each group and corresponding
         # augmented state variables. For discrete dynamics, preserve these states
         # by identity mapping across impulsive updates.
@@ -566,17 +554,25 @@ def augment_dynamics_with_ctcs(
                 augmented_state_expr = Add(*penalty_terms)
             augmented_state_exprs.append(augmented_state_expr)
 
-            # Resolve per-group LICQ bounds
-            idx_min = licq_min[idx] if isinstance(licq_min, dict) else licq_min
-            idx_max = licq_max[idx] if isinstance(licq_max, dict) else licq_max
+            # Resolve the group's LICQ bound from its member constraints:
+            # explicit values must agree; otherwise fall back to the
+            # problem-wide default.
+            explicit = {c.licq_max for c in penalty_terms if c.licq_max is not None}
+            if len(explicit) > 1:
+                raise ValueError(
+                    f"CTCS constraints sharing augmented state idx={idx} specify "
+                    f"conflicting licq_max values: {sorted(explicit)}. Constraints "
+                    f"in the same group must agree on licq_max; set the same value "
+                    f"on each, or separate them into different groups via idx."
+                )
+            group_licq_max = explicit.pop() if explicit else licq_max
 
             aug_var = State(f"_ctcs_aug_{idx}", shape=(1,))
-            aug_var.initial = np.array([idx_min])  # Set initial to respect bounds
+            aug_var.initial = np.array([0.0])
             aug_var.final = [("free", 0)]
-            aug_var.min = np.array([idx_min])
-            aug_var.max = np.array([idx_max])
-            # Set guess to idx_min as well
-            aug_var.guess = np.full([N, 1], idx_min)  # N x num augmented states
+            aug_var.min = np.array([0.0])
+            aug_var.max = np.array([group_licq_max])
+            aug_var.guess = np.zeros([N, 1])  # N x num augmented states
             states_augmented.append(aug_var)
             augmented_state_exprs_discrete.append(aug_var)
 

--- a/openscvx/symbolic/builder.py
+++ b/openscvx/symbolic/builder.py
@@ -29,7 +29,7 @@ Pipeline stages:
 See `preprocess_symbolic_problem()` for the main entry point.
 """
 
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 
@@ -71,8 +71,7 @@ def preprocess_symbolic_problem(
     controls: List[Control],
     N: int,
     time: Time,
-    licq_min: Union[float, Dict[int, float]] = 0.0,
-    licq_max: Union[float, Dict[int, float]] = 1e-4,
+    licq_max: float = 1e-4,
     dynamics_prop_extra: dict = None,
     dynamics_discrete: dict = None,
     states_prop_extra: List[State] = None,
@@ -106,12 +105,9 @@ def preprocess_symbolic_problem(
         controls: List of user-defined Control objects (should NOT include time dilation)
         N: Number of discretization nodes in the trajectory
         time: Time configuration object specifying time bounds and constraints
-        licq_min: Minimum bound for CTCS augmented states (default: 0.0).
-            Either a scalar (applied to all groups) or a dict mapping
-            CTCS group ``idx`` to per-group bounds.
-        licq_max: Maximum bound for CTCS augmented states (default: 1e-4).
-            Either a scalar (applied to all groups) or a dict mapping
-            CTCS group ``idx`` to per-group bounds.
+        licq_max: Problem-wide default upper bound for CTCS augmented states
+            (default: 1e-4). Per-constraint ``licq_max`` values override it
+            for their group.
         dynamics_prop_extra: Optional dictionary of additional dynamics for propagation-only
             states (default: None)
         states_prop_extra: Optional list of additional State objects for propagation only
@@ -350,7 +346,6 @@ def preprocess_symbolic_problem(
         constraints.ctcs,
         N,
         xdelta=dynamics_discrete_concat,
-        licq_min=licq_min,
         licq_max=licq_max,
     )
 

--- a/openscvx/symbolic/expr/constraint.py
+++ b/openscvx/symbolic/expr/constraint.py
@@ -127,6 +127,7 @@ class Constraint(Expr):
         penalty: str = "squared_relu",
         idx: Optional[int] = None,
         check_nodally: bool = False,
+        licq_max: Optional[float] = None,
     ) -> "CTCS":
         """Apply this constraint over a continuous interval using CTCS.
 
@@ -135,11 +136,22 @@ class Constraint(Expr):
             penalty: Penalty function type ("squared_relu", "huber", "smooth_relu")
             idx: Optional grouping index for multiple augmented states
             check_nodally: Whether to also enforce this constraint nodally
+            licq_max: Optional upper bound on the augmented state that accumulates
+                this constraint's violation penalty. Constraints sharing an
+                augmented state must agree on the value; groups without one use
+                the problem-wide ``licq_max`` (a ``Problem`` argument).
 
         Returns:
             CTCS constraint wrapping this constraint with interval specification
         """
-        return CTCS(self, penalty=penalty, nodes=interval, idx=idx, check_nodally=check_nodally)
+        return CTCS(
+            self,
+            penalty=penalty,
+            nodes=interval,
+            idx=idx,
+            check_nodally=check_nodally,
+            licq_max=licq_max,
+        )
 
     def convex(self) -> "Constraint":
         """Mark this constraint as convex for CVXPy lowering.
@@ -609,6 +621,11 @@ class CTCS(Expr):
             an augmented state. If None, auto-assigned based on node intervals.
         check_nodally: Whether to also enforce the constraint at discrete nodes for
             additional numerical robustness (creates both continuous and nodal constraints)
+        licq_max: Optional upper bound on the augmented state accumulating this
+            constraint's violation penalty. Smaller values enforce the constraint
+            more strictly between nodes. Constraints sharing an augmented state
+            must agree on the value; groups without one use the problem-wide
+            ``licq_max`` (a ``Problem`` argument).
 
     Example:
         Single augmented state (default behavior - same node interval):
@@ -642,6 +659,7 @@ class CTCS(Expr):
         nodes: Optional[Tuple[int, int]] = None,
         idx: Optional[int] = None,
         check_nodally: bool = False,
+        licq_max: Optional[float] = None,
     ):
         """Initialize a CTCS constraint.
 
@@ -662,11 +680,16 @@ class CTCS(Expr):
             check_nodally: If True, also enforce the constraint at discrete nodes for
                 numerical stability (creates both continuous and nodal constraints).
                 Defaults to False.
+            licq_max: Optional upper bound on the augmented state accumulating this
+                constraint's violation penalty. Constraints sharing an augmented
+                state must agree on the value; groups without one use the
+                problem-wide ``licq_max`` (a ``Problem`` argument).
 
         Raises:
             TypeError: If constraint is not a Constraint instance
             ValueError: If nodes is not None or a 2-tuple of integers
             ValueError: If nodes[0] >= nodes[1] (invalid interval)
+            ValueError: If licq_max is not a positive number
         """
         if not isinstance(constraint, Constraint):
             raise TypeError("CTCS must wrap a Constraint")
@@ -683,12 +706,19 @@ class CTCS(Expr):
             if nodes[0] >= nodes[1]:
                 raise ValueError("CTCS node range must have start < end")
 
+        if licq_max is not None:
+            if not isinstance(licq_max, (int, float)) or licq_max <= 0:
+                raise ValueError(f"licq_max must be a positive number, got {licq_max!r}")
+            licq_max = float(licq_max)
+
         self.constraint = constraint
         self.penalty = penalty
         self.nodes = nodes  # (start, end) node range or None for all nodes
         self.idx = idx  # Optional grouping index for multiple augmented states
         # Whether to also enforce this constraint nodally for numerical stability
         self.check_nodally = check_nodally
+        # Upper bound on the augmented state; None defers to the group default
+        self.licq_max = licq_max
 
     def children(self) -> List[Expr]:
         """Return the wrapped constraint as the only child.
@@ -711,6 +741,7 @@ class CTCS(Expr):
             nodes=self.nodes,
             idx=self.idx,
             check_nodally=self.check_nodally,
+            licq_max=self.licq_max,
         )
 
     def check_shape(self) -> Tuple[int, ...]:
@@ -767,6 +798,11 @@ class CTCS(Expr):
             hasher.update(b"None")
         # Hash check_nodally
         hasher.update(b"1" if self.check_nodally else b"0")
+        # Hash licq_max
+        if self.licq_max is not None:
+            hasher.update(struct.pack(">d", self.licq_max))
+        else:
+            hasher.update(b"None")
         # Hash the wrapped constraint
         self.constraint._hash_into(hasher)
 
@@ -794,6 +830,7 @@ class CTCS(Expr):
             nodes=interval,
             idx=self.idx,
             check_nodally=self.check_nodally,
+            licq_max=self.licq_max,
         )
 
     def __repr__(self) -> str:
@@ -809,6 +846,8 @@ class CTCS(Expr):
             parts.append(f"idx={self.idx}")
         if self.check_nodally:
             parts.append(f"check_nodally={self.check_nodally}")
+        if self.licq_max is not None:
+            parts.append(f"licq_max={self.licq_max}")
         return f"CTCS({', '.join(parts)})"
 
     def penalty_expr(self) -> Expr:
@@ -861,6 +900,7 @@ def ctcs(
     nodes: Optional[Tuple[int, int]] = None,
     idx: Optional[int] = None,
     check_nodally: bool = False,
+    licq_max: Optional[float] = None,
 ) -> CTCS:
     """Helper function to create CTCS (Continuous-Time Constraint Satisfaction) constraints.
 
@@ -876,6 +916,10 @@ def ctcs(
         idx: Optional grouping index for multiple augmented states
         check_nodally: Whether to also enforce constraint at discrete nodes.
             Defaults to False.
+        licq_max: Optional upper bound on the augmented state accumulating this
+            constraint's violation penalty. Constraints sharing an augmented
+            state must agree on the value; groups without one use the
+            problem-wide ``licq_max`` (a ``Problem`` argument).
 
     Returns:
         CTCS: A CTCS constraint wrapping the input constraint
@@ -899,4 +943,4 @@ def ctcs(
 
             altitude_constraint = (altitude >= 10).over((0, 100), penalty="huber")
     """
-    return CTCS(constraint, penalty, nodes, idx, check_nodally)
+    return CTCS(constraint, penalty, nodes, idx, check_nodally, licq_max)

--- a/openscvx/symbolic/expr/stl.py
+++ b/openscvx/symbolic/expr/stl.py
@@ -310,6 +310,7 @@ class STLExpr(Expr):
         penalty: str = "smooth_relu",
         idx: Optional[int] = None,
         check_nodally: bool = False,
+        licq_max: Optional[float] = None,
         interval_type: IntervalKind = "nodes",
     ) -> "CTCS":
         """Apply this STL expression over an enforcement interval using CTCS.
@@ -323,6 +324,10 @@ class STLExpr(Expr):
             penalty: Penalty function type for CTCS
             idx: Optional grouping index for multiple augmented states
             check_nodally: Whether to also enforce at discrete nodes
+            licq_max: Optional upper bound on the augmented state accumulating
+                this constraint's violation penalty. Constraints sharing an
+                augmented state must agree on the value; groups without one use
+                the problem-wide ``licq_max`` (a ``Problem`` argument).
 
         Returns:
             Continuous-time constraint satisfaction wrapper
@@ -359,6 +364,7 @@ class STLExpr(Expr):
             nodes=(coerced.start, coerced.end),
             idx=idx,
             check_nodally=check_nodally,
+            licq_max=licq_max,
         )
 
     def at(self, nodes: Union[list, tuple]) -> "NodalConstraint":
@@ -863,6 +869,7 @@ class Always(_TemporalSTLExpr):
         penalty: str = "smooth_relu",
         idx: Optional[int] = None,
         check_nodally: bool = False,
+        licq_max: Optional[float] = None,
         interval_type: IntervalKind = "nodes",
     ) -> "CTCS":
         """Convert this ``Always`` to a ``CTCS`` constraint.
@@ -876,6 +883,10 @@ class Always(_TemporalSTLExpr):
             penalty: CTCS penalty function name.
             idx: Optional grouping index for multiple augmented states.
             check_nodally: Whether to additionally enforce at discrete nodes.
+            licq_max: Optional upper bound on the augmented state accumulating
+                this constraint's violation penalty. Constraints sharing an
+                augmented state must agree on the value; groups without one use
+                the problem-wide ``licq_max`` (a ``Problem`` argument).
 
         Returns:
             A ``CTCS`` constraint enforcing the inner predicate over the
@@ -903,7 +914,7 @@ class Always(_TemporalSTLExpr):
 
         if isinstance(self.predicate, STLExpr):
             return self.predicate.over(
-                chosen, penalty=penalty, idx=idx, check_nodally=check_nodally
+                chosen, penalty=penalty, idx=idx, check_nodally=check_nodally, licq_max=licq_max
             )
 
         from .constraint import CTCS
@@ -914,6 +925,7 @@ class Always(_TemporalSTLExpr):
             nodes=(chosen.start, chosen.end),
             idx=idx,
             check_nodally=check_nodally,
+            licq_max=licq_max,
         )
 
     def __repr__(self) -> str:

--- a/openscvx/symbolic/expr/stljax.py
+++ b/openscvx/symbolic/expr/stljax.py
@@ -59,6 +59,7 @@ class STLJaxExpr(Expr):
         penalty: str = "squared_relu",
         idx: Optional[int] = None,
         check_nodally: bool = False,
+        licq_max: Optional[float] = None,
     ) -> "CTCS":
         """Apply this STL expression over a continuous interval using CTCS.
 
@@ -70,6 +71,10 @@ class STLJaxExpr(Expr):
             penalty: Penalty function type for CTCS
             idx: Optional grouping index for multiple augmented states
             check_nodally: Whether to also enforce at discrete nodes
+            licq_max: Optional upper bound on the augmented state accumulating
+                this constraint's violation penalty. Constraints sharing an
+                augmented state must agree on the value; groups without one use
+                the problem-wide ``licq_max`` (a ``Problem`` argument).
 
         Returns:
             Continuous-time constraint satisfaction wrapper
@@ -89,7 +94,12 @@ class STLJaxExpr(Expr):
         constraint = Inequality(Neg(self), Constant(np.array(0.0)))
 
         return CTCS(
-            constraint, penalty=penalty, nodes=interval, idx=idx, check_nodally=check_nodally
+            constraint,
+            penalty=penalty,
+            nodes=interval,
+            idx=idx,
+            check_nodally=check_nodally,
+            licq_max=licq_max,
         )
 
     def at(self, nodes: Union[list, tuple]) -> "NodalConstraint":

--- a/tests/symbolic/test_augmentation.py
+++ b/tests/symbolic/test_augmentation.py
@@ -789,7 +789,7 @@ def test_equality_constraint_penalty():
 
 
 def test_augmented_state_bounds():
-    """Test that augmented state has correct min/max bounds."""
+    """Augmented state is bounded to [0, licq_max] from the constraint."""
     x = State("x", (1,))
     x.final = np.array([0.0])
     time = State("time", (1,))
@@ -800,7 +800,7 @@ def test_augmented_state_bounds():
     N = 5
     time.guess = np.linspace(0, time.final[0], N).reshape(-1, 1)
 
-    constraint = ctcs(x <= 1.0, penalty="squared_relu")
+    constraint = ctcs(x <= 1.0, penalty="squared_relu", licq_max=0.01)
 
     xdot_aug, _, states_aug, controls_aug = augment_dynamics_with_ctcs(
         xdot,
@@ -808,21 +808,19 @@ def test_augmented_state_bounds():
         controls,
         [constraint],
         N,
-        licq_min=0.001,
-        licq_max=0.01,
     )
 
     # Check augmented state bounds (third state after time and x)
     aug_state = states_aug[2]  # third state is the augmented one
-    assert aug_state.min[0] == 0.001, "Augmented state min should match licq_min"
+    assert aug_state.min[0] == 0.0, "Augmented state min should be 0"
     assert aug_state.max[0] == 0.01, "Augmented state max should match licq_max"
-    assert aug_state.initial[0] == 0.001, "Augmented state initial should be licq_min"
+    assert aug_state.initial[0] == 0.0, "Augmented state initial should be 0"
     assert aug_state.guess.shape == (N, 1), "Augmented state guess should have correct shape"
-    assert np.allclose(aug_state.guess, 0.001), "Augmented state guess should be licq_min"
+    assert np.allclose(aug_state.guess, 0.0), "Augmented state guess should be 0"
 
 
-def test_augmented_state_bounds_per_group_dict():
-    """Per-group LICQ bounds via dict keyed by idx."""
+def test_augmented_state_bounds_per_group():
+    """Each group takes its licq_max from its member constraints."""
     x = State("x", (1,))
     time = State("time", (1,))
     time.final = np.array([10.0])
@@ -833,8 +831,8 @@ def test_augmented_state_bounds_per_group_dict():
     time.guess = np.linspace(0, time.final[0], N).reshape(-1, 1)
 
     # Two constraints with different node intervals → two groups (idx 0 and 1)
-    c0 = ctcs(x <= 1.0, penalty="squared_relu", nodes=(0, 3))
-    c1 = ctcs(x <= 2.0, penalty="squared_relu", nodes=(3, 5))
+    c0 = ctcs(x <= 1.0, penalty="squared_relu", nodes=(0, 3), licq_max=1e-8)
+    c1 = ctcs(x <= 2.0, penalty="squared_relu", nodes=(3, 5), licq_max=0.01)
 
     _, _, states_aug, _ = augment_dynamics_with_ctcs(
         xdot,
@@ -842,8 +840,6 @@ def test_augmented_state_bounds_per_group_dict():
         controls,
         [c0, c1],
         N,
-        licq_min={0: 0.0, 1: 0.001},
-        licq_max={0: 1e-8, 1: 0.01},
     )
 
     aug0 = states_aug[2]  # _ctcs_aug_0
@@ -854,14 +850,14 @@ def test_augmented_state_bounds_per_group_dict():
     assert aug0.initial[0] == 0.0
     assert np.allclose(aug0.guess, 0.0)
 
-    assert aug1.min[0] == 0.001
+    assert aug1.min[0] == 0.0
     assert aug1.max[0] == 0.01
-    assert aug1.initial[0] == 0.001
-    assert np.allclose(aug1.guess, 0.001)
+    assert aug1.initial[0] == 0.0
+    assert np.allclose(aug1.guess, 0.0)
 
 
-def test_augmented_state_bounds_scalar_with_multiple_groups():
-    """Scalar LICQ bounds broadcast to all groups."""
+def test_licq_max_defaults_when_unspecified():
+    """Groups without an explicit licq_max fall back to the 1e-4 default."""
     x = State("x", (1,))
     time = State("time", (1,))
     time.final = np.array([10.0])
@@ -880,44 +876,88 @@ def test_augmented_state_bounds_scalar_with_multiple_groups():
         controls,
         [c0, c1],
         N,
-        licq_min=0.002,
-        licq_max=0.05,
     )
 
     for i in [2, 3]:
         aug = states_aug[i]
-        assert aug.min[0] == 0.002
-        assert aug.max[0] == 0.05
-        assert aug.initial[0] == 0.002
+        assert aug.min[0] == 0.0
+        assert aug.max[0] == 1e-4
+        assert aug.initial[0] == 0.0
 
 
-def test_licq_dict_unknown_idx_raises():
-    """Dict licq with unknown idx raises helpful error."""
+def test_licq_max_problem_default_and_override():
+    """A problem-wide licq_max applies to groups without an explicit value;
+    per-constraint values override it."""
     x = State("x", (1,))
     time = State("time", (1,))
     time.final = np.array([10.0])
     states = [time, x]
     N = 5
     time.guess = np.linspace(0, time.final[0], N).reshape(-1, 1)
-    c0 = ctcs(x <= 1.0, penalty="squared_relu", nodes=(0, 5))
 
-    with pytest.raises(ValueError, match="unknown CTCS group idx.*5"):
-        augment_dynamics_with_ctcs(x, states, [], [c0], N, licq_max={0: 1e-8, 5: 1e-4})
-
-
-def test_licq_dict_missing_idx_raises():
-    """Dict licq missing a group idx raises helpful error."""
-    x = State("x", (1,))
-    time = State("time", (1,))
-    time.final = np.array([10.0])
-    states = [time, x]
-    N = 5
-    time.guess = np.linspace(0, time.final[0], N).reshape(-1, 1)
-    c0 = ctcs(x <= 1.0, penalty="squared_relu", nodes=(0, 3))
+    c0 = ctcs(x <= 1.0, penalty="squared_relu", nodes=(0, 3), licq_max=1e-8)
     c1 = ctcs(x <= 2.0, penalty="squared_relu", nodes=(3, 5))
 
-    with pytest.raises(ValueError, match="missing entries for CTCS group idx.*1"):
-        augment_dynamics_with_ctcs(x, states, [], [c0, c1], N, licq_max={0: 1e-8})
+    _, _, states_aug, _ = augment_dynamics_with_ctcs(x, states, [], [c0, c1], N, licq_max=0.05)
+
+    assert states_aug[2].max[0] == 1e-8, "Per-constraint licq_max should override"
+    assert states_aug[3].max[0] == 0.05, "Unspecified group should use problem-wide default"
+
+
+def test_licq_max_explicit_wins_within_group():
+    """A single explicit licq_max applies to the whole group, even if other
+    members leave it unspecified."""
+    x = State("x", (1,))
+    time = State("time", (1,))
+    time.final = np.array([10.0])
+    states = [time, x]
+    N = 5
+    time.guess = np.linspace(0, time.final[0], N).reshape(-1, 1)
+
+    # Same interval → same group; only one constraint specifies licq_max
+    c0 = ctcs(x <= 1.0, penalty="squared_relu", nodes=(0, 5), licq_max=1e-8)
+    c1 = ctcs(x <= 2.0, penalty="squared_relu", nodes=(0, 5))
+
+    _, _, states_aug, _ = augment_dynamics_with_ctcs(x, states, [], [c0, c1], N)
+
+    aug = states_aug[2]
+    assert aug.max[0] == 1e-8
+
+
+def test_licq_max_conflict_raises():
+    """Conflicting licq_max values within a group raise a helpful error."""
+    x = State("x", (1,))
+    time = State("time", (1,))
+    time.final = np.array([10.0])
+    states = [time, x]
+    N = 5
+    time.guess = np.linspace(0, time.final[0], N).reshape(-1, 1)
+
+    # Same interval → same group, but conflicting licq_max values
+    c0 = ctcs(x <= 1.0, penalty="squared_relu", nodes=(0, 5), licq_max=1e-8)
+    c1 = ctcs(x <= 2.0, penalty="squared_relu", nodes=(0, 5), licq_max=1e-4)
+
+    with pytest.raises(ValueError, match="conflicting licq_max"):
+        augment_dynamics_with_ctcs(x, states, [], [c0, c1], N)
+
+
+def test_licq_max_nonpositive_raises():
+    """Non-positive licq_max is rejected, per-constraint and problem-wide."""
+    x = State("x", (1,))
+
+    with pytest.raises(ValueError, match="licq_max must be a positive number"):
+        ctcs(x <= 1.0, licq_max=0.0)
+
+    with pytest.raises(ValueError, match="licq_max must be a positive number"):
+        (x <= 1.0).over((0, 5), licq_max=-1e-4)
+
+    time = State("time", (1,))
+    time.final = np.array([10.0])
+    time.guess = np.linspace(0, time.final[0], 5).reshape(-1, 1)
+    c0 = ctcs(x <= 1.0)
+
+    with pytest.raises(ValueError, match="licq_max must be a positive number"):
+        augment_dynamics_with_ctcs(x, [time, x], [], [c0], 5, licq_max=0.0)
 
 
 def test_time_dilation_control_bounds():


### PR DESCRIPTION
Closes #558, closes #559.

## What changed

**Per-constraint LICQ limits (#558).** `CTCS`, the `ctcs()` helper, and every `.over()` method that seals to CTCS (`Constraint`, the STL exprs in `stl.py`, and `stljax`) now accept a `licq_max` bounding the augmented state that accumulates the constraint's violation penalty.

The bound for each augmented state is resolved as:
1. An explicit `licq_max` on a member constraint — all explicit values within a group must agree, otherwise a `ValueError` suggests aligning the values or splitting the group via `idx`.
2. Otherwise the problem-wide `Problem(licq_max=...)` default.
3. Which itself defaults to `1e-4`.

The dict-keyed-by-idx form of the `Problem` kwarg is gone — per-constraint `licq_max` is now the one way to set per-group bounds. The value is preserved through `canonicalize()` / `over()`, included in expression hashing, validated positive, and shown in `repr()`. The byof path is untouched — its specs already carry their own per-group `bounds`.

**Remove `licq_min` (#559).** Augmented states are now always bounded below at 0, with the initial condition and trajectory guess pinned there too.

## Notes

- Examples keep their original `Problem(licq_max=...)` style — that kwarg still means what it meant, so the only example change is dropping `licq_min=0.0` from `relative_loitering.py`.
- Auto-added time-bound CTCS constraints carry no explicit value, so they inherit the group's explicit value when sharing an augmented state with user constraints, and the problem-wide default otherwise — matching prior behavior.

## Verification

- `tests/symbolic/` (1529 tests) and `tests/e2e/test_brachistochrone.py` (39 tests) pass, plus ruff.
- New unit tests: per-group values, problem-default + per-constraint override precedence, explicit-wins-within-group, conflicting-values error, non-positive rejection (per-constraint and problem-wide).
- Dubins car, waypoint-STL (problem-wide `1e-10`), and flappy bird examples run to convergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)