### PR TITLE
Fix/initialize sync guesses

### DIFF
--- a/openscvx/problem.py
+++ b/openscvx/problem.py
@@ -1113,6 +1113,8 @@ class Problem:
 
         This method vmaps dynamics, JIT-compiles constraints, builds the convex
         subproblem, and initializes the solver state. Must be called before solve().
+        The solver state is seeded from the current `.guess` and `.initial`/`.final`
+        on the State/Control objects; to re-seed after `initialize()`, use :meth:`reset`.
 
         Example:
             Prior to calling the `.solve()` method it is necessary to initialize the problem
@@ -1331,6 +1333,11 @@ class Problem:
         else:
             # Printing was disabled after __init__, disable emitter to avoid queue buildup
             self.emitter_function = lambda data: None
+
+        # Re-read guesses and boundary conditions off the State/Control objects
+        # before seeding the state, so post-construction edits take effect (as reset() does).
+        self._sync_guesses()
+        self._sync_boundary_conditions()
 
         # Create fresh solver state + history pair.
         self._state = self._default_state()

--- a/tests/test_initialize_syncs_guesses.py
+++ b/tests/test_initialize_syncs_guesses.py
@@ -1,0 +1,71 @@
+"""``Problem.initialize`` seeds the solver state from current guesses/boundaries.
+
+Trajectory guesses and boundary conditions live on the ``State``/``Control``
+objects the user builds. They are only copied into the lowered representation by
+``_sync_guesses`` / ``_sync_boundary_conditions``. Before #561, those syncs ran
+only inside ``reset()``, so a ``.guess`` edited between ``Problem(...)`` and
+``initialize()`` was silently ignored — the fresh state was seeded from the
+guess snapshotted at construction. ``initialize()`` now re-reads both, matching
+the ``.value`` / ``.initial`` mental model where post-construction edits take
+effect on the next solve.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from tests.e2e.test_solve_batched_brachistochrone import _build_brachistochrone_with_params
+
+# === initialize() re-reads post-construction guesses ===
+
+
+def test_initialize_reads_guess_edited_after_construction():
+    prob = _build_brachistochrone_with_params("cvxpy", n=8, k_max=1)
+
+    # The fixture seeds theta.guess at construction; overwrite it afterwards.
+    # (symbolic.controls also carries the augmented ``_time_dilation`` control.)
+    (theta,) = [c for c in prob.symbolic.controls if c.name == "theta"]
+    new_guess = np.full((prob.symbolic.N, 1), 0.42)
+    theta.guess = new_guess
+
+    prob.initialize()
+
+    # The solver state is seeded from the *edited* guess, not the construction-
+    # time one. Pre-#561 this held the fixture's linspace instead.
+    np.testing.assert_allclose(np.asarray(prob.state.u[:, theta._slice]), new_guess)
+
+    jax.clear_caches()
+
+
+def test_initialize_reads_boundary_condition_edited_after_construction():
+    prob = _build_brachistochrone_with_params("cvxpy", n=8, k_max=1)
+
+    position = prob.symbolic.states[0]
+    new_initial = np.array([1.0, 9.0])
+    position.initial = new_initial
+
+    prob.initialize()
+
+    np.testing.assert_allclose(
+        np.asarray(prob.state.x_init_pin[position._slice]), new_initial
+    )
+
+    jax.clear_caches()
+
+
+# === the reset() workaround and initialize() now agree ===
+
+
+def test_initialize_matches_reset_for_guess_sync():
+    prob = _build_brachistochrone_with_params("cvxpy", n=8, k_max=1)
+
+    (theta,) = [c for c in prob.symbolic.controls if c.name == "theta"]
+    prob.initialize()
+
+    # The historical workaround: edit the guess, then reset() to sync it.
+    reset_guess = np.full((prob.symbolic.N, 1), 0.17)
+    theta.guess = reset_guess
+    prob.reset()
+    np.testing.assert_allclose(np.asarray(prob.state.u[:, theta._slice]), reset_guess)
+
+    jax.clear_caches()

--- a/tests/test_initialize_syncs_guesses.py
+++ b/tests/test_initialize_syncs_guesses.py
@@ -11,7 +11,6 @@ effect on the next solve.
 """
 
 import jax
-import jax.numpy as jnp
 import numpy as np
 
 from tests.e2e.test_solve_batched_brachistochrone import _build_brachistochrone_with_params
@@ -46,9 +45,7 @@ def test_initialize_reads_boundary_condition_edited_after_construction():
 
     prob.initialize()
 
-    np.testing.assert_allclose(
-        np.asarray(prob.state.x_init_pin[position._slice]), new_initial
-    )
+    np.testing.assert_allclose(np.asarray(prob.state.x_init_pin[position._slice]), new_initial)
 
     jax.clear_caches()
 


### PR DESCRIPTION
Closes #561.

## Problem

Trajectory guesses were baked into the lowered problem at `Problem(...)` construction. Mutating `state.guess` / `control.guess` afterwards and calling `initialize()` + `solve()` silently used the *old* guesses — only `reset()` re-read them via `_sync_guesses()`. This broke the natural A/B mental model, where `Parameter.value` and `State.initial`/`final` edits *do* take effect on the next solve.

## Fix

`initialize()` now calls `_sync_guesses()` and `_sync_boundary_conditions()` before building the fresh state pytree — exactly mirroring `reset()`. Root cause: `settings.sim.x`/`.u` *are* `lowered.x_unified`/`u_unified`, and `AlgorithmState.from_settings` seeds the state from `settings.sim.x.guess`/`u.guess`, but nothing copied a post-construction `.guess` edit into the unified rep except `_sync_guesses()`.

The issue's open question — should `solve()` also sync guesses? — is resolved **no**: `solve()` never rebuilds the state pytree (it continues from the existing state for warm-starting/continuation), so syncing there would be a silent no-op, and forcing a rebuild would discard the warm-start. `initialize()`/`reset()` are the correct sync points since both create a fresh state.

## Tests

`tests/test_initialize_syncs_guesses.py` — a guess/boundary edited after construction reaches the solver state, and `initialize()` agrees with the historical `reset()` workaround. Verified the two `initialize` guards fail on baseline and pass with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)