### PR TITLE
SEO improvements for the 1.0 release

### DIFF
--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -61,6 +61,7 @@ jobs:
       run: |
         uv pip install --system "mkdocs-material[imaging]" mkdocstrings-python
         uv pip install --system mkdocs-gen-files mkdocs-literate-nav mkdocs-section-index
+        uv pip install --system mkdocs-git-revision-date-localized-plugin
         uv pip install --system mike
 
     - name: Install package

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,42 @@
+cff-version: 1.2.0
+message: >-
+  If you use OpenSCvx in your research, please cite the software and the
+  preferred citation (Hayner et al., IEEE RA-L 2025) below.
+title: "OpenSCvx: Nonlinear Trajectory Optimization via Successive Convexification"
+abstract: >-
+  OpenSCvx is an open-source Python library for nonlinear trajectory optimization
+  built on successive convexification (SCvx). It compiles a composable symbolic
+  problem definition into JAX/CVXPY code and solves nonconvex trajectory problems
+  through sequential convex programming.
+type: software
+authors:
+  - family-names: Hayner
+    given-names: Christopher R.
+  - family-names: Norris
+    given-names: Griffin
+repository-code: "https://github.com/OpenSCvx/OpenSCvx"
+url: "https://openscvx.github.io/OpenSCvx/"
+license: Apache-2.0
+keywords:
+  - trajectory optimization
+  - successive convexification
+  - optimal control
+  - JAX
+  - Python
+preferred-citation:
+  type: article
+  title: >-
+    Continuous-Time Line-of-Sight Constrained Trajectory Planning for
+    6-Degree of Freedom Systems
+  authors:
+    - family-names: Hayner
+      given-names: Christopher R.
+    - family-names: Carson III
+      given-names: John M.
+    - family-names: Açıkmeşe
+      given-names: Behçet
+    - family-names: Leung
+      given-names: Karen
+  journal: IEEE Robotics and Automation Letters
+  year: 2025
+  doi: 10.1109/LRA.2025.3545299

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Check out the OpenSCvx documentation:
 
 - [Users Guide](https://openscvx.github.io/OpenSCvx/latest/UsersGuide/00_introduction/)
 - [API Reference](https://openscvx.github.io/OpenSCvx/latest/Reference/)
-- [Examples overview](https://openscvx.github.io/OpenSCvx/latest/examples/)
+- [Examples overview](https://openscvx.github.io/OpenSCvx/latest/Examples/)
 
 ### Running the Examples
 

--- a/docs/Foundations/constraint_reformulation.md
+++ b/docs/Foundations/constraint_reformulation.md
@@ -1,10 +1,77 @@
-# Isoperimetric Constraint Reformulation
+---
+title: Constraint Reformulation (CTCS)
+description: >-
+  How OpenSCvx enforces path constraints continuously in time by integrating an
+  augmented penalty state, rather than only at the discretization nodes.
+---
 
-!!! Warning
-    This page is still under development :construction:.
+# Isoperimetric Constraint Reformulation
 
 ![CTCS_dark]{ align=right width="60%" }
 ![CTCS_light]{ align=right width="60%" }
+
+Path constraints are meant to hold for *all* time, but a node-based
+transcription only checks them at the discretization nodes — leaving the solution
+free to violate them *between* nodes. OpenSCvx closes this gap with
+**continuous-time constraint satisfaction (CTCS)**: it reformulates a path
+constraint as an integral condition on an augmented state, so satisfying it at
+the nodes guarantees satisfaction throughout the interval.
+
+## The augmented penalty state
+
+Write each path constraint in canonical form $g(x, u) \le 0$. For a group of
+CTCS constraints, OpenSCvx adds one augmented state $y$ whose derivative
+accumulates a non-negative penalty of the constraint violations:
+
+$$
+\frac{\mathrm{d}y}{\mathrm{d}\tau}
+  = s(\tau)\, \sum_j \mathrm{penalty}\big(g_j(x, u)\big),
+$$
+
+where the default penalty is the squared ReLU $\max(0, g_j)^2$ (Huber and smooth
+ReLU are also available), and $s$ is the [time-dilation](time_dilation.md)
+factor. Because the integrand is non-negative, $y$ is monotonically
+non-decreasing and accumulates *any* violation occurring between nodes.
+
+Enforcing $y \equiv 0$ then drives every penalty — and hence every constraint —
+to zero continuously. In practice the convex subproblem (i) resets $y$ to $0$ at
+the start of each enforcement interval and (ii) bounds the per-segment increment,
+
+$$
+y_0 = 0, \qquad |y_k - y_{k-1}| \le y_{\max},
+$$
+
+so a small $y_{\max}$ makes the between-node violation provably small. This is
+the isoperimetric-style reformulation: a bounded integral of the violation stands
+in for an infinite family of pointwise constraints.
+
+## Declaring CTCS constraints
+
+Wrap any path constraint with `ox.ctcs`, or call `.over(...)` on a constraint to
+restrict it to a node interval:
+
+```python
+import openscvx as ox
+
+constraints = [
+    ox.ctcs(state <= state.max),
+    ox.ctcs(state.min <= state, penalty="huber"),
+    (distance >= obstacle_radius).over((0, N)),
+]
+```
+
+Constraints sharing an enforcement interval are grouped onto one augmented state;
+different intervals get separate states. The bound $y_{\max}$ is the constraint's
+`licq_max` (default $10^{-4}$); tighten it for stricter between-node enforcement.
+After solving, the achieved continuous-time violation is reported as
+`results.ctcs_violation`.
+
+## Related reading
+
+- [Optimal Control Problem](ocp.md) — where the CTCS reset-and-bound constraints
+  enter the convex subproblem.
+- [Time Dilation](time_dilation.md) — the $s$ factor that also scales the CTCS
+  dynamics.
 
 [CTCS_dark]: ../assets/images/ctcs_dark.png#only-dark
 [CTCS_light]: ../assets/images/ctcs_light.png#only-light

--- a/docs/Foundations/control_parameterization.md
+++ b/docs/Foundations/control_parameterization.md
@@ -1,4 +1,70 @@
+---
+title: Control Parameterization
+description: >-
+  Zero-order-hold (ZOH) versus first-order-hold (FOH) control parameterization
+  between nodes in OpenSCvx, and how to set it per problem or per control.
+---
+
 # Control Parameterization
 
-!!! Warning
-    This page is still under development :construction:.
+The optimization variables live at discrete **nodes**, but the dynamics are
+continuous, so OpenSCvx must decide how the control behaves *between* nodes. This
+choice is the **control parameterization**, and it determines how the control
+value on a segment is reconstructed from the node values during discretization.
+
+## Zero-order versus first-order hold
+
+Across a segment from node $k$ to node $k+1$, the control is interpolated as
+
+$$
+u(\tau) = u_k + \beta(\tau)\,\big(u_{k+1} - u_k\big),
+$$
+
+where $\beta$ ramps from $0$ to $1$ over the segment. The two standard choices
+differ only in $\beta$:
+
+- **Zero-order hold (ZOH):** $\beta = 0$, so $u(\tau) = u_k$ is held constant
+  across the segment. Only the current node couples into the segment dynamics, so
+  discretization produces a single control transition matrix $B_d$.
+- **First-order hold (FOH):** $\beta$ blends linearly from $0$ to $1$, so the
+  control is piecewise-linear and continuous across nodes. Both endpoints couple
+  in, producing two transition matrices, $B_d$ (current node) and $C_d$ (next
+  node).
+
+FOH gives a smoother, continuous control profile at the cost of an extra
+transition matrix per segment; ZOH is cheaper and matches hardware that applies a
+piecewise-constant command.
+
+## Choosing a parameterization
+
+The default parameterization is **FOH**. Set it globally through the
+discretizer:
+
+```python
+import openscvx as ox
+
+problem = ox.Problem(
+    dynamics, ...,
+    discretizer={"dis_type": "ZOH"},   # or "FOH" (default)
+)
+```
+
+`dis_type` also accepts a per-control sequence (e.g. `["FOH", "ZOH", "FOH"]`) to
+mix parameterizations across control channels.
+
+A per-control setting overrides the discretizer default, so you can request a
+specific hold on the control that needs it:
+
+```python
+thrust = ox.Control("thrust", shape=(3,), parameterization="ZOH")
+```
+
+The time-dilation control added for [free-final-time problems](time_dilation.md)
+is parameterized as ZOH.
+
+## Related reading
+
+- [Exact Discretization](discretization.md) — how the chosen hold enters the
+  discretized transition matrices.
+- [Time Dilation](time_dilation.md) — the dilation control and its
+  parameterization.

--- a/docs/Foundations/discretization.md
+++ b/docs/Foundations/discretization.md
@@ -1,7 +1,11 @@
-# Exact Discretization
+---
+title: Exact Discretization
+description: >-
+  How OpenSCvx discretizes and linearizes continuous-time dynamics by
+  integrating an augmented state vector to build the ZOH/FOH transition matrices.
+---
 
-!!! Warning
-    This page is still under development :construction:.
+# Exact Discretization
 
 ``` py title="dVdt.py"
 def dVdt(self,

--- a/docs/Foundations/ocp.md
+++ b/docs/Foundations/ocp.md
@@ -1,6 +1,11 @@
+---
+title: Optimal Control Problem
+description: >-
+  The convex subproblem OpenSCvx solves each SCP iteration: variables, affine
+  scaling, discretized dynamics, virtual control, and trust-region costs.
+---
+
 # Optimal Control Problem
-!!! Warning
-    This page is still under development :construction:.
 
 The underlying convex subproblem is posed in the following general form. 
 

--- a/docs/Foundations/scvx.md
+++ b/docs/Foundations/scvx.md
@@ -1,6 +1,12 @@
-# What is Succesive Convexification?
-!!! Warning
-    This page is still under development :construction:.
+---
+title: What is Successive Convexification?
+description: >-
+  Successive convexification (SCvx) solves nonconvex trajectory optimization by
+  repeatedly linearizing the problem and solving the convex subproblem until
+  convergence.
+---
+
+# What is Successive Convexification?
 
 *Successive Convexification* is an approach to solve infinite dimensional nonconvex trajectory optimization problems. It works by *successively* convexifying or linearizing a problem and solving the convex subproblem. The solution to the convex subproblem is then used to update the original problem, and the process is repeated until convergence.
 
@@ -9,7 +15,7 @@
 
 
 ## Problem Formulation
-In this repository, the user will likely find it most useful specify there problem in the Mayer Form order to take full advantage of the features of this repo, but not worry this is quite easy.
+In this repository, the user will likely find it most useful to specify their problem in the Mayer Form in order to take full advantage of the features of this repo, but do not worry, this is quite easy.
 
 $$
 \begin{align}

--- a/docs/Foundations/time_dilation.md
+++ b/docs/Foundations/time_dilation.md
@@ -1,4 +1,82 @@
+---
+title: Time Dilation
+description: >-
+  How OpenSCvx handles free-final-time and minimum-time problems by optimizing a
+  time-dilation control on a fixed normalized-time grid.
+---
+
 # Time Dilation
 
-!!! Warning
-    This page is still under development :construction:.
+*Time dilation* is how OpenSCvx supports **free-final-time** problems — including
+minimum-time problems — on a fixed transcription grid. Rather than optimize over
+physical time directly, OpenSCvx discretizes the trajectory on a **normalized
+time** $\tau \in [0, 1]$ with fixed node spacing, and lets the solver stretch or
+compress physical time through an extra control.
+
+## Normalized time and the dilation factor
+
+Let $\tau$ be normalized time and $t$ physical time. Their relationship is
+governed by a scalar **time-dilation factor** $s(\tau)$:
+
+$$
+\frac{\mathrm{d}t}{\mathrm{d}\tau} = s(\tau).
+$$
+
+Because every physical derivative is taken with respect to $t$, expressing the
+dynamics on the $\tau$ grid scales them by $s$:
+
+$$
+\frac{\mathrm{d}x}{\mathrm{d}\tau}
+  = \frac{\mathrm{d}x}{\mathrm{d}t}\,\frac{\mathrm{d}t}{\mathrm{d}\tau}
+  = s(\tau)\, f\big(x(\tau), u(\tau)\big).
+$$
+
+OpenSCvx treats time as a state (with $\mathrm{d}t/\mathrm{d}\tau = s \cdot 1$)
+and $s$ as an ordinary per-node control. Making $s(\tau)$ a decision variable is
+what turns a fixed-grid transcription into a free-final-time problem: a larger
+$s$ spends more physical time per grid interval, so the solver can slow down near
+constraint boundaries and speed up elsewhere. The dilation multiplication is
+applied symbolically when the problem is built, so JAX autodiff produces the
+correct Jacobians — including $\partial f/\partial s = f$ — automatically.
+
+## Declaring a free final time
+
+Free and minimum-time problems are declared through the `ox.Time` object passed
+to `ox.Problem`. The `final` field accepts the same boundary markers as any
+state — `"free"`, `"minimize"`, or `"maximize"` — so a minimum-time problem is
+simply a free final time that is minimized:
+
+```python
+import openscvx as ox
+
+# Minimum-time: final time is free and minimized.
+time = ox.Time(initial=0.0, final=("minimize", tf_guess), min=0.0, max=800.0)
+
+problem = ox.Problem(dynamics, ..., time=time)
+```
+
+OpenSCvx augments the problem with a dedicated dilation control automatically. By
+default its per-node bounds are $0.3\,t_f \le s \le 3\,t_f$; you can override
+them, seed a dilation guess, or force a uniform physical time step:
+
+```python
+time = ox.Time(
+    initial=0.0,
+    final=time_final,
+    guess=time_guess,
+    time_dilation_min=time_dilation_min,
+    time_dilation_max=time_dilation_max,
+    uniform_time_grid=False,  # allow s to vary node to node
+)
+```
+
+Setting `uniform_time_grid=True` adds equality constraints forcing $s$ equal
+across all nodes, recovering a single free scalar duration with evenly spaced
+physical time steps.
+
+## Related reading
+
+- [Exact Discretization](discretization.md) — how the dilated dynamics are
+  integrated on the $\tau$ grid.
+- [Control Parameterization](control_parameterization.md) — how controls,
+  including the dilation control, are interpolated between nodes.

--- a/docs/UnderTheHood/batching_jit_grad.md
+++ b/docs/UnderTheHood/batching_jit_grad.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  How OpenSCvx's `solve_jax()` entry point runs the SCP loop as a pure JAX
+  `lax.while_loop` so solves compose with `jax.vmap`, `jax.jit`, and `jax.grad`.
+---
+
 # Batching, JIT, and Grad with `Problem.solve_jax()`
 
 `Problem` exposes two solve entry points. `solve()` is the familiar

--- a/docs/UnderTheHood/custom_algorithms_autotuners.md
+++ b/docs/UnderTheHood/custom_algorithms_autotuners.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  How to swap OpenSCvx's SCP iteration and penalty-weight schedule by subclassing
+  the `Algorithm` and `AutotuningBase` bases without forking the solver.
+---
+
 # Custom Algorithms and Autotuners
 
 OpenSCvx solves through a pluggable SCP loop: an **algorithm** owns the

--- a/docs/UnderTheHood/lowering_architecture.md
+++ b/docs/UnderTheHood/lowering_architecture.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  How OpenSCvx lowers symbolic problem definitions into executable JAX and CVXPy
+  code — the second of its preprocessing, lowering, solving, and post-processing phases.
+---
+
 # Lowering Architecture
 
 This document explains how OpenSCvx converts symbolic problem definitions into executable code for optimization.

--- a/docs/UnderTheHood/vectorization_and_vmapping.md
+++ b/docs/UnderTheHood/vectorization_and_vmapping.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  How OpenSCvx unifies per-node State and Control objects into monolithic vectors and
+  applies `jax.vmap` to evaluate dynamics and nonconvex constraints across decision nodes in parallel.
+---
+
 # Vectorization and Vmapping Across Decision Nodes
 
 This page explains how OpenSCvx internally processes symbolic problem definitions into vectorized JAX computations. After symbolic preprocessing and augmentation (which you've likely seen in basic usage), the library creates unified state/control vectors and applies JAX's `vmap` to evaluate dynamics and non-convex constraints across decision nodes in parallel.

--- a/docs/UsersGuide/00_introduction.md
+++ b/docs/UsersGuide/00_introduction.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  A progressive introduction to trajectory optimization with OpenSCvx, building from a first model to representative real-world problems.
+---
+
 # Users Guide
 
 Welcome to the OpenSCvx Users Guide. This section aims to provides a progressive and useful introduction to trajectory optimization with OpenSCvx, starting from first principles and building toward complex, representative problems.

--- a/docs/UsersGuide/01_hello_world_brachistochrone.md
+++ b/docs/UsersGuide/01_hello_world_brachistochrone.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  A hello-world OpenSCvx tutorial that solves the brachistochrone minimum-time problem: states, controls, dynamics, time, and CTCS constraints.
+---
+
 # 01 Hello Brachistochrone
 
 In this _hello world_ tutorial we will introduce the reader to the fundamental concepts and API needed to define and solve a problem using OpenSCvx as well as how the results can be accessed.

--- a/docs/UsersGuide/02_drone_racing_constraints.md
+++ b/docs/UsersGuide/02_drone_racing_constraints.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Model a 3-DOF drone racing through gates in OpenSCvx using nodal constraints, .at()/.over()/.convex(), and keyframe initialization.
+---
+
 # 02 Drone Racing: Constraints and 3-DOF Dynamics
 
 In this tutorial we build on the concepts from [Hello Brachistochrone](01_hello_world_brachistochrone.md) to tackle a more interesting problem: time-optimal drone racing through gates.

--- a/docs/UsersGuide/03_obstacle_avoidance_vmap.md
+++ b/docs/UsersGuide/03_obstacle_avoidance_vmap.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Solve 6-DOF obstacle avoidance in OpenSCvx using parameters and ox.Vmap to batch many obstacles without hand-written Python loops.
+---
+
 # 03 Obstacle Avoidance: 6-DOF Dynamics, Parameters, and Vmap
 
 In this tutorial we tackle a more realistic drone control problem: navigating through obstacles with full 6-DOF rigid body dynamics.

--- a/docs/UsersGuide/04_viewpoint_constraints.md
+++ b/docs/UsersGuide/04_viewpoint_constraints.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Add continuous line-of-sight viewpoint constraints to a 6-DOF OpenSCvx trajectory optimization problem.
+---
+
 # 04 Looking Back: Viewpoint Constraints
 
 In this tutorial we will combine what we have learned in the past several exercises while introducing a new viewplanning constraint formulation.

--- a/docs/UsersGuide/05_visualization.md
+++ b/docs/UsersGuide/05_visualization.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Plot and inspect OpenSCvx results with Matplotlib and interactive Viser visualization.
+---
+
 # 05 Visualizing Results
 
 Once you've solved a trajectory optimization problem, you'll want to see the results. OpenSCvx provides two complementary visualization systems:

--- a/docs/UsersGuide/06_logic.md
+++ b/docs/UsersGuide/06_logic.md
@@ -1,4 +1,5 @@
 ---
+noindex: true
 search:
   exclude: true
 ---

--- a/docs/UsersGuide/06_logic.md
+++ b/docs/UsersGuide/06_logic.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 # 06 Dubin's Car: Conditional Statements and Signal Temporal Logic
 
 !!! Warning "Work In Progress"

--- a/docs/UsersGuide/07_lie.md
+++ b/docs/UsersGuide/07_lie.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Optimize a 7-DOF redundant arm pick-and-place in OpenSCvx using Lie-group forward kinematics on SE(3) and algebraic propagated states.
+---
+
 # 07 Multi-Link Arms: Lie Algebra and Propagated States
 
 In this tutorial we leave the world of free-flying rigid bodies and step into manipulation.

--- a/docs/UsersGuide/08_mpcc.md
+++ b/docs/UsersGuide/08_mpcc.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Build receding-horizon model predictive contouring control (MPCC) in OpenSCvx to track a reference path through gates at speed.
+---
+
 # 08 Receding Horizon Drone Racing: Model Predictive Contouring Control
 
 In this tutorial we step away from single-shot trajectory optimization and into the world of receding-horizon control.

--- a/docs/UsersGuide/09_mjx_dynamics.md
+++ b/docs/UsersGuide/09_mjx_dynamics.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Drive OpenSCvx trajectory optimization with MuJoCo MJX dynamics for contact-rich robotic systems.
+---
+
 # 09 MuJoCo MJX Dynamics
 
 In earlier tutorials we wrote dynamics by hand as symbolic expressions. Many real systems already have a MuJoCo model — articulated robots, cartpoles, quadrotors — and re-deriving those equations is tedious and error-prone.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,20 @@
+---
+title: Changelog
+description: >-
+  Release history for OpenSCvx. Each tagged release publishes versioned documentation and a
+  detailed set of notes on GitHub.
+---
+
+# Changelog
+
+OpenSCvx follows [semantic versioning](https://semver.org/). Every tagged release ships its own
+snapshot of these docs (selectable from the version picker in the header) and a full set of
+release notes on GitHub.
+
+- :material-tag-outline: __[Release notes on GitHub](https://github.com/OpenSCvx/OpenSCvx/releases)__
+  — the authoritative, per-version changelog with highlights, fixes, and upgrade notes.
+- :material-package-variant: __[Releases on PyPI](https://pypi.org/project/openscvx/#history)__
+  — published wheels and source distributions.
+
+The documentation you are reading tracks the `latest` release. Use the version selector to browse
+the docs for an earlier tag, or switch to `nightly` for the in-development build from `main`.

--- a/docs/citation.md
+++ b/docs/citation.md
@@ -1,8 +1,22 @@
+---
+title: Citation
+description: >-
+  How to cite OpenSCvx and the successive-convexification methods it implements,
+  including Hayner et al., IEEE RA-L 2025, in BibTeX.
+---
+
 # Citation
 
-If you use OpenSCvx in your research, please cite the following works:
+If you use OpenSCvx in your research, please cite Hayner et al., *Continuous-Time
+Line-of-Sight Constrained Trajectory Planning for 6-Degree of Freedom Systems*,
+IEEE Robotics and Automation Letters (RA-L), 2025
+([DOI: 10.1109/LRA.2025.3545299](https://doi.org/10.1109/LRA.2025.3545299)),
+along with the methodological and solver references below.
 
 ## Primary Citation
+
+Hayner et al., IEEE RA-L 2025 — DOI:
+[10.1109/LRA.2025.3545299](https://doi.org/10.1109/LRA.2025.3545299).
 
 ```bibtex
 @ARTICLE{hayner2025los,
@@ -19,6 +33,10 @@ If you use OpenSCvx in your research, please cite the following works:
 
 ## Methodological Foundation
 
+Elango et al., *Successive Convexification for Trajectory Optimization with
+Continuous-Time Constraint Satisfaction*, 2024 — preprint:
+[arXiv:2404.16826](https://arxiv.org/abs/2404.16826).
+
 ```bibtex
 @misc{elango2024ctscvx,
       title={Successive Convexification for Trajectory Optimization with Continuous-Time Constraint Satisfaction}, 
@@ -33,6 +51,10 @@ If you use OpenSCvx in your research, please cite the following works:
 
 ## Solver Technology
 
+Chari and Açıkmeşe, *QOCO: A Quadratic Objective Conic Optimizer with Custom
+Solver Generation*, 2025 — preprint:
+[arXiv:2503.12658](https://arxiv.org/abs/2503.12658).
+
 ```bibtex
 @misc{chari2025qoco,
   title = {QOCO: A Quadratic Objective Conic Optimizer with Custom Solver Generation},
@@ -43,6 +65,14 @@ If you use OpenSCvx in your research, please cite the following works:
   primaryclass = {math.OC},
 }
 ```
+
+## Citing the software
+
+To cite the OpenSCvx software itself, use the
+[`CITATION.cff`](https://github.com/OpenSCvx/OpenSCvx/blob/main/CITATION.cff) file
+at the repository root — GitHub's "Cite this repository" widget reads it directly.
+It points to the RA-L paper above as the preferred citation. A dedicated software
+DOI (Zenodo) is planned for the 1.0 release.
 
 ## Acknowledgments
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Runnable OpenSCvx trajectory optimization examples spanning aerospace, robotics, and abstract optimal-control problems.
+---
+
 # Examples
 
 OpenSCvx comes with a comprehensive set of examples demonstrating various trajectory optimization problems. These examples are located in the `examples/` folder and cover different applications and complexity levels.

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,9 +42,8 @@ for every outer loop (see [Obstacle avoidance with Vmap](UsersGuide/03_obstacle_
 
 <div class="grid cards" markdown>
 
-- :material-rocket-launch: __[Run examples](examples.md)__ — locate scripts in the repo, run them locally, and browse problem categories.
 - :material-book-open-variant: __[Users guide](UsersGuide/00_introduction.md)__ — modeling, constraints, and visualization.
 - :material-code-braces: __[API reference](Reference/index.md)__ — modules and functions generated from source with docstrings.
-- :material-view-dashboard: __[Examples](Examples/index.md)__ — runnable scripts organized by topic.
+- :material-view-dashboard: __[Examples](Examples/index.md)__ — runnable scripts organized by topic, run them locally and browse problem categories.
 
 </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,11 +5,23 @@ hide:
   - navigation
   - toc
 description: >-
-  An Open-Source Modular and Extensible Nonlinear Trajectory Optimization Package
+  OpenSCvx is an open-source Python library for nonlinear trajectory
+  optimization built on successive convexification (SCvx), with a composable
+  problem API and a JAX backend.
 social:
   cards_layout_options:
     title: Fast and Easy Nonconvex Trajectory Optimization
 ---
+
+# OpenSCvx — Trajectory Optimization via Successive Convexification in Python/JAX
+
+OpenSCvx is an open-source Python library for nonlinear trajectory optimization
+built on successive convexification (SCvx). You write dynamics, costs, and
+constraints as a single composable problem object; the library lowers that
+symbolic definition to JAX, discretizes it on a time grid, and solves the
+resulting nonconvex problem through a sequence of convex subproblems. The same
+problem definition runs on CPU and GPU, and vectorizes across decision nodes and
+scenario batches.
 
 ## Why OpenSCvx
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,67 @@
+---
+title: Installation
+description: >-
+  How to install OpenSCvx from PyPI with uv or pip, or from source, including
+  the optional extras and supported Python versions.
+---
+
+# Installation
+
+OpenSCvx is published on PyPI as [`openscvx`](https://pypi.org/project/openscvx/)
+and requires **Python 3.11 or newer**. Its core depends on JAX and CVXPY; the
+optional extras below pull in additional solvers, dynamics backends, and modeling
+features only when you need them.
+
+## How to install OpenSCvx
+
+=== "uv"
+
+    ```sh
+    uv pip install openscvx
+
+    # Optional: cvxpygen, stljax, jaxlie, mujoco-mjx extras
+    uv pip install "openscvx[cvxpygen,stl,lie,mjx]"
+    ```
+
+=== "pip"
+
+    ```sh
+    pip install openscvx
+
+    # Optional: cvxpygen, stljax, jaxlie, mujoco-mjx extras
+    pip install "openscvx[cvxpygen,stl,lie,mjx]"
+    ```
+
+=== "From source (editable)"
+
+    ```sh
+    git clone https://github.com/OpenSCvx/OpenSCvx.git
+    cd OpenSCvx
+    uv pip install -e .
+
+    # Optional: cvxpygen, stljax, jaxlie, mujoco-mjx extras
+    uv pip install -e ".[cvxpygen,stl,lie,mjx]"
+    ```
+
+Install from source if you want to run the [examples](examples.md), modify the
+library, or track the development branch.
+
+## Optional extras
+
+Extras are installed with the `openscvx[extra1,extra2]` syntax shown above.
+
+| Extra | Enables |
+|-------|---------|
+| `cvxpygen` | Generated C solvers via `cvxpygen` + `qocogen`. |
+| `qpax` | The `qpax` differentiable QP backend. |
+| `moreau` | The licensed `moreau` conic solver. |
+| `stl` | Signal Temporal Logic constraints via `stljax`. |
+| `lie` | Lie-group operators via `jaxlie`. |
+| `mjx` | MuJoCo MJX dynamics (`mujoco`, `mujoco-mjx`). |
+| `frax` | Fractal / `frax` dynamics support. |
+
+## Next steps
+
+- Follow the [Users Guide](UsersGuide/00_introduction.md) from a first model to a solve.
+- Browse runnable [examples](examples.md) organized by topic.
+- Read the [API reference](Reference/index.md) generated from source.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,28 @@
+# OpenSCvx
+
+> OpenSCvx is an open-source Python library for nonlinear trajectory optimization built on successive convexification (SCvx). You write dynamics, costs, and constraints as a single composable problem object; the library lowers that symbolic definition to JAX, discretizes it on a time grid, and solves the resulting nonconvex problem through a sequence of convex subproblems. The same problem definition runs on CPU and GPU and vectorizes across decision nodes and scenario batches.
+
+- Package: `openscvx` on PyPI (Python 3.11+). Install with `pip install openscvx` or `uv pip install openscvx`; optional extras: `cvxpygen`, `qpax`, `moreau`, `stl`, `lie`, `mjx`, `frax`.
+- Documentation: https://openscvx.github.io/OpenSCvx/
+- Source: https://github.com/OpenSCvx/OpenSCvx
+- PyPI: https://pypi.org/project/openscvx/
+
+## Getting started
+
+- [Installation](https://openscvx.github.io/OpenSCvx/installation/): install from PyPI with uv or pip, or from source, with optional extras.
+- [Users Guide](https://openscvx.github.io/OpenSCvx/UsersGuide/00_introduction/): a progressive tutorial series from a first model to representative problems.
+- [Examples](https://openscvx.github.io/OpenSCvx/examples/): runnable trajectory optimization scripts across aerospace, robotics, and abstract control.
+
+## Key concepts
+
+- [What is Successive Convexification?](https://openscvx.github.io/OpenSCvx/Foundations/scvx/): the SCvx algorithm and the Mayer-form problem statement.
+- [Optimal Control Problem](https://openscvx.github.io/OpenSCvx/Foundations/ocp/): the convex subproblem solved each SCP iteration.
+- [Exact Discretization](https://openscvx.github.io/OpenSCvx/Foundations/discretization/): linearizing and discretizing continuous-time dynamics.
+- [Constraint Reformulation (CTCS)](https://openscvx.github.io/OpenSCvx/Foundations/constraint_reformulation/): enforcing path constraints continuously in time.
+- [Control Parameterization](https://openscvx.github.io/OpenSCvx/Foundations/control_parameterization/): zero-order vs first-order hold between nodes.
+- [Time Dilation](https://openscvx.github.io/OpenSCvx/Foundations/time_dilation/): free-final-time and minimum-time problems.
+
+## Reference and citation
+
+- [API Reference](https://openscvx.github.io/OpenSCvx/Reference/): modules and functions generated from source docstrings.
+- [Citation](https://openscvx.github.io/OpenSCvx/citation/): cite Hayner et al., IEEE RA-L 2025 (DOI: 10.1109/LRA.2025.3545299); see CITATION.cff at the repository root.

--- a/examples/abstract/hypersensitive.py
+++ b/examples/abstract/hypersensitive.py
@@ -1,3 +1,5 @@
+"""Hypersensitive optimal control benchmark: minimize ½∫(x²+u²) over a long horizon."""
+
 import os
 import sys
 

--- a/examples/drone/logo_utils/svg_path_utils.py
+++ b/examples/drone/logo_utils/svg_path_utils.py
@@ -1,3 +1,5 @@
+"""SVG path extraction utilities for the logo-tracing drone examples."""
+
 import jax.numpy as jnp
 import numpy as np
 from svgpathtools import svg2paths2

--- a/material/overrides/assets/stylesheets/home-hero.css
+++ b/material/overrides/assets/stylesheets/home-hero.css
@@ -149,7 +149,7 @@
  * Hero title: Material's .md-typeset h1 beats a lone class — use h1 + id + .md-typeset
  * so OpenSCvx actually renders at display size.
  */
-.osc-home-hero__inner.md-typeset h1#osc-home-hero-title.osc-home-hero__title {
+.osc-home-hero__inner.md-typeset p#osc-home-hero-title.osc-home-hero__title {
   margin: 0 0 1rem;
   font-family: "League Spartan", var(--md-text-font-family), system-ui, sans-serif;
   font-weight: 600 !important;
@@ -161,7 +161,7 @@
 }
 
 /* Slate: hero copy in white (light mode keeps warm custom palette above). */
-[data-md-color-scheme="slate"] .osc-home-hero__inner.md-typeset h1#osc-home-hero-title.osc-home-hero__title {
+[data-md-color-scheme="slate"] .osc-home-hero__inner.md-typeset p#osc-home-hero-title.osc-home-hero__title {
   color: var(--osc-palette-4) !important;
 }
 
@@ -443,7 +443,7 @@
 
 /* Light hero title = same fill as .md-button--primary (“Getting started”) */
 [data-md-color-scheme="default"][data-md-color-primary="custom"][data-md-color-accent="custom"]
-  .osc-home-hero__inner.md-typeset h1#osc-home-hero-title.osc-home-hero__title {
+  .osc-home-hero__inner.md-typeset p#osc-home-hero-title.osc-home-hero__title {
   color: var(--md-primary-bg-color) !important;
 }
 

--- a/material/overrides/main.html
+++ b/material/overrides/main.html
@@ -21,9 +21,11 @@
 -#}
 {% block extrahead %}
   {{ super() }}
-  {%- if config.extra.mike_version == "nightly" %}
-  <!-- Nightly is a moving development build; keep it out of the index so it does not
-       compete with the released docs served from latest/. -->
+  {%- if config.extra.mike_version == "nightly" or (page and page.meta and page.meta.noindex) %}
+  <!-- Nightly is a moving development build, and pages front-mattered `noindex: true`
+       (e.g. work-in-progress tutorials) are unfinished; keep both out of the index so
+       they do not compete with the released docs served from latest/. Noindexed pages
+       are also dropped from sitemap.xml (see the sitemap.xml override). -->
   <meta name="robots" content="noindex">
   {%- endif %}
   {#- Twitter/X card metas are emitted by Material's social plugin (twitter:card/title/

--- a/material/overrides/main.html
+++ b/material/overrides/main.html
@@ -1,5 +1,7 @@
 {#-
-  This file was automatically generated - do not edit
+  Site-wide theme override: extends Material's base to add web fonts, custom styles, and the
+  SEO head block below (noindex for nightly, homepage JSON-LD). Homepage-specific blocks live
+  in home.html, which extends this file.
 -#}
 {% extends "base.html" %}
 {% block styles %}
@@ -8,4 +10,47 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=League+Spartan:wght@500;600;700&display=swap">
   <link rel="stylesheet" href="{{ 'assets/stylesheets/custom.css' | url }}">
+{% endblock %}
+
+{#-
+  SEO head extensions shared across every page. `config.extra.mike_version` carries the
+  deployed mike version (populated from $MIKE_DOCS_VERSION via mkdocs.yml); it is empty on
+  a plain `mkdocs build`. The canonical URL itself is unified onto `latest/` by mike's
+  `canonical_version` option (see the mike plugin config in mkdocs.yml), so no rewrite is
+  needed here.
+-#}
+{% block extrahead %}
+  {{ super() }}
+  {%- if config.extra.mike_version == "nightly" %}
+  <!-- Nightly is a moving development build; keep it out of the index so it does not
+       compete with the released docs served from latest/. -->
+  <meta name="robots" content="noindex">
+  {%- endif %}
+  {#- Twitter/X card metas are emitted by Material's social plugin (twitter:card/title/
+      description/image); no override needed here. -#}
+  {%- if page.is_homepage %}
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "SoftwareSourceCode",
+      "name": "OpenSCvx",
+      "description": {{ (page.meta.description or config.site_description) | tojson }},
+      "url": "https://openscvx.github.io/OpenSCvx/latest/",
+      "codeRepository": "https://github.com/OpenSCvx/OpenSCvx",
+      "programmingLanguage": "Python",
+      "license": "https://www.apache.org/licenses/LICENSE-2.0",
+      "author": {
+        "@type": "Person",
+        "name": "Chris Hayner"
+      }{% if config.extra.mike_version and config.extra.mike_version != "nightly" %},
+      "softwareVersion": {{ config.extra.mike_version | tojson }}{% endif %},
+      "sameAs": [
+        "https://github.com/OpenSCvx/OpenSCvx",
+        "https://pypi.org/project/openscvx/",
+        "https://arxiv.org/abs/2404.16826",
+        "https://doi.org/10.1109/LRA.2025.3545299"
+      ]
+    }
+  </script>
+  {%- endif %}
 {% endblock %}

--- a/material/overrides/partials/home-hero.html
+++ b/material/overrides/partials/home-hero.html
@@ -8,7 +8,9 @@
 <section class="osc-home-hero" data-osc-hero-bg="mesh" aria-labelledby="osc-home-hero-title">
   <div class="osc-home-hero__inner md-typeset">
     <p class="osc-home-hero__kicker">Nonconvex trajectory optimization</p>
-    <h1 id="osc-home-hero-title" class="osc-home-hero__title">{{ config.site_name }}</h1>
+    {#- Brand text only, not a heading: the page's single H1 is the keyword-carrying
+        title in the article body (docs/index.md). -#}
+    <p id="osc-home-hero-title" class="osc-home-hero__title">{{ config.site_name }}</p>
     <p class="osc-home-hero__tagline">
       {% if page.meta and page.meta.description %}
         {{ page.meta.description }}

--- a/material/overrides/sitemap.xml
+++ b/material/overrides/sitemap.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+{#-
+  Override of MkDocs' stock sitemap template with one change: pages front-mattered
+  `noindex: true` are omitted, matching the robots meta emitted for them in main.html
+  (a noindexed URL in the sitemap sends crawlers contradictory signals).
+-#}
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+{%- for file in pages -%}
+    {% if not file.page.is_link and (file.page.abs_url or file.page.canonical_url) and not (file.page.meta and file.page.meta.noindex) %}
+    <url>
+         <loc>{% if file.page.canonical_url %}{{ file.page.canonical_url|e }}{% else %}{{ file.page.abs_url|e }}{% endif %}</loc>
+         {% if file.page.update_date %}<lastmod>{{file.page.update_date}}</lastmod>{% endif %}
+    </url>
+    {%- endif -%}
+{% endfor %}
+</urlset>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -172,6 +172,7 @@ extra_javascript:
 # Page tree
 nav:
     - Home: index.md
+    - Installation: installation.md
     - Resources:
       - 'examples.md'
       - 'citation.md'
@@ -182,7 +183,6 @@ nav:
       - 'UsersGuide/03_obstacle_avoidance_vmap.md'
       - 'UsersGuide/04_viewpoint_constraints.md'
       - 'UsersGuide/05_visualization.md'
-      - 'UsersGuide/06_logic.md'
       - 'UsersGuide/07_lie.md'
       - 'UsersGuide/08_mpcc.md'
       - 'UsersGuide/09_mjx_dynamics.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,14 +73,21 @@ theme:
   icon:
     logo: logo
 
-# Copy Viser's bundled ``client/build`` into ``docs/assets/viser-client`` so home-page embeds resolve.
+# Copy Viser's bundled ``client/build`` into ``docs/assets/viser-client`` so home-page embeds
+# resolve; drop the literate-nav SUMMARY.md files from the built site and sitemap.
 hooks:
   - scripts/mkdocs_copy_viser_client_hook.py
+  - scripts/mkdocs_seo_hook.py
 
 # Plugin choices preserve API docs from docstrings (mkdocstrings + gen-files). Before moving to
 # Zensical, confirm parity for mkdocstrings, mkdocs-gen-files, literate-nav, section-index, and mike.
 # Plugins
 plugins:
+  # Declared (not just injected at deploy) so `canonical_version` unifies every deployed
+  # version's canonical URL onto `latest/`. Without a deploy, $MIKE_DOCS_VERSION is unset and
+  # this plugin is a no-op. Keep it first to match mike's own injection position.
+  - mike:
+      canonical_version: latest
   - meta
   # Social cards render via Pillow + fonts from Google Fonts only (not self-hosted CMU).
   - social:
@@ -107,11 +114,25 @@ plugins:
               show_docstring: true
             docstring_style: google
             filters: ["!^_[^_]", "!^__(?!init)"]
+  # Real per-page last-modified dates from git, surfaced in the footer and sitemap <lastmod>.
+  - git-revision-date-localized:
+      enable_creation_date: true
+      fallback_to_build_date: true
+
+# Drop the stale hand-written examples.md (superseded by the generated Examples/ index, and a
+# case-colliding duplicate of its URL) from the built site and sitemap. The generated
+# SUMMARY.md files are removed by scripts/mkdocs_seo_hook.py (exclude_docs only filters the
+# docs_dir scan, not gen-files output).
+exclude_docs: |
+  examples.md
 
 
 # Additional configuration
 extra:
   favicon: assets/favicon.png
+  # Deployed mike version name (e.g. "nightly", "v0.5.2"); empty on a plain build. Read by
+  # material/overrides/main.html to noindex nightly and stamp softwareVersion in the homepage JSON-LD.
+  mike_version: !ENV [MIKE_DOCS_VERSION, ""]
   version:
     provider: mike
     default: latest
@@ -174,8 +195,8 @@ nav:
     - Home: index.md
     - Installation: installation.md
     - Resources:
-      - 'examples.md'
       - 'citation.md'
+      - 'changelog.md'
     - Users Guide:
       - 'UsersGuide/00_introduction.md'
       - 'UsersGuide/01_hello_world_brachistochrone.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -118,6 +118,9 @@ plugins:
   - git-revision-date-localized:
       enable_creation_date: true
       fallback_to_build_date: true
+      # --follow across gen-files renames produces out-of-order timestamps on a few
+      # Reference pages; plain path history is correct for this repo.
+      enable_git_follow: false
 
 # Drop the stale hand-written examples.md (superseded by the generated Examples/ index, and a
 # case-colliding duplicate of its URL) from the built site and sitemap. The generated

--- a/openscvx/integrators/diffrax.py
+++ b/openscvx/integrators/diffrax.py
@@ -1,3 +1,23 @@
+"""Adaptive-step ODE integration through the Diffrax backend.
+
+Wraps :mod:`diffrax` to integrate continuous-time dynamics for the two roles the
+pipeline needs, both over the normalized pseudo-time ``tau`` rather than physical
+time:
+
+- :func:`solve_ivp_diffrax` saves the solution on a fixed grid of substeps and is
+  the workhorse behind discretization, where the augmented dynamics are
+  propagated between trajectory nodes.
+- :func:`solve_ivp_diffrax_prop` retains the dense interpolant and evaluates it at
+  arbitrary ``save_time`` points (with masking); post-optimization propagation
+  uses it to reconstruct a high-resolution trajectory from the optimized nodes.
+
+The solver, tolerances, and step count are configurable; ``SOLVER_MAP`` names the
+available explicit and implicit Diffrax schemes (Dopri5/8, Tsit5, KenCarp3/4/5,
+...). At import time the module registers Diffrax's ``DenseInterpolation`` as a
+JAX pytree node so dense solution objects survive ``jit``/``vmap`` and can be
+returned from transformed functions.
+"""
+
 import os
 from typing import Any, Callable
 

--- a/openscvx/integrators/runge_kutta.py
+++ b/openscvx/integrators/runge_kutta.py
@@ -1,3 +1,16 @@
+"""Fixed-step Runge-Kutta integration in pure JAX.
+
+Provides a self-contained RK45 (Runge-Kutta-Fehlberg) integrator that needs no
+external ODE library: :func:`rk45_step` takes a single Dormand-Prince step and
+:func:`solve_ivp_rk45` rolls it forward over a fixed grid via ``jax.lax.fori_loop``
+(or a Python loop when tracing is disabled). Integration runs over the normalized
+pseudo-time ``tau``.
+
+This is the lightweight, always-differentiable alternative to the Diffrax backend
+(:mod:`openscvx.integrators.diffrax`): fixed-step and dependency-free, at the cost
+of the adaptive step-size control and implicit solvers Diffrax offers.
+"""
+
 from typing import Any, Callable
 
 import jax

--- a/openscvx/symbolic/lowerers/cvxpy/arithmetic.py
+++ b/openscvx/symbolic/lowerers/cvxpy/arithmetic.py
@@ -1,6 +1,12 @@
 """CVXPy visitors for arithmetic expressions.
 
 Visitors: Add, Sub, Mul, Div, MatMul, Neg, Power
+
+Lowers the arithmetic AST nodes to CVXPy expressions that build the convex
+subproblem. ``Add``, ``Sub``, and ``Neg`` are affine and always DCP; ``Mul``,
+``Div``, ``MatMul``, and ``Power`` are admitted structurally but are only
+disciplined-convex under the usual conditions (one operand constant, a valid
+exponent), which CVXPy verifies when the problem is assembled rather than here.
 """
 
 import cvxpy as cp

--- a/openscvx/symbolic/lowerers/cvxpy/array.py
+++ b/openscvx/symbolic/lowerers/cvxpy/array.py
@@ -1,6 +1,13 @@
 """CVXPy visitors for array expressions.
 
 Visitors: Index, Concat, Stack, Hstack, Vstack, Block
+
+Lowers the array construction and indexing AST nodes to CVXPy expressions via
+``cp.hstack``/``cp.vstack``/``cp.bmat``, all of which preserve DCP curvature.
+``Concat`` promotes scalars to 1-D before joining, and ``Hstack``/``Block`` route
+2-D+ inputs through ``cp.bmat`` to match NumPy stacking semantics. CVXPy's
+``bmat`` is 2-D only, so ``Block`` raises for 3-D+ tensors, which must go through
+the JAX backend instead.
 """
 
 import cvxpy as cp

--- a/openscvx/symbolic/lowerers/cvxpy/constraint.py
+++ b/openscvx/symbolic/lowerers/cvxpy/constraint.py
@@ -1,6 +1,14 @@
 """CVXPy visitors for constraint expressions.
 
 Visitors: Equality, Inequality, CrossNodeConstraint, CTCS
+
+Lowers constraint AST nodes to CVXPy ``Constraint`` objects for the convex
+subproblem. ``Equality`` (``lhs == rhs``) and ``Inequality`` (``lhs <= rhs``)
+become the corresponding relational constraints, admissible when their sides obey
+DCP; ``CrossNodeConstraint`` simply lowers its inner constraint, relying on the
+full-trajectory ``x`` / ``u`` in ``variable_map`` so its node references resolve.
+``CTCS`` is continuous-time and non-convex, enforced through dynamics
+augmentation in the JAX backend, so it raises ``NotImplementedError`` here.
 """
 
 import cvxpy as cp

--- a/openscvx/symbolic/lowerers/cvxpy/control.py
+++ b/openscvx/symbolic/lowerers/cvxpy/control.py
@@ -1,6 +1,11 @@
 """CVXPy visitors for control expressions.
 
 Visitors: Control
+
+Lowers a ``Control`` leaf to a slice of the unified control variable ``u`` held in
+the lowerer's ``variable_map``, using the slice assigned during unification. If
+the control carries no slice the whole ``u`` is returned; a missing ``u`` in the
+map is a usage error and raises.
 """
 
 import cvxpy as cp

--- a/openscvx/symbolic/lowerers/cvxpy/expr.py
+++ b/openscvx/symbolic/lowerers/cvxpy/expr.py
@@ -1,6 +1,14 @@
 """CVXPy visitors for core expression types.
 
 Visitors: Constant, Parameter, NodeReference
+
+Lowers the leaf value nodes that bottom out expression recursion. ``Constant``
+wraps its value in a ``cp.Constant``; ``Parameter`` resolves by name through the
+lowerer's ``variable_map``, which may bind it to a ``cp.Parameter`` for
+recompilation-free parameter sweeps or to a fixed constant; ``NodeReference``
+indexes a full-trajectory variable ``(N, n_x)`` / ``(N, n_u)`` at a fixed node,
+which is how cross-node constraints reach across the time grid. Unlike the JAX
+backend, compound-expression node references are not yet supported here.
 """
 
 import cvxpy as cp

--- a/openscvx/symbolic/lowerers/cvxpy/linalg.py
+++ b/openscvx/symbolic/lowerers/cvxpy/linalg.py
@@ -1,6 +1,12 @@
 """CVXPy visitors for linear algebra expressions.
 
 Visitors: Sum, Norm, Transpose, Inv
+
+Lowers the linear-algebra AST nodes to CVXPy expressions. ``Sum`` and
+``Transpose`` are curvature-preserving, and ``Norm`` maps onto ``cp.norm`` (a
+convex atom) for any supported order. ``Inv`` has no disciplined-convex form for a
+variable matrix and raises ``NotImplementedError``, pointing the user to a
+constant precomputation or the JAX layer.
 """
 
 import cvxpy as cp

--- a/openscvx/symbolic/lowerers/cvxpy/logic.py
+++ b/openscvx/symbolic/lowerers/cvxpy/logic.py
@@ -1,6 +1,12 @@
 """CVXPy visitors for logic expressions.
 
 Visitors: All, Any, Cond
+
+Registers the logic AST nodes for CVXPy, but every one raises
+``NotImplementedError``: boolean reductions (``All``, ``Any``) and conditional
+branching (``Cond``) are non-convex and have no disciplined-convex encoding. The
+visitors exist so that misusing a logic node in a convex constraint fails with a
+message pointing at the JAX backend rather than an opaque dispatch error.
 """
 
 import cvxpy as cp

--- a/openscvx/symbolic/lowerers/cvxpy/math.py
+++ b/openscvx/symbolic/lowerers/cvxpy/math.py
@@ -2,6 +2,14 @@
 
 Visitors: Sin, Cos, Tan, Exp, Log, Abs, PositivePart, Square, Huber,
           SmoothReLU, Sqrt, Max, Min, LogSumExp, Linterp, Cinterp, Bilerp
+
+Lowers the scalar math AST nodes to CVXPy expressions, but only the subset with a
+disciplined-convex form: the convex atoms (``Exp``, ``Abs``, ``Square``,
+``PositivePart``, ``Huber``, ``SmoothReLU``, ``Max``, ``LogSumExp``), the concave
+atoms (``Log``, ``Sqrt``, ``Min``), and the DCP curvature they carry. The nodes
+with no convex representation — the trigonometric functions and the interpolators
+(``Linterp``, ``Cinterp``, ``Bilerp``) — raise ``NotImplementedError`` with a
+message steering the user to a piecewise-linear reformulation or the JAX layer.
 """
 
 import cvxpy as cp

--- a/openscvx/symbolic/lowerers/cvxpy/state.py
+++ b/openscvx/symbolic/lowerers/cvxpy/state.py
@@ -1,6 +1,12 @@
 """CVXPy visitors for state/time expressions.
 
 Visitors: State, Time
+
+Lowers a ``State`` leaf to a slice of the unified state variable ``x`` held in the
+lowerer's ``variable_map``, using the slice assigned during unification. ``Time``
+is a ``State`` subclass and shares the visitor; if the state carries no slice the
+whole ``x`` is returned, and a missing ``x`` in the map is a usage error and
+raises.
 """
 
 import cvxpy as cp

--- a/openscvx/symbolic/lowerers/jax/arithmetic.py
+++ b/openscvx/symbolic/lowerers/jax/arithmetic.py
@@ -1,6 +1,12 @@
 """JAX visitors for arithmetic expressions.
 
 Visitors: Add, Sub, Mul, Div, MatMul, Neg, Power
+
+Lowers the arithmetic AST nodes to JAX functions ``(x, u, node, params) -> array``.
+``Add``, ``Sub``, ``Mul`` (Hadamard), ``Div``, and ``Power`` are element-wise and
+broadcast following NumPy/JAX rules; ``MatMul`` lowers to ``jnp.matmul``. Each
+visitor recursively lowers its operands and composes their functions, so nothing
+here evaluates until the returned closure is called with concrete arrays.
 """
 
 import jax.numpy as jnp

--- a/openscvx/symbolic/lowerers/jax/array.py
+++ b/openscvx/symbolic/lowerers/jax/array.py
@@ -1,6 +1,14 @@
 """JAX visitors for array expressions.
 
 Visitors: Index, Concat, Stack, Hstack, Vstack, Block
+
+Lowers the array construction and indexing AST nodes to JAX functions built on
+``jnp`` (``concatenate``, ``stack``, ``hstack``, ``vstack``, ``block``). Two
+shape details drive the code: ``Index`` first reshapes its base back to the
+node's declared shape, since states live flattened in the unified state vector,
+and the joining visitors promote scalars to 1-D before combining. ``Block`` uses
+``jnp.block`` for 2-D and falls back to manual axis-0/axis-1 concatenation for
+3-D+ tensors, where ``jnp.block`` semantics no longer match.
 """
 
 import jax.numpy as jnp

--- a/openscvx/symbolic/lowerers/jax/constraint.py
+++ b/openscvx/symbolic/lowerers/jax/constraint.py
@@ -1,6 +1,17 @@
 """JAX visitors for constraint expressions.
 
 Visitors: Equality, Inequality, NodalConstraint, CrossNodeConstraint, CTCS
+
+Lowers constraint AST nodes to residual functions in the ``g <= 0`` / ``h = 0``
+convention: ``Equality`` and ``Inequality`` both return ``lhs - rhs``.
+``NodalConstraint`` merely unwraps to its inner constraint (which nodes it applies
+to is handled elsewhere), while ``CrossNodeConstraint`` exposes a trajectory-level
+``(X, U, params) -> scalar`` signature for constraints that reference several
+nodes at once (e.g. rate limits). ``CTCS`` produces the penalty integrand for
+continuous-time constraint satisfaction, gated to its node range by wrapping the
+penalty in a :class:`~openscvx.symbolic.expr.logic.Cond`; unlike CVXPy, this
+backend can lower CTCS because the penalty is enforced through dynamics
+augmentation, not a convex constraint.
 """
 
 # Expression types to handle — uncomment as you paste visitors:

--- a/openscvx/symbolic/lowerers/jax/control.py
+++ b/openscvx/symbolic/lowerers/jax/control.py
@@ -1,6 +1,11 @@
 """JAX visitors for control expressions.
 
 Visitors: Control
+
+Lowers a ``Control`` leaf to a JAX function that slices the corresponding entries
+out of the unified control vector ``u``. The slice is the one assigned during
+unification; lowering a control whose slice is still unset is a usage error and
+raises.
 """
 
 # Expression types to handle — uncomment as you paste visitors:

--- a/openscvx/symbolic/lowerers/jax/expr.py
+++ b/openscvx/symbolic/lowerers/jax/expr.py
@@ -1,6 +1,14 @@
 """JAX visitors for core expression types.
 
 Visitors: Constant, Parameter, NodeReference
+
+Lowers the leaf value nodes that bottom out expression recursion. ``Constant``
+bakes its value into the closure (squeezing singletons to true scalars);
+``Parameter`` defers to a runtime lookup in the ``params`` dict, so parameters can
+be updated between SCP iterations without recompiling; ``NodeReference`` extracts
+a state/control value at a fixed trajectory node (the index is resolved at
+construction time), which is what lets cross-node constraints reach across the
+time grid.
 """
 
 import jax.numpy as jnp

--- a/openscvx/symbolic/lowerers/jax/lie.py
+++ b/openscvx/symbolic/lowerers/jax/lie.py
@@ -2,6 +2,15 @@
 
 Visitors: AdjointDual, Adjoint, SE3Adjoint, SE3AdjointDual,
           SO3Exp, SO3Log, SE3Exp, SE3Log
+
+Lowers the SO(3)/SE(3) Lie-group primitives used in rigid-body dynamics to JAX
+functions. The little adjoint ``Adjoint`` (Lie bracket) and its dual
+``AdjointDual`` (coadjoint) compute the twist- and wrench-space operators behind
+the Coriolis/centrifugal terms of the Newton-Euler equations; ``SE3Adjoint`` /
+``SE3AdjointDual`` build the 6x6 matrices that transport twists and wrenches
+between frames. The exp/log maps (``SO3Exp``/``SO3Log``, ``SE3Exp``/``SE3Log``)
+defer to :mod:`jaxlie` for numerically robust, differentiable implementations,
+with the twist convention ``[v; omega]`` matching jaxlie's SE(3) tangent.
 """
 
 import jax.numpy as jnp

--- a/openscvx/symbolic/lowerers/jax/linalg.py
+++ b/openscvx/symbolic/lowerers/jax/linalg.py
@@ -1,6 +1,12 @@
 """JAX visitors for linear algebra expressions.
 
 Visitors: Transpose, Diag, Sum, Inv, Norm
+
+Lowers the linear-algebra AST nodes to JAX functions over ``jnp`` and
+``jnp.linalg``. ``Sum`` reduces over all elements; ``Norm`` translates the
+node's symbolic ``ord`` (including the string forms ``"inf"``/``"-inf"``/``"fro"``)
+to the value ``jnp.linalg.norm`` expects. ``Inv`` lowers to a full matrix inverse
+here — a node the CVXPy backend rejects as non-convex.
 """
 
 import jax.numpy as jnp

--- a/openscvx/symbolic/lowerers/jax/logic.py
+++ b/openscvx/symbolic/lowerers/jax/logic.py
@@ -1,6 +1,17 @@
 """JAX visitors for logic expressions.
 
 Visitors: All, Any, Cond
+
+Lowers the logic AST nodes to traceable JAX functions: ``All``/``Any`` reduce
+predicate residuals (satisfied when ``<= 0``) with ``jnp.all``/``jnp.any``, and
+``Cond`` wraps ``jax.lax.cond`` so a predicate selects between two lowered
+branches at runtime, optionally gated to a set of node ranges. These
+branching/boolean nodes have no disciplined-convex form, so they are lowered only
+by this JAX backend, never by CVXPy.
+
+Both ``cond`` branches are cast to a shared default float dtype
+(:func:`set_default_float_dtype`, configured by ``Problem.__init__``) to avoid
+dtype-mismatch errors when JAX traces the two branches separately.
 """
 
 import jax.numpy as jnp

--- a/openscvx/symbolic/lowerers/jax/math.py
+++ b/openscvx/symbolic/lowerers/jax/math.py
@@ -3,6 +3,14 @@
 Visitors: Sin, Cos, Tan, Asin, Acos, Atan, Atan2, Square, Sqrt, Exp, Log, Abs,
           Max, Min, PositivePart, Huber, SmoothReLU, LogSumExp, Linterp, Cinterp,
           Bilerp
+
+Lowers the scalar math AST nodes to JAX functions over ``jnp`` and
+``jax.scipy``. Unlike the CVXPy backend, every node here is admissible: the
+trigonometric, elementary, and reduction functions map straight onto their
+``jnp`` counterparts, the smooth penalties (``PositivePart``, ``Huber``,
+``SmoothReLU``, ``LogSumExp``) are the differentiable surrogates the SCP loop
+relies on, and the interpolators (``Linterp``, ``Cinterp``, ``Bilerp``) evaluate
+baked tabulated data while staying differentiable through JAX autodiff.
 """
 
 import jax

--- a/openscvx/symbolic/lowerers/jax/spatial.py
+++ b/openscvx/symbolic/lowerers/jax/spatial.py
@@ -1,6 +1,13 @@
 """JAX visitors for spatial expressions.
 
 Visitors: QDCM, SSMP, SSM
+
+Lowers the 6-DOF rigid-body primitives to JAX functions that build small
+matrices from their operand vectors: ``QDCM`` turns a (normalized) quaternion
+into a 3x3 direction-cosine matrix, ``SSM`` builds the 3x3 skew-symmetric
+(cross-product) matrix of a 3-vector, and ``SSMP`` builds the 4x4 matrix used in
+the quaternion kinematics ``q_dot = 0.5 * SSMP(omega) @ q``. These are the
+building blocks for attitude and spacecraft/robotics dynamics.
 """
 
 import jax.numpy as jnp

--- a/openscvx/symbolic/lowerers/jax/state.py
+++ b/openscvx/symbolic/lowerers/jax/state.py
@@ -1,6 +1,11 @@
 """JAX visitors for state/time expressions.
 
 Visitors: State, Time
+
+Lowers a ``State`` leaf to a JAX function that slices the corresponding entries
+out of the unified state vector ``x``, using the slice assigned during
+unification. ``Time`` is a ``State`` subclass and shares the same visitor;
+lowering a state whose slice is still unset is a usage error and raises.
 """
 
 # Expression types to handle — uncomment as you paste visitors:

--- a/openscvx/symbolic/lowerers/jax/stljax.py
+++ b/openscvx/symbolic/lowerers/jax/stljax.py
@@ -1,6 +1,14 @@
 """JAX visitors for STL (Signal Temporal Logic) expressions.
 
 Visitors: Or
+
+Lowers the :mod:`~openscvx.symbolic.expr.stljax` disjunction to a JAX function
+that evaluates robustness through the external ``stljax`` library, as opposed to
+the in-house GMSR STL backend in :mod:`openscvx.symbolic.lowerers.jax.stl`. Each
+predicate contributes a robustness signal (``rhs - lhs`` for a constraint,
+positive when satisfied, or a recursively lowered nested STL expression); these
+become ``stljax`` predicates combined by ``stljax.formula.Or``, whose robustness
+is positive when at least one predicate holds.
 """
 
 # Expression types to handle — uncomment as you paste visitors:

--- a/openscvx/symbolic/lowerers/jax/vmap.py
+++ b/openscvx/symbolic/lowerers/jax/vmap.py
@@ -1,6 +1,15 @@
 """JAX visitors for vmap expressions.
 
 Visitors: _Placeholder, Vmap
+
+Lowers a ``Vmap`` node to a ``jax.vmap`` over its body, mapping each batch
+argument to a ``_Placeholder`` that the body reads back through ``params``. Batch
+data is resolved per source: constants are baked into the closure at lowering
+time, while ``Parameter``/``State``/``Control`` batches are gathered from
+``params``/``x``/``u`` at runtime so they track SCP updates. Because the mapped
+body is a nested sub-trace that re-reads the same captured ``(x, u, node)``, the
+visitor pauses the value memo around the ``vmap`` so no cached tracer leaks across
+the trace boundary.
 """
 
 import jax

--- a/openscvx/symbolic/lowerers/latex/arithmetic.py
+++ b/openscvx/symbolic/lowerers/latex/arithmetic.py
@@ -1,6 +1,13 @@
 """LaTeX visitors for arithmetic expressions.
 
 Visitors: Add, Sub, Mul, Div, MatMul, Neg, Power
+
+Renders the arithmetic AST nodes to LaTeX math strings: sums join with ``+``,
+products with ``\\cdot``, and ``Div`` becomes a self-delimiting ``\\frac``.
+Operands are wrapped by operator precedence (via ``wrap``/``_PRECEDENCE``) so
+parenthesization stays minimal but correct — e.g. ``Sub`` wraps its right operand
+one level higher so ``a - (b + c)`` is grouped, while a ``\\frac`` needs no
+wrapping at all.
 """
 
 from openscvx.symbolic.expr.arithmetic import Add, Div, MatMul, Mul, Neg, Power, Sub

--- a/openscvx/symbolic/lowerers/latex/array.py
+++ b/openscvx/symbolic/lowerers/latex/array.py
@@ -1,6 +1,13 @@
 """LaTeX visitors for array expressions.
 
 Visitors: Index, Concat, Stack, Hstack, Vstack
+
+Renders the array construction and indexing AST nodes to LaTeX: the joining nodes
+build ``bmatrix`` blocks, and ``Index`` renders as a subscript. Indexing uses
+``merge_subscript`` so an index on a role-prefixed variable comma-merges into the
+existing subscript group (``x_{\\mathrm{velocity}}`` -> ``x_{\\mathrm{velocity},0}``)
+rather than emitting a double subscript. ``Block`` has no LaTeX visitor — the
+notation is only defined for the flat array constructors.
 """
 
 from openscvx.symbolic.expr.array import Concat, Hstack, Index, Stack, Vstack

--- a/openscvx/symbolic/lowerers/latex/constraint.py
+++ b/openscvx/symbolic/lowerers/latex/constraint.py
@@ -1,6 +1,14 @@
 """LaTeX visitors for constraint expressions.
 
 Visitors: Equality, Inequality, NodalConstraint, CrossNodeConstraint, CTCS
+
+Renders constraint AST nodes to LaTeX relational rows. ``Equality`` and
+``Inequality`` render as ``lhs = rhs`` / ``lhs \\le rhs``; ``NodalConstraint`` adds
+a node-set annotation (``k = a``, a contiguous ``k \\in \\{a, \\dots, b\\}``, or an
+explicit set elided past six entries); ``CrossNodeConstraint`` renders its inner
+constraint with its node-referencing operands; and ``CTCS`` renders as the
+continuous-time path constraint it stands for (``\\forall t``), which is how the
+Mayer-form formulation presents it.
 """
 
 from openscvx.symbolic.expr.constraint import (

--- a/openscvx/symbolic/lowerers/latex/control.py
+++ b/openscvx/symbolic/lowerers/latex/control.py
@@ -1,6 +1,11 @@
 """LaTeX visitors for control expressions.
 
 Visitors: Control
+
+Renders a ``Control`` leaf as its role-prefixed symbol via ``control_symbol``:
+a named control becomes ``u_{<sym>}`` while the anonymous unified control renders
+as a bare ``u``. Rendering reads the control's name only — no slice into the
+unified vector, since the LaTeX form names the variable rather than locating it.
 """
 
 from openscvx.symbolic.expr.control import Control

--- a/openscvx/symbolic/lowerers/latex/expr.py
+++ b/openscvx/symbolic/lowerers/latex/expr.py
@@ -1,6 +1,11 @@
 """LaTeX visitors for core expression types.
 
 Visitors: Constant, Parameter, NodeReference
+
+Renders the leaf value nodes to LaTeX math strings: ``Constant`` via
+``format_constant`` (scalars, vectors, and matrices), ``Parameter`` as its
+symbol via ``latex_symbol``, and ``NodeReference`` as its base carrying a node
+superscript ``x^{(k)}`` — the notation for "this variable at trajectory node k".
 """
 
 from openscvx.symbolic.expr.expr import Constant, NodeReference

--- a/openscvx/symbolic/lowerers/latex/linalg.py
+++ b/openscvx/symbolic/lowerers/latex/linalg.py
@@ -1,6 +1,12 @@
 """LaTeX visitors for linear algebra expressions.
 
 Visitors: Transpose, Diag, Sum, Inv, Norm
+
+Renders the linear-algebra AST nodes to LaTeX math strings: ``Transpose`` as
+``A^{\\top}``, ``Inv`` as ``A^{-1}``, ``Sum`` as ``\\sum``, ``Diag`` as
+``\\operatorname{diag}(...)``, and ``Norm`` as ``\\left\\| ... \\right\\|`` with an
+order subscript. Euclidean/Frobenius orders (``None``, ``2``, ``"fro"``) render
+without a subscript, since the double-bar already reads as the 2-norm.
 """
 
 from openscvx.symbolic.expr.linalg import Diag, Inv, Norm, Sum, Transpose

--- a/openscvx/symbolic/lowerers/latex/logic.py
+++ b/openscvx/symbolic/lowerers/latex/logic.py
@@ -1,6 +1,13 @@
 """LaTeX visitors for logic expressions.
 
 Visitors: All, Any, Cond
+
+Renders the logic AST nodes to LaTeX math strings. ``All`` and ``Any`` render as
+big-operator reductions over their predicates (``\\bigwedge`` / ``\\bigvee``); a
+single predicate still gets the operator so the reduce-over-elements semantics of
+a vector predicate stay visible. ``Cond`` renders as a cases block. These nodes
+have no convex form, so where the CVXPy backend rejects them, LaTeX simply
+typesets the logical structure the user wrote.
 """
 
 from openscvx.symbolic.expr.logic import All, Any, Cond

--- a/openscvx/symbolic/lowerers/latex/math.py
+++ b/openscvx/symbolic/lowerers/latex/math.py
@@ -3,6 +3,12 @@
 Visitors: Sin, Cos, Tan, Asin, Acos, Atan, Atan2, Square, Sqrt, Exp, Log, Abs,
           Max, Min, PositivePart, Huber, SmoothReLU, LogSumExp, Linterp,
           Cinterp, Bilerp
+
+Renders the scalar math AST nodes to LaTeX math strings. The elementary functions
+render as ordinary function applications (``\\sin\\left( ... \\right)`` via
+``_call``), and the penalty/interpolation atoms render as named operators. Unlike
+the CVXPy backend, which admits only the DCP-representable subset, every math node
+has a valid LaTeX form, since rendering imposes no convexity requirement.
 """
 
 from openscvx.symbolic.expr.arithmetic import Power

--- a/openscvx/symbolic/lowerers/latex/vmap.py
+++ b/openscvx/symbolic/lowerers/latex/vmap.py
@@ -1,6 +1,13 @@
 """LaTeX visitors for vmap expressions.
 
 Visitors: _Placeholder, Vmap
+
+Renders a ``Vmap`` node as ``\\operatorname{vmap}\\left( <body> \\right)`` — the
+symbolic analogue of ``jax.vmap`` — by lowering its body once and showing the
+mapped expression rather than an opaque repr. Each ``_Placeholder`` (a single
+batch element) renders as a neutral ``\\square``; with multiple batch arguments
+every placeholder shares that box, so distinct batch sources are not visually
+disambiguated.
 """
 
 from openscvx.symbolic.expr.vmap import Vmap, _Placeholder

--- a/openscvx/symbolic/parser/array.py
+++ b/openscvx/symbolic/parser/array.py
@@ -1,6 +1,11 @@
 """Parser handlers for array manipulation operations.
 
 Handlers: Concat, Stack, Hstack, Vstack, Block
+
+Each handler is registered under its function name via ``@function`` and turns the
+call-syntax form (e.g. ``Stack(a, b)``) that the Pratt parser encounters in an
+expression string into the corresponding array-construction ``Expr`` node,
+validating argument counts as it goes.
 """
 
 from openscvx.symbolic.expr.array import Block, Concat, Hstack, Stack, Vstack

--- a/openscvx/symbolic/parser/lie.py
+++ b/openscvx/symbolic/parser/lie.py
@@ -2,6 +2,11 @@
 
 Handlers: AdjointDual, Adjoint, SE3Adjoint, SE3AdjointDual,
           SO3Exp, SO3Log, SE3Exp, SE3Log
+
+Each handler is registered under its function name via ``@function`` and turns the
+call-syntax form (e.g. ``SE3Exp(twist)``) that the Pratt parser encounters in an
+expression string into the corresponding SO(3)/SE(3) ``Expr`` node — the group
+exp/log maps and the (co)adjoint operators used in rigid-body dynamics.
 """
 
 from openscvx.symbolic.expr.lie import (

--- a/openscvx/symbolic/parser/linalg.py
+++ b/openscvx/symbolic/parser/linalg.py
@@ -1,6 +1,11 @@
 """Parser handlers for linear algebra operations.
 
 Handlers: Norm, Sum, Diag, Inv, Transpose
+
+Each handler is registered under its function name via ``@function`` and turns the
+call-syntax form (e.g. ``Norm(x, 2)``) that the Pratt parser encounters in an
+expression string into the corresponding linear-algebra ``Expr`` node, forwarding
+options such as the norm order.
 """
 
 from openscvx.symbolic.expr.expr import Constant

--- a/openscvx/symbolic/parser/logic.py
+++ b/openscvx/symbolic/parser/logic.py
@@ -1,6 +1,11 @@
 """Parser handlers for logical and control flow operations.
 
 Handlers: All, Any, Cond
+
+Each handler is registered under its function name via ``@function`` and turns the
+call-syntax form (e.g. ``Cond(pred, a, b)``) that the Pratt parser encounters in
+an expression string into the corresponding logic ``Expr`` node — the boolean
+reductions and the conditional branch.
 """
 
 from openscvx.symbolic.expr.constraint import Inequality

--- a/openscvx/symbolic/parser/math.py
+++ b/openscvx/symbolic/parser/math.py
@@ -3,6 +3,12 @@
 Handlers: Sin, Cos, Tan, Asin, Acos, Atan, Atan2, Sqrt, Square, Exp, Log, Abs,
           Max, Min, PositivePart, Huber, SmoothReLU, LogSumExp, Linterp, Cinterp,
           Bilerp
+
+Each handler is registered under its function name via ``@function`` and turns the
+call-syntax form (e.g. ``Huber(x, 0.1)``) that the Pratt parser encounters in an
+expression string into the corresponding math ``Expr`` node. Scalar options such
+as a penalty width or smoothing constant are coerced to Python floats (via
+``_as_float``) so a constant literal and a bare number parse the same way.
 """
 
 from openscvx.symbolic.expr.expr import Constant

--- a/openscvx/symbolic/parser/spatial.py
+++ b/openscvx/symbolic/parser/spatial.py
@@ -1,6 +1,11 @@
 """Parser handlers for spatial / 6-DOF operations.
 
 Handlers: QDCM, SSM, SSMP
+
+Each handler is registered under its function name via ``@function`` and turns the
+call-syntax form (e.g. ``QDCM(q)``) that the Pratt parser encounters in an
+expression string into the corresponding 6-DOF ``Expr`` node — the
+quaternion-to-DCM conversion and the skew-symmetric matrices.
 """
 
 from openscvx.symbolic.expr.spatial import QDCM, SSM, SSMP

--- a/openscvx/symbolic/parser/stl.py
+++ b/openscvx/symbolic/parser/stl.py
@@ -1,6 +1,13 @@
 """Parser handlers for GMSR-based Signal Temporal Logic operations.
 
 Handlers: Or, And, Not, IfThen, IntegerVariable, Always, Eventually, Until
+
+Each handler is registered under its function name via ``@function`` and turns the
+call-syntax form (e.g. ``Always(pred, interval)``) that the Pratt parser
+encounters in an expression string into the corresponding GMSR STL ``Expr`` node —
+the propositional connectives and the interval-carrying temporal operators. This
+is the in-house GMSR STL family, distinct from the external-library
+:mod:`openscvx.symbolic.parser.stljax` handlers.
 """
 
 from openscvx.symbolic.expr.expr import Constant

--- a/openscvx/symbolic/parser/stljax.py
+++ b/openscvx/symbolic/parser/stljax.py
@@ -1,6 +1,13 @@
 """Parser handlers for Signal Temporal Logic operations.
 
 Handlers: stljax.Or
+
+Registers the ``stljax``-backed disjunction under its namespaced name
+``"stljax.Or"`` via ``@function``, turning the call-syntax form the Pratt parser
+encounters in an expression string into an
+:class:`openscvx.symbolic.expr.stljax.Or` node. The ``stljax.`` prefix keeps this
+external-library operator distinct from the in-house GMSR ``Or`` handled in
+:mod:`openscvx.symbolic.parser.stl`.
 """
 
 from openscvx.symbolic.expr.stljax import Or

--- a/scripts/gen_example_pages.py
+++ b/scripts/gen_example_pages.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import ast
-from collections import defaultdict
+import json
+from collections import Counter, defaultdict
 from pathlib import Path
 
 import mkdocs_gen_files
@@ -123,12 +124,35 @@ def _category_section_title(category: str) -> str:
 
 
 def _docstring_teaser(docstring: str | None, max_len: int = 120) -> str:
-    if not docstring:
+    first = _docstring_summary(docstring)
+    if first is None:
         return "Runnable script; full source on the detail page."
-    first = docstring.strip().split("\n", 1)[0].strip()
     if len(first) > max_len:
         return first[: max_len - 1].rstrip() + "…"
     return first
+
+
+def _docstring_summary(docstring: str | None) -> str | None:
+    """First non-empty line of a module docstring, or ``None`` when absent."""
+    if not docstring:
+        return None
+    first = docstring.strip().splitlines()[0].strip()
+    return first or None
+
+
+def _page_description(docstring: str | None, rel_path: Path) -> str:
+    """Per-page ``description`` meta text for an example page.
+
+    Sourced from the example script's module docstring so the SEO description, the
+    index-card teaser, and the rendered docstring all agree. Mirrors the reference
+    pages (``gen_ref_pages.py``): every page gets a distinct one-liner instead of
+    inheriting the site-wide tagline. Falls back to the repo-relative path for the
+    rare script that carries no docstring.
+    """
+    summary = _docstring_summary(docstring)
+    if summary is not None:
+        return summary
+    return f"Runnable OpenSCvx trajectory optimization example: examples/{rel_path.as_posix()}."
 
 
 def _examples_index_markdown(
@@ -177,16 +201,26 @@ helpers) are omitted from this index.
 """
 
 
+def _is_example_page(path: Path) -> bool:
+    """Whether a discovered ``.py`` file becomes an example page (vs a utility module)."""
+    rel_path = path.relative_to(examples_dir)
+    if len(rel_path.parts) < 2:  # Must live in a category subdirectory
+        return False
+    return path.name not in SKIP_FILES and not path.name.startswith("_")
+
+
+example_paths = [p for p in sorted(examples_dir.rglob("*.py")) if _is_example_page(p)]
+
+# Leaf file names recur across categories (the animations/ demos mirror arm/ and
+# drone/ examples), so bare titles collide. Qualify only the colliding ones with
+# their category to keep every page's <title> tag and search entry distinct.
+_title_counts = Counter(format_title(p.stem) for p in example_paths)
+
 # (category, doc_path, page_title, teaser) for the landing page
 _index_entries: list[tuple[str, Path, str, str]] = []
 
-for path in sorted(examples_dir.rglob("*.py")):
-    # Skip files in the root examples/ directory and skip utility files
+for path in example_paths:
     rel_path = path.relative_to(examples_dir)
-    if len(rel_path.parts) < 2:  # Must be in a subdirectory
-        continue
-    if path.name in SKIP_FILES or path.name.startswith("_"):
-        continue
 
     # Create the documentation path
     module_path = rel_path.with_suffix("")
@@ -204,10 +238,20 @@ for path in sorted(examples_dir.rglob("*.py")):
     source_code = get_source_without_docstring(path)
     page_title = format_title(path.stem)
     category = rel_path.parts[0]
+    meta_title = page_title
+    if _title_counts[page_title] > 1:
+        meta_title = f"{page_title} ({_category_section_title(category)})"
     _index_entries.append((category, doc_path, page_title, _docstring_teaser(docstring)))
 
     # Generate the markdown content
     with mkdocs_gen_files.open(full_doc_path, "w") as fd:
+        # Front matter carries a unique title and a per-page description so the page
+        # stops inheriting the site-wide tagline; the H1 keeps the clean, unqualified
+        # title. json.dumps yields a double-quoted, escaped scalar that is valid YAML.
+        fd.write("---\n")
+        fd.write(f"title: {json.dumps(meta_title)}\n")
+        fd.write(f"description: {json.dumps(_page_description(docstring, rel_path))}\n")
+        fd.write("---\n\n")
         fd.write(f"# {page_title}\n\n")
 
         if docstring:

--- a/scripts/gen_ref_pages.py
+++ b/scripts/gen_ref_pages.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import ast
+import json
 from pathlib import Path
 
 import mkdocs_gen_files
@@ -10,6 +12,25 @@ nav = mkdocs_gen_files.Nav()
 
 root = Path(__file__).parent.parent
 src = root / "openscvx"
+
+
+def _module_summary(path: Path, dotted: str) -> str:
+    """First line of a module's docstring, or a package-qualified fallback.
+
+    The summary becomes the page's ``description`` meta tag so that every module
+    in the reference gets a distinct, extractable one-liner instead of inheriting
+    the site-wide tagline. ``dotted`` is the import path relative to ``openscvx``
+    (e.g. ``symbolic.lowerers.jax.state``).
+    """
+    try:
+        docstring = ast.get_docstring(ast.parse(path.read_text(encoding="utf-8")))
+    except (SyntaxError, OSError):
+        docstring = None
+    if docstring:
+        first_line = docstring.strip().splitlines()[0].strip()
+        if first_line:
+            return first_line
+    return f"API reference for openscvx.{dotted}, generated from source."
 
 # Icon + one-line blurb for each subpackage (Material emoji shortcodes for MkDocs).
 _REFERENCE_PACKAGES: dict[str, tuple[str, str]] = {
@@ -155,8 +176,17 @@ for path in sorted(src.rglob("*.py")):
 
     nav[parts] = doc_path.as_posix()
 
+    dotted = ".".join(parts)
+    identifier = ".".join(("openscvx",) + parts)
     with mkdocs_gen_files.open(full_doc_path, "w") as fd:
-        identifier = ".".join(("openscvx",) + parts)
+        # Front matter qualifies the page title by package path (leaf module names
+        # such as ``state`` and ``base`` recur across the jax/cvxpy/latex lowerers)
+        # and gives each module a distinct meta description.
+        fd.write("---\n")
+        fd.write(f"title: {dotted}\n")
+        # json.dumps yields a double-quoted, escaped scalar that is valid YAML.
+        fd.write(f"description: {json.dumps(_module_summary(path, dotted))}\n")
+        fd.write("---\n\n")
         fd.write(f"::: {identifier}\n")
 
     mkdocs_gen_files.set_edit_path(full_doc_path, path.relative_to(root))

--- a/scripts/gen_ref_pages.py
+++ b/scripts/gen_ref_pages.py
@@ -32,6 +32,7 @@ def _module_summary(path: Path, dotted: str) -> str:
             return first_line
     return f"API reference for openscvx.{dotted}, generated from source."
 
+
 # Icon + one-line blurb for each subpackage (Material emoji shortcodes for MkDocs).
 _REFERENCE_PACKAGES: dict[str, tuple[str, str]] = {
     "algorithms": (

--- a/scripts/mkdocs_seo_hook.py
+++ b/scripts/mkdocs_seo_hook.py
@@ -1,0 +1,37 @@
+"""SEO fix-ups that need to reach files MkDocs config options cannot.
+
+Two concerns live here, both stemming from pages/dates that plugins produce after the point where
+static config (``exclude_docs``, the sitemap template) is resolved:
+
+* ``scripts/gen_ref_pages.py`` and ``scripts/gen_example_pages.py`` emit ``Reference/SUMMARY.md``
+  and ``Examples/SUMMARY.md`` via ``mkdocs-gen-files``. ``mkdocs-literate-nav`` consumes them to
+  build the section navigation but leaves them in the file set, so MkDocs renders each as a real
+  page (``.../SUMMARY/``) and lists it in ``sitemap.xml`` — a navigation artifact with no reader
+  value. Because ``gen-files`` adds them at ``on_files`` time, ``exclude_docs`` (which only filters
+  the ``docs_dir`` scan) never sees them; we drop them from the file set instead.
+
+* ``mkdocs-git-revision-date-localized`` stamps each page's real git date into ``page.meta`` but
+  not into ``page.update_date``, which is the field MkDocs' ``sitemap.xml`` reads for ``<lastmod>``.
+  Left alone, every URL is stamped with the uniform build date. We copy the git date across so the
+  sitemap carries a genuine per-page freshness signal.
+"""
+
+from mkdocs.plugins import event_priority
+from mkdocs.structure.files import Files
+from mkdocs.structure.pages import Page
+
+
+@event_priority(-200)  # After mkdocs-literate-nav (-100) has consumed the SUMMARY files.
+def on_files(files: Files, config) -> Files:
+    for file in list(files):
+        if file.src_uri.endswith("SUMMARY.md"):
+            files.remove(file)
+    return files
+
+
+@event_priority(-100)  # After git-revision-date-localized has populated page.meta.
+def on_page_markdown(markdown: str, page: Page, config, files) -> str:
+    git_date = page.meta.get("git_revision_date_localized_raw_iso_date")
+    if git_date:
+        page.update_date = git_date
+    return markdown


### PR DESCRIPTION
Implements the pre-1.0 SEO work tracked in #565. A full audit of the docs site (2026-07-14, all 276 sitemap pages crawled) scored it 61/100: the infrastructure was healthy — fast, fully static, zero broken links — but the findings clustered into a broken version/canonical strategy and an entity that search engines and AI assistants had to assemble from fragments. Each section below gives the finding, then the fix.

Closes #567. Closes #568. #566 stays open for its two maintainer-side checklist items (see "Remaining work").

## Version canonicals & indexation (#566)

**Found:** mike serves seven complete copies of the docs, and every copy declared itself canonical — `latest/` even canonicalized *away* to the version-pinned `v0.5.2/`, so accumulated ranking resets at every release. Root cause: mike injects the version into `site_url` at deploy time (`MIKE_DOCS_VERSION` → `on_config`), so each deployment self-canonicalizes. The nightly build was fully indexable with its own sitemap, competing with release docs.

**Fixed:** declared the `mike` plugin in `mkdocs.yml` with `canonical_version: latest`, its purpose-built option for exactly this — every deployment now emits `…/OpenSCvx/latest/<page>/` canonicals (verified on simulated nightly and tagged builds; a plain `mkdocs build` stays version-less). The deployed version is passed to templates via `extra.mike_version`, and `material/overrides/main.html` emits `<meta name="robots" content="noindex">` on nightly only. A `noindex: true` front-matter flag gets the same treatment and also drops the page from a new `sitemap.xml` override, applied to the hidden WIP tutorial.

## Entity metadata (#566, #567)

**Found:** no structured data on any of the 276 pages, no page stating "OpenSCvx is a …" in an extractable sentence, homepage titled bare "OpenSCvx" with two H1s ("OpenSCvx" from the hero template + "Home" auto-injected), no PyPI link, citations raw-BibTeX-only with the arXiv URL rendering as unlinked text.

**Fixed:** homepage now renders `SoftwareSourceCode` JSON-LD (repo, license, language, `sameAs` → GitHub/PyPI/arXiv/DOI), a single keyword-carrying H1 ("OpenSCvx — Trajectory Optimization via Successive Convexification in Python/JAX" — the hero brand text is demoted to a styled paragraph), and an extractable definition paragraph. The citation page gains a plain-language cite line and clickable DOI/arXiv anchors, plus a root `CITATION.cff` with the RA-L preferred-citation. Added a dedicated Installation page (Python version, uv/pip/source, extras, PyPI link) and `llms.txt`.

## Duplicate page metadata (#567)

**Found:** 273/276 pages shared one site-wide meta description; 27 duplicate-title groups in the API reference (the jax/cvxpy/latex lowerers share leaf module names, so five pages were each titled "state - OpenSCvx", etc.).

**Fixed:** `gen_ref_pages.py` and `gen_example_pages.py` now emit per-page front matter — package-qualified titles and descriptions sourced from module docstrings (example titles are category-qualified only for the five recurring leaf names, keeping visible H1s clean). Hand-written `description:` front matter on the high-intent pages (Users Guide, Foundations, Under-the-Hood, citation, examples index). After this PR, zero real pages inherit the site tagline and zero duplicate titles remain.

## Thin & stub content (#567)

**Found:** three Foundations pages were 11–12-word stubs ("This page is still under development"), all six Foundations pages carried that banner including a 2,494-word one, the SCvx explainer — the site's best AI-citable passage — misspelled "Succesive" in its H1, and a 43-word WIP tutorial sat in the flagship Users Guide series.

**Fixed:** wrote the three empty Foundations pages grounded in the source (dilation control in `symbolic/builder.py`, ZOH/FOH parameterization in `discretization/`, CTCS penalty-state reformulation in the solvers), removed the banner from finished pages, fixed the typos. The WIP logic tutorial was hidden (nav, search, sitemap, robots) rather than written, since a correct worked STL tutorial needs verified runnable code — the file stays because two other pages link to it.

## Near-empty API reference pages (#568)

**Found:** ~46 generated reference pages rendered as bare class lists (`integrators/diffrax` was literally one word) because the modules had no docstrings — also the source of the duplicate-title collisions.

**Fixed:** module-level docstrings on 41 modules (both integrators, the full jax/cvxpy/latex lowerer trees, the parser leaves), written as a coherent family — parallel phrasing across backends, each stating what AST-node class it lowers to what target. Docstring-only diff (+297/−0); these first lines now also feed the generated meta descriptions.

## Sitemap hygiene & freshness (#566)

**Found:** the sitemap listed both `/examples/` and `/Examples/` (case-colliding duplicates) plus contentless literate-nav `SUMMARY/` pages; every `lastmod` was the uniform build date.

**Fixed:** the stale `examples.md` is excluded (superseded by the generated `Examples/` section), a new `scripts/mkdocs_seo_hook.py` removes gen-files SUMMARY pages from the build (they're created after `exclude_docs` runs), and `git-revision-date-localized` now provides real per-page dates in footers and sitemap `lastmod` (generated pages fall back to build date — inherent to gen-files output). Added a Changelog page linking GitHub releases and PyPI history.

## Verification

- `mkdocs build` clean; homepage has exactly one `<h1>`; JSON-LD parses; sitemap holds 274 URLs with zero SUMMARY/case-duplicate/noindexed entries
- Tagline-inheriting descriptions: 273 → 0 real pages; duplicate `<title>`s: 27 groups → 0
- `import openscvx` and 1,665 targeted tests pass (`tests/symbolic/`, `tests/test_integrators.py`); the #568 diff verified docstring-only
- CI note: the git-revision plugin needs full history and the docs workflow already uses `fetch-depth: 0`

## Remaining work (not in this PR)

Each item below says what to do, what the action does, and what it fixes. Step-by-step detail lives in the issue comments: [deploy/infra on #566](https://github.com/OpenSCvx/OpenSCvx/issues/566#issuecomment-4974539200), [content on #567](https://github.com/OpenSCvx/OpenSCvx/issues/567#issuecomment-4974539290), [consolidated on #565](https://github.com/OpenSCvx/OpenSCvx/issues/565#issuecomment-4974539411).

- [ ] **Delete (or redeploy) v0.3.0/v0.3.1** (#566): run `mike delete --push v0.3.0 v0.3.1`. Removes the two deployed versions whose HTML has the pre-org `haynec.github.io` canonical baked in — that domain 404s, so search engines ignore the canonical and index both versions as stale duplicate copies of the docs.
- [ ] **Redeploy v0.4.0–v0.5.2** (#566): rebuild each still-published version once with the post-merge config (`MIKE_DOCS_VERSION=vX.Y.Z mike deploy --push vX.Y.Z`). mike bakes canonicals at deploy time, so this PR only fixes versions deployed after it merges; until rebuilt, the old versions keep self-canonicalizing and ranking stays split across version-pinned URLs instead of consolidating on `latest/`.
- [ ] **Org-root robots.txt + Search Console** (#566): create the `openscvx.github.io` repo (a project Pages site can't serve domain-root robots.txt) with `Sitemap: https://openscvx.github.io/OpenSCvx/latest/sitemap.xml`, then register the property in GSC and submit that sitemap. Tells crawlers which of the seven per-version sitemaps is authoritative and unlocks index-coverage/CWV field data — the visibility the audit had to skip.
- [ ] **Zenodo software DOI at 1.0** (#567): enable the Zenodo–GitHub integration for the repo and publish the release; wire the minted concept DOI into `CITATION.cff` and the citation page. Makes the library itself citable per-version (today only the papers are) and completes the GitHub⇄PyPI⇄arXiv⇄DOI entity graph this PR starts.
- [ ] **Write the `06_logic` STL tutorial** (#567): build it on verified runnable code (`examples/abstract/stl_or.py`, `stl_integer_variable.py`), then drop its `noindex`/search-exclude front matter and restore the nav entry. Fills the one gap in the Users Guide series, which this PR hides rather than leaving indexable as a 43-word stub.
- [ ] **Post-deploy verification**: after the 1.0 deploy, spot-check canonicals on nightly/`latest`/one tag (all `…/latest/…`), confirm nightly carries the robots noindex meta, and watch GSC consolidate onto `latest/` URLs — the end-to-end proof the canonical strategy took effect on the live site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
