### PR TITLE
Add coefficient-override to Cinterp for between-solve retuning

### DIFF
--- a/openscvx/symbolic/expr/math.py
+++ b/openscvx/symbolic/expr/math.py
@@ -1135,23 +1135,40 @@ _CINTERP_METHODS = {
 
 
 class Cinterp(Expr):
-    """1D cubic spline interpolation for symbolic expressions.
+    """1D piecewise-cubic interpolation for symbolic expressions.
 
-    Computes a cubic spline through data points (xp, fp) and evaluates it at
-    query point x.  Spline coefficients are precomputed at construction time
-    via scipy so that JAX evaluation reduces to a segment lookup and
-    polynomial eval.
+    Evaluates a piecewise-cubic polynomial at query point ``x`` by a segment
+    lookup on the fixed breakpoints ``xp`` followed by Horner evaluation.  The
+    polynomial table is held as ``coeffs`` of shape ``(4, n_segments)`` where
+    ``n_segments = len(xp) - 1``; row ``k`` holds the degree-``k`` coefficients,
+    so the value in segment ``i`` at local coordinate ``t = x - xp[i]`` is
+    ``coeffs[0, i] + coeffs[1, i]*t + coeffs[2, i]*t**2 + coeffs[3, i]*t**3``.
+
+    The table can be supplied two ways, and exactly one must be chosen:
+
+    - **Fit from data (default).** Pass ``fp`` (values at the breakpoints) and
+      an optional ``method``; scipy fits the spline once at construction and the
+      coefficients are baked into the compiled function as constants.
+    - **Coefficient override.** Pass ``coeffs`` directly — either a numeric
+      ``(4, n_segments)`` array or a symbolic :class:`~openscvx.Parameter` of
+      that shape.  A symbolic override is *not* baked in: the compiled function
+      gathers the current parameter value at run time, so the interpolated
+      function can be swapped **between solves** — with any host-side fitting
+      method you like — without recompiling.  ``method`` is meaningless with an
+      override and passing it is an error.
 
     Attributes:
         x: Query point at which to evaluate the spline (symbolic expression).
-        xp: 1D array of breakpoints (must be strictly increasing).
-        fp: 1D array of values at the breakpoints (same length as xp).
-        method: Spline method used — ``"cubic"`` (not-a-knot, C2),
+        xp: 1D array of breakpoints (must be strictly increasing). Fixed at
+            construction; it drives the segment lookup and cannot be symbolic.
+        fp: 1D array of values at the breakpoints (fit path only; ``None`` for a
+            coefficient override).
+        method: Spline method used to fit ``fp`` — ``"cubic"`` (not-a-knot, C2),
             ``"pchip"`` (monotonicity-preserving, C1), or ``"akima"`` (C1).
-        coeffs: Precomputed polynomial coefficients, shape (4, n_segments).
-            Row k contains the degree-k coefficients, so the value in segment i
-            at local coordinate t = x - xp[i] is
-            ``coeffs[0, i] + coeffs[1, i]*t + coeffs[2, i]*t**2 + coeffs[3, i]*t**3``.
+            ``None`` for a coefficient override.
+        coeffs: The polynomial table. A numeric ``(4, n_segments)`` array for
+            the fit and numeric-override paths, or the coefficient ``Expr`` for a
+            symbolic override.
 
     Example:
         Interpolate a discrete reference path::
@@ -1173,34 +1190,102 @@ class Cinterp(Expr):
             altitude = ox.State("altitude", shape=(1,))
             rho = ox.Cinterp(altitude[0], alt_data, rho_data, method="pchip")
 
+        Drive the table with a :class:`~openscvx.Parameter` so the interpolated
+        function can be retuned between solves without recompiling. Fit the
+        spline host-side with any scipy method and push its coefficients (scipy
+        stores them highest-degree-first, so reverse to this class's
+        ascending-degree layout)::
+
+            from scipy.interpolate import PchipInterpolator
+
+            xp = np.linspace(0, 1, 11)
+            n_seg = len(xp) - 1
+
+            cs = PchipInterpolator(xp, fp_data)
+            coeffs = ox.Parameter("spline_coeffs", shape=(4, n_seg),
+                                  value=cs.c[::-1])
+
+            progress = ox.State("progress", shape=(1,))
+            ref = ox.Cinterp(progress[0], xp, coeffs=coeffs)
+
+            # ... build and solve the problem, then before the next solve:
+            cs = PchipInterpolator(xp, new_fp_data)
+            problem.parameters["spline_coeffs"] = cs.c[::-1]
+
     !!! note
         `xp` must be strictly increasing.
 
     !!! warning "Extrapolation behavior"
         For query points outside `[xp[0], xp[-1]]`, boundary segment
         polynomials are extrapolated (consistent with scipy defaults).
+
+    !!! warning "Continuity is the caller's responsibility"
+        With a coefficient override the library no longer guarantees that the
+        table describes a continuous function — that is now the caller's job.
+        A table whose segment polynomials disagree at a breakpoint yields a
+        discontinuous dynamics function, which the discretizer will linearize
+        and integrate without complaint, silently degrading accuracy.
     """
 
     def __init__(
         self,
         x: Union[Expr, float, int, np.ndarray],
         xp: Union[np.ndarray, list],
-        fp: Union[np.ndarray, list],
+        fp: Union[np.ndarray, list, None] = None,
         *,
-        method: str = "cubic",
+        coeffs: Union[Expr, np.ndarray, list, None] = None,
+        method: Union[str, None] = None,
         _coeffs: Union[np.ndarray, None] = None,
     ):
         self.x = to_expr(x)
         xp = np.asarray(xp, dtype=float)
-        fp = np.asarray(fp, dtype=float)
+        if xp.ndim != 1:
+            raise ValueError(f"Cinterp xp must be 1D, got shape {xp.shape}")
+        self.xp_np = xp
+        n_seg = xp.shape[0] - 1
 
+        if (fp is None) == (coeffs is None):
+            raise ValueError(
+                "Cinterp requires exactly one of fp or coeffs: pass fp to fit a "
+                "spline through breakpoint values, or coeffs to supply the "
+                "polynomial table directly."
+            )
+
+        if coeffs is not None:
+            # --- Coefficient-override path (numeric array or symbolic Expr). ---
+            if method is not None:
+                raise ValueError(
+                    "Cinterp method is meaningless with a coeffs override "
+                    "(the table is supplied, not fit); drop the method argument."
+                )
+            expected = (4, n_seg)
+            if isinstance(coeffs, Expr):
+                got = coeffs.check_shape()
+                if got != expected:
+                    raise ValueError(
+                        f"Cinterp coeffs must have shape {expected} "
+                        f"(4 by len(xp) - 1), got {got}"
+                    )
+                self.coeffs = coeffs
+            else:
+                arr = np.asarray(coeffs, dtype=float)
+                if arr.shape != expected:
+                    raise ValueError(
+                        f"Cinterp coeffs must have shape {expected} "
+                        f"(4 by len(xp) - 1), got {arr.shape}"
+                    )
+                self.coeffs = arr
+            self.fp_np = None
+            self.method = None
+            return
+
+        # --- Fit path: precompute spline coefficients via scipy. ---
+        method = "cubic" if method is None else method
         if method not in _CINTERP_METHODS:
             raise ValueError(
                 f"Cinterp method must be one of {set(_CINTERP_METHODS)}, got {method!r}"
             )
-
-        if xp.ndim != 1:
-            raise ValueError(f"Cinterp xp must be 1D, got shape {xp.shape}")
+        fp = np.asarray(fp, dtype=float)
         if fp.ndim != 1:
             raise ValueError(f"Cinterp fp must be 1D, got shape {fp.shape}")
         if xp.shape != fp.shape:
@@ -1208,38 +1293,53 @@ class Cinterp(Expr):
                 f"Cinterp xp and fp must have same length, got {xp.shape} vs {fp.shape}"
             )
 
-        self.xp_np = xp
         self.fp_np = fp
         self.method = method
 
         if _coeffs is not None:
             self.coeffs = _coeffs
         else:
-            # Precompute spline coefficients via scipy.
             # scipy returns shape (4, n_seg) with c[0]=cubic, c[1]=quadratic, ...
             # We reorder to ascending-degree layout for Horner evaluation.
             cs = _CINTERP_METHODS[method](xp, fp)
             self.coeffs = cs.c[::-1].copy()  # row 0 = const, row 3 = cubic
 
     def children(self):
+        if isinstance(self.coeffs, Expr):
+            return [self.x, self.coeffs]
         return [self.x]
 
     def canonicalize(self) -> "Expr":
         x = self.x.canonicalize()
-        return Cinterp(x, self.xp_np, self.fp_np, method=self.method, _coeffs=self.coeffs)
+        if isinstance(self.coeffs, Expr):
+            return Cinterp(x, self.xp_np, coeffs=self.coeffs.canonicalize())
+        if self.fp_np is not None:
+            return Cinterp(x, self.xp_np, self.fp_np, method=self.method, _coeffs=self.coeffs)
+        return Cinterp(x, self.xp_np, coeffs=self.coeffs)
 
     def check_shape(self) -> Tuple[int, ...]:
         return self.x.check_shape()
 
     def _hash_into(self, hasher: "hashlib._Hash") -> None:
         hasher.update(b"Cinterp")
-        hasher.update(self.method.encode())
-        hasher.update(self.xp_np.tobytes())
-        hasher.update(self.fp_np.tobytes())
+        if isinstance(self.coeffs, Expr):
+            hasher.update(b"coeffs_expr")
+            hasher.update(self.xp_np.tobytes())
+            self.coeffs._hash_into(hasher)
+        elif self.fp_np is not None:
+            hasher.update(self.method.encode())
+            hasher.update(self.xp_np.tobytes())
+            hasher.update(self.fp_np.tobytes())
+        else:
+            hasher.update(b"coeffs_num")
+            hasher.update(self.xp_np.tobytes())
+            hasher.update(np.asarray(self.coeffs).tobytes())
         self.x._hash_into(hasher)
 
     def __repr__(self) -> str:
-        if self.method == "cubic":
+        if isinstance(self.coeffs, Expr):
+            return f"cinterp({self.x!r}, coeffs={self.coeffs!r})"
+        if self.method == "cubic" or self.method is None:
             return f"cinterp({self.x!r})"
         return f"cinterp({self.x!r}, method={self.method!r})"
 

--- a/openscvx/symbolic/expr/math.py
+++ b/openscvx/symbolic/expr/math.py
@@ -1263,8 +1263,7 @@ class Cinterp(Expr):
                 got = coeffs.check_shape()
                 if got != expected:
                     raise ValueError(
-                        f"Cinterp coeffs must have shape {expected} "
-                        f"(4 by len(xp) - 1), got {got}"
+                        f"Cinterp coeffs must have shape {expected} (4 by len(xp) - 1), got {got}"
                     )
                 self.coeffs = coeffs
             else:

--- a/openscvx/symbolic/lowerers/jax/math.py
+++ b/openscvx/symbolic/lowerers/jax/math.py
@@ -41,6 +41,7 @@ from openscvx.symbolic.expr.math import (
     Square,
     Tan,
 )
+from openscvx.symbolic.expr.expr import Expr
 from openscvx.symbolic.lowerers.jax._registry import visitor  # noqa: F401
 
 
@@ -285,32 +286,45 @@ def _visit_linterp(lowerer, node: Linterp):
 
 @visitor(Cinterp)
 def _visit_cinterp(lowerer, node: Cinterp):
-    """Lower 1D cubic spline interpolation to JAX function.
+    """Lower 1D piecewise-cubic interpolation to a JAX function.
 
-    Evaluates a precomputed cubic spline via segment lookup and Horner's
-    method.  Coefficients are baked in as constants; only the query point
-    is symbolic.  For queries outside the data range the boundary segment
-    polynomial is extrapolated.
+    Evaluates the polynomial table via segment lookup on the fixed breakpoints
+    and Horner's method.  When ``node.coeffs`` is a numeric array it is baked in
+    as a constant; when it is a symbolic ``Expr`` (e.g. a ``Parameter``) it is
+    lowered too and gathered at run time, so the table can change between solves
+    without recompiling.  Either way only ``xp`` is fixed.  For queries outside
+    the data range the boundary segment polynomial is extrapolated.
 
     Args:
-        node: Cinterp expression node with precomputed coeffs and xp_np.
+        node: Cinterp expression node with xp_np and numeric-or-symbolic coeffs.
 
     Returns:
         Function (x, u, node_idx, params) -> interpolated value(s)
     """
     f_x = lowerer.lower(node.x)
     xp = jnp.asarray(node.xp_np)
-    coeffs = jnp.asarray(node.coeffs)  # (4, n_seg)
 
-    def cinterp_fn(x, u, node_idx, params):
-        x_val = f_x(x, u, node_idx, params)
-        # Segment index (clamp to valid range)
+    def evaluate(x_val, coeffs):
+        # Segment index (clamp to valid range), then Horner: c0 + t*(c1 + t*(c2 + t*c3)).
         idx = jnp.searchsorted(xp, x_val, side="right") - 1
         idx = jnp.clip(idx, 0, xp.shape[0] - 2)
         t = x_val - xp[idx]
-        # Horner evaluation: c0 + t*(c1 + t*(c2 + t*c3))
         c = coeffs[:, idx]
         return c[0] + t * (c[1] + t * (c[2] + t * c[3]))
+
+    if isinstance(node.coeffs, Expr):
+        f_coeffs = lowerer.lower(node.coeffs)
+
+        def cinterp_fn(x, u, node_idx, params):
+            coeffs = f_coeffs(x, u, node_idx, params)  # (4, n_seg)
+            return evaluate(f_x(x, u, node_idx, params), coeffs)
+
+        return cinterp_fn
+
+    coeffs = jnp.asarray(node.coeffs)  # (4, n_seg)
+
+    def cinterp_fn(x, u, node_idx, params):
+        return evaluate(f_x(x, u, node_idx, params), coeffs)
 
     return cinterp_fn
 

--- a/openscvx/symbolic/lowerers/jax/math.py
+++ b/openscvx/symbolic/lowerers/jax/math.py
@@ -17,6 +17,8 @@ import jax
 import jax.numpy as jnp
 from jax.scipy.special import logsumexp
 
+from openscvx.symbolic.expr.expr import Expr
+
 # Expression types to handle — uncomment as you paste visitors:
 from openscvx.symbolic.expr.math import (
     Abs,
@@ -41,7 +43,6 @@ from openscvx.symbolic.expr.math import (
     Square,
     Tan,
 )
-from openscvx.symbolic.expr.expr import Expr
 from openscvx.symbolic.lowerers.jax._registry import visitor  # noqa: F401
 
 

--- a/openscvx/symbolic/lowerers/latex/math.py
+++ b/openscvx/symbolic/lowerers/latex/math.py
@@ -171,14 +171,13 @@ def _visit_linterp(lowerer, node: Linterp):
 
 @visitor(Cinterp)
 def _visit_cinterp(lowerer, node: Cinterp):
-    """Render 1-D cubic-spline interpolation as ``\\operatorname{cinterp}(x)``.
+    """Render 1-D piecewise-cubic interpolation as ``\\operatorname{cinterp}(x)``.
 
-    Only the query point is a symbolic operand — the breakpoints and spline
-    coefficients are baked in at construction — so it is the only rendered
-    argument.
+    Only the query point is rendered; the breakpoints and the polynomial table
+    (whether baked-in coefficients or a symbolic override) are structural and
+    stay implicit.
     """
-    args = ", ".join(lowerer.lower(c) for c in node.children())
-    return _call(r"\operatorname{cinterp}", args)
+    return _call(r"\operatorname{cinterp}", lowerer.lower(node.x))
 
 
 @visitor(Bilerp)

--- a/tests/symbolic/expr/test_math.py
+++ b/tests/symbolic/expr/test_math.py
@@ -3533,6 +3533,172 @@ def test_cvxpy_cinterp_not_implemented():
         lowerer.lower(expr)
 
 
+# --- Cinterp: Coefficient Override ---
+
+
+def _reverse_coeffs(cs):
+    """scipy stores coefficients highest-degree-first; Cinterp uses ascending."""
+    return np.asarray(cs.c[::-1], dtype=float)
+
+
+def test_cinterp_numeric_coeffs_override_matches_fit():
+    """A numeric coeffs override reproduces the fitted spline exactly."""
+    import jax.numpy as jnp
+    from scipy.interpolate import CubicSpline
+
+    from openscvx.symbolic.expr import Cinterp, Constant
+    from openscvx.symbolic.lower import lower_to_jax
+
+    xp = np.array([0.0, 1.0, 2.0, 3.0])
+    fp = np.array([0.0, 2.0, 1.0, 3.0])
+    query = np.linspace(0.0, 3.0, 50)
+
+    coeffs = _reverse_coeffs(CubicSpline(xp, fp))
+
+    fitted = lower_to_jax(Cinterp(Constant(query), xp, fp))(None, None, None, None)
+    override = lower_to_jax(Cinterp(Constant(query), xp, coeffs=coeffs))(None, None, None, None)
+
+    assert jnp.allclose(fitted, override)
+
+
+def test_cinterp_symbolic_coeffs_matches_scipy():
+    """Symbolic coeffs (via a Parameter) evaluate to the host-side scipy spline.
+
+    Covers each host-side fitting method: cubic, pchip, akima.
+    """
+    import jax.numpy as jnp
+    from scipy.interpolate import Akima1DInterpolator, CubicSpline, PchipInterpolator
+
+    from openscvx.symbolic.expr import Cinterp, Constant, Parameter
+    from openscvx.symbolic.lower import lower_to_jax
+
+    xp = np.linspace(0.0, 5.0, 8)
+    fp = np.array([0.0, 1.5, 1.0, 2.0, 0.5, 2.5, 1.0, 3.0])
+    n_seg = len(xp) - 1
+    query = np.linspace(0.0, 5.0, 120)
+
+    for fitter in (CubicSpline, PchipInterpolator, Akima1DInterpolator):
+        cs = fitter(xp, fp)
+        coeffs = _reverse_coeffs(cs)
+        param = Parameter("spline_coeffs", shape=(4, n_seg), value=coeffs)
+
+        fn = lower_to_jax(Cinterp(Constant(query), xp, coeffs=param))
+        result = fn(None, None, None, {"spline_coeffs": coeffs})
+
+        assert jnp.allclose(result, cs(query)), fitter.__name__
+
+
+def test_cinterp_symbolic_coeffs_update_between_evals_no_recompile():
+    """Updating the parameter value changes the SAME lowered function's output."""
+    import jax.numpy as jnp
+    from scipy.interpolate import PchipInterpolator
+
+    from openscvx.symbolic.expr import Cinterp, Constant, Parameter
+    from openscvx.symbolic.lower import lower_to_jax
+
+    xp = np.linspace(0.0, 1.0, 6)
+    n_seg = len(xp) - 1
+    query = np.linspace(0.0, 1.0, 40)
+
+    fp_a = np.array([0.0, 0.4, 0.2, 0.9, 0.3, 1.0])
+    fp_b = np.array([1.0, 0.2, 0.7, 0.1, 0.8, 0.0])
+    cs_a = PchipInterpolator(xp, fp_a)
+    cs_b = PchipInterpolator(xp, fp_b)
+
+    param = Parameter("c", shape=(4, n_seg), value=_reverse_coeffs(cs_a))
+    fn = lower_to_jax(Cinterp(Constant(query), xp, coeffs=param))
+
+    result_a = fn(None, None, None, {"c": _reverse_coeffs(cs_a)})
+    result_b = fn(None, None, None, {"c": _reverse_coeffs(cs_b)})
+
+    assert jnp.allclose(result_a, cs_a(query))
+    assert jnp.allclose(result_b, cs_b(query))
+    assert not jnp.allclose(result_a, result_b)
+
+
+def test_cinterp_symbolic_coeffs_children_and_canonicalize():
+    """Symbolic coeffs appear as a child (so the Parameter binds) and survive canonicalize."""
+    from openscvx.symbolic.expr import Cinterp, Parameter, State
+
+    xp = np.array([0.0, 1.0, 2.0, 3.0])
+    n_seg = len(xp) - 1
+    param = Parameter("c", shape=(4, n_seg), value=np.ones((4, n_seg)))
+
+    state = State("s", shape=(1,))
+    interp = Cinterp(state[0], xp, coeffs=param)
+
+    children = interp.children()
+    assert len(children) == 2
+    assert param in children
+
+    canonical = interp.canonicalize()
+    assert isinstance(canonical, Cinterp)
+    assert isinstance(canonical.coeffs, Parameter)
+    assert canonical.coeffs.name == "c"
+    assert canonical.fp_np is None
+    assert canonical.method is None
+
+
+# --- Cinterp: Coefficient-Override Validation ---
+
+
+def test_cinterp_coeffs_wrong_shape():
+    """A coeffs table that is not (4, len(xp) - 1) raises, stating the expected shape."""
+    from openscvx.symbolic.expr import Cinterp, State
+
+    xp = np.array([0.0, 1.0, 2.0, 3.0])  # n_seg = 3, expected (4, 3)
+    x = State("s", shape=(1,))[0]
+
+    with pytest.raises(ValueError, match=r"Cinterp coeffs must have shape \(4, 3\)"):
+        Cinterp(x, xp, coeffs=np.ones((4, 5)))
+
+
+def test_cinterp_symbolic_coeffs_wrong_shape():
+    """A Parameter of the wrong shape raises, stating the expected shape."""
+    from openscvx.symbolic.expr import Cinterp, Parameter, State
+
+    xp = np.array([0.0, 1.0, 2.0, 3.0])  # expected (4, 3)
+    x = State("s", shape=(1,))[0]
+    param = Parameter("c", shape=(3, 3), value=np.ones((3, 3)))
+
+    with pytest.raises(ValueError, match=r"Cinterp coeffs must have shape \(4, 3\)"):
+        Cinterp(x, xp, coeffs=param)
+
+
+def test_cinterp_both_fp_and_coeffs():
+    """Passing both fp and coeffs is ambiguous and raises."""
+    from openscvx.symbolic.expr import Cinterp, State
+
+    xp = np.array([0.0, 1.0, 2.0, 3.0])
+    fp = np.array([0.0, 1.0, 2.0, 3.0])
+    x = State("s", shape=(1,))[0]
+
+    with pytest.raises(ValueError, match="exactly one of fp or coeffs"):
+        Cinterp(x, xp, fp, coeffs=np.ones((4, 3)))
+
+
+def test_cinterp_neither_fp_nor_coeffs():
+    """Passing neither fp nor coeffs raises."""
+    from openscvx.symbolic.expr import Cinterp, State
+
+    xp = np.array([0.0, 1.0, 2.0, 3.0])
+    x = State("s", shape=(1,))[0]
+
+    with pytest.raises(ValueError, match="exactly one of fp or coeffs"):
+        Cinterp(x, xp)
+
+
+def test_cinterp_method_with_coeffs_rejected():
+    """method is meaningless with a coeffs override and is rejected."""
+    from openscvx.symbolic.expr import Cinterp, State
+
+    xp = np.array([0.0, 1.0, 2.0, 3.0])
+    x = State("s", shape=(1,))[0]
+
+    with pytest.raises(ValueError, match="method is meaningless with a coeffs override"):
+        Cinterp(x, xp, coeffs=np.ones((4, 3)), method="pchip")
+
+
 # =============================================================================
 # Bilerp (2D Bilinear Interpolation)
 # =============================================================================


### PR DESCRIPTION
## Why

`Cinterp` fits spline coefficients once at construction and bakes them into the compiled function as constants, so the only way to change an interpolated function is to redefine the problem and recompile. That is wasteful whenever a reference path or tabulated curve needs retuning between solves — warm-started MPC, parameter sweeps, and interactive examples where the user edits geometry while the SCP loop keeps running.

## What

Extends `Cinterp` itself (no parallel node) with a **coefficient override**: pass the `(4, n_seg)` polynomial table directly instead of `fp`, either as a numeric array or as a symbolic Expr — in practice an `ox.Parameter`:

```python
cs = PchipInterpolator(xp, fp_data)                     # any scipy method, host-side
coeffs = ox.Parameter("spline_coeffs", shape=(4, len(xp) - 1), value=cs.c[::-1])
ref = ox.Cinterp(progress[0], xp, coeffs=coeffs)

# ... between solves:
problem.parameters["spline_coeffs"] = PchipInterpolator(xp, new_fp).c[::-1]
```

A symbolic override is lowered like any Parameter — gathered from the params dict at run time — so swapping the table never recompiles. Fitting moves host-side, which is what makes the feature method-agnostic: cubic, PCHIP, Akima, or anything else that produces a piecewise-cubic table.

Design points:

- Exactly one of `fp` / `coeffs` is required; `method` alongside `coeffs` is rejected (it only governs fitting). `method`'s default became a `None` sentinel (normalized to `"cubic"` on the fit path) so an explicit `method` is distinguishable from a defaulted one.
- `xp` stays numeric/fixed — it is structural (drives the segment lookup).
- Symbolic coeffs join `children()` so parser traversal binds the Parameter; canonicalize, hashing, `repr`, and the LaTeX lowerer handle the new form. The numeric fit path is unchanged, including its hash bytes.
- SCP linearizes w.r.t. states and controls only, so no gradients ever flow through the fitting — only exact derivatives w.r.t. the query point, which come from the coefficients regardless of who computed them.
- With an override, continuity of the table becomes the caller's responsibility; the docstring warns that a discontinuous table degrades the discretizer silently.

## Tests

9 new tests in `tests/symbolic/expr/test_math.py`: scipy parity for cubic/PCHIP/Akima through a `Parameter`, parameter update between two evaluations of the same lowered function (no recompile), numeric-override regression, and validation errors (shape, both/neither, method+coeffs). Targeted runs: 29 passed (cinterp), 412 passed (math/latex/hashing/parameters), 67 passed (parser/jax lowering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdMsrPCbaCSD4sHMkQta7a