### PR TITLE
Reformat docs code blocks with ruff 0.16

### DIFF
--- a/docs/Foundations/control_parameterization.md
+++ b/docs/Foundations/control_parameterization.md
@@ -44,8 +44,9 @@ discretizer:
 import openscvx as ox
 
 problem = ox.Problem(
-    dynamics, ...,
-    discretizer={"dis_type": "ZOH"},   # or "FOH" (default)
+    dynamics,
+    ...,
+    discretizer={"dis_type": "ZOH"},  # or "FOH" (default)
 )
 ```
 

--- a/docs/Foundations/discretization.md
+++ b/docs/Foundations/discretization.md
@@ -8,78 +8,87 @@ description: >-
 # Exact Discretization
 
 ``` py title="dVdt.py"
-def dVdt(self,
-             tau: float,
-             V: jnp.ndarray,
-             u_cur: np.ndarray,
-             u_next: np.ndarray
-             ) -> jnp.ndarray:
-        """
-        Computes the time derivative of the augmented state vector for the system for a sequence of states.
+def dVdt(self, tau: float, V: jnp.ndarray, u_cur: np.ndarray, u_next: np.ndarray) -> jnp.ndarray:
+    """
+    Computes the time derivative of the augmented state vector for the system for a sequence of states.
 
-        Parameters:
-        tau (float): Current time.
-        V (np.ndarray): Sequence of augmented state vectors.
-        u_cur (np.ndarray): Sequence of current control inputs.
-        u_next (np.ndarray): Sequence of next control inputs.
-        A: Function that computes the Jacobian of the system dynamics with respect to the state.
-        B: Function that computes the Jacobian of the system dynamics with respect to the control input.
-        obstacles: List of obstacles in the environment.
-        params (dict): Parameters of the system.
+    Parameters:
+    tau (float): Current time.
+    V (np.ndarray): Sequence of augmented state vectors.
+    u_cur (np.ndarray): Sequence of current control inputs.
+    u_next (np.ndarray): Sequence of next control inputs.
+    A: Function that computes the Jacobian of the system dynamics with respect to the state.
+    B: Function that computes the Jacobian of the system dynamics with respect to the control input.
+    obstacles: List of obstacles in the environment.
+    params (dict): Parameters of the system.
 
-        Returns:
-        np.ndarray: Time derivatives of the augmented state vectors.
-        """
-        
-        # Extract the number of states and controls from the parameters
-        n_x = self.params.sim.n_states
-        n_u = self.params.sim.n_controls
+    Returns:
+    np.ndarray: Time derivatives of the augmented state vectors.
+    """
 
-        # Unflatten V
-        V = V.reshape(-1, self.i5)
+    # Extract the number of states and controls from the parameters
+    n_x = self.params.sim.n_states
+    n_u = self.params.sim.n_controls
 
-        # Compute the interpolation factor based on the discretization type
-        if self.dis_type == 'ZOH':
-            beta = 0.
-        elif self.dis_type == 'FOH':
-            beta = (tau) * self.params.sim.n
-        alpha = 1 - beta
+    # Unflatten V
+    V = V.reshape(-1, self.i5)
 
-        # Interpolate the control input
-        u = u_cur + beta * (u_next - u_cur)
-        s = u[:,-1]
+    # Compute the interpolation factor based on the discretization type
+    if self.dis_type == "ZOH":
+        beta = 0.0
+    elif self.dis_type == "FOH":
+        beta = (tau) * self.params.sim.n
+    alpha = 1 - beta
 
-        # Initialize the augmented Jacobians
-        dfdx = jnp.zeros((V.shape[0], n_x, n_x))
-        dfdu = jnp.zeros((V.shape[0], n_x, n_u))
+    # Interpolate the control input
+    u = u_cur + beta * (u_next - u_cur)
+    s = u[:, -1]
 
-        # Ensure x_seq and u have the same batch size
-        x = V[:,:self.params.sim.n_states]
-        u = u[:x.shape[0]]
+    # Initialize the augmented Jacobians
+    dfdx = jnp.zeros((V.shape[0], n_x, n_x))
+    dfdu = jnp.zeros((V.shape[0], n_x, n_u))
 
-        # Compute the nonlinear propagation term
-        f = self.params.dyn.state_dot(x, u[:,:-1])
-        F = s[:, None] * f
+    # Ensure x_seq and u have the same batch size
+    x = V[:, : self.params.sim.n_states]
+    u = u[: x.shape[0]]
 
-        # Evaluate the State Jacobian
-        dfdx = self.params.dyn.A(x, u[:,:-1])
-        sdfdx = s[:, None, None] * dfdx
+    # Compute the nonlinear propagation term
+    f = self.params.dyn.state_dot(x, u[:, :-1])
+    F = s[:, None] * f
 
-        # Evaluate the Control Jacobian
-        dfdu_veh = self.params.dyn.B(x, u[:,:-1])
-        dfdu = dfdu.at[:, :, :-1].set(s[:, None, None] * dfdu_veh)
-        dfdu = dfdu.at[:, :, -1].set(f)
-        
-        # Compute the defect
-        z = F - jnp.einsum('ijk,ik->ij', sdfdx, x) - jnp.einsum('ijk,ik->ij', dfdu, u)
+    # Evaluate the State Jacobian
+    dfdx = self.params.dyn.A(x, u[:, :-1])
+    sdfdx = s[:, None, None] * dfdx
 
-        # Stack up the results into the augmented state vector
-        dVdt = jnp.zeros_like(V)
-        dVdt = dVdt.at[:, self.i0:self.i1].set(F)
-        dVdt = dVdt.at[:, self.i1:self.i2].set(jnp.matmul(sdfdx, V[:, self.i1:self.i2].reshape(-1, n_x, n_x)).reshape(-1, n_x * n_x))
-        dVdt = dVdt.at[:, self.i2:self.i3].set((jnp.matmul(sdfdx, V[:, self.i2:self.i3].reshape(-1, n_x, n_u)) + dfdu * alpha).reshape(-1, n_x * n_u))
-        dVdt = dVdt.at[:, self.i3:self.i4].set((jnp.matmul(sdfdx, V[:, self.i3:self.i4].reshape(-1, n_x, n_u)) + dfdu * beta).reshape(-1, n_x * n_u))
-        dVdt = dVdt.at[:, self.i4:self.i5].set((jnp.matmul(sdfdx, V[:, self.i4:self.i5].reshape(-1, n_x)[..., None]).squeeze(-1) + z).reshape(-1, n_x))
-        return dVdt.flatten()
+    # Evaluate the Control Jacobian
+    dfdu_veh = self.params.dyn.B(x, u[:, :-1])
+    dfdu = dfdu.at[:, :, :-1].set(s[:, None, None] * dfdu_veh)
+    dfdu = dfdu.at[:, :, -1].set(f)
+
+    # Compute the defect
+    z = F - jnp.einsum("ijk,ik->ij", sdfdx, x) - jnp.einsum("ijk,ik->ij", dfdu, u)
+
+    # Stack up the results into the augmented state vector
+    dVdt = jnp.zeros_like(V)
+    dVdt = dVdt.at[:, self.i0 : self.i1].set(F)
+    dVdt = dVdt.at[:, self.i1 : self.i2].set(
+        jnp.matmul(sdfdx, V[:, self.i1 : self.i2].reshape(-1, n_x, n_x)).reshape(-1, n_x * n_x)
+    )
+    dVdt = dVdt.at[:, self.i2 : self.i3].set(
+        (jnp.matmul(sdfdx, V[:, self.i2 : self.i3].reshape(-1, n_x, n_u)) + dfdu * alpha).reshape(
+            -1, n_x * n_u
+        )
+    )
+    dVdt = dVdt.at[:, self.i3 : self.i4].set(
+        (jnp.matmul(sdfdx, V[:, self.i3 : self.i4].reshape(-1, n_x, n_u)) + dfdu * beta).reshape(
+            -1, n_x * n_u
+        )
+    )
+    dVdt = dVdt.at[:, self.i4 : self.i5].set(
+        (
+            jnp.matmul(sdfdx, V[:, self.i4 : self.i5].reshape(-1, n_x)[..., None]).squeeze(-1) + z
+        ).reshape(-1, n_x)
+    )
+    return dVdt.flatten()
 ```
     

--- a/docs/Foundations/ocp.md
+++ b/docs/Foundations/ocp.md
@@ -18,21 +18,21 @@ The problem is defined as a function that takes in a `Config` object, which cont
 The state, constrol and additional parameters are defined as follows:
 
 ```python
+lam_prox = cp.Parameter(nonneg=True, name="lam_prox")  # Weight on the Trust Region
+lam_cost = cp.Parameter(nonneg=True, name="lam_cost")  # Weight on the Nonlinear Cost
+lam_vc = cp.Parameter(
+    (params.sim.n - 1, params.sim.n_states), nonneg=True, name="lam_vc"
+)  # Weight on Virtual Control
+lam_vb = cp.Parameter(nonneg=True, name="lam_vb")  # Weight on Virtual Buffer
 
-lam_prox = cp.Parameter(nonneg = True, name='lam_prox')       # Weight on the Trust Region
-lam_cost = cp.Parameter(nonneg=True, name='lam_cost') # Weight on the Nonlinear Cost
-lam_vc = cp.Parameter((params.sim.n - 1, params.sim.n_states), nonneg=True, name='lam_vc')  # Weight on Virtual Control
-lam_vb = cp.Parameter(nonneg=True, name='lam_vb')     # Weight on Virtual Buffer
-
-x = cp.Variable((params.sim.n, params.sim.n_states), name='x')   # State
-dx = cp.Variable((params.sim.n, params.sim.n_states), name='dx') # State Trust Region
-x_bar = cp.Parameter((params.sim.n, params.sim.n_states), name='x_bar') # Previous SCP State
+x = cp.Variable((params.sim.n, params.sim.n_states), name="x")  # State
+dx = cp.Variable((params.sim.n, params.sim.n_states), name="dx")  # State Trust Region
+x_bar = cp.Parameter((params.sim.n, params.sim.n_states), name="x_bar")  # Previous SCP State
 
 
-u = cp.Variable((params.sim.n, params.sim.n_controls), name='u')   # Control
-du = cp.Variable((params.sim.n, params.sim.n_controls), name='du') # Control Trust Region
-u_bar = cp.Parameter((params.sim.n, params.sim.n_controls), name='u_bar') # Previous SCP Control
-
+u = cp.Variable((params.sim.n, params.sim.n_controls), name="u")  # Control
+du = cp.Variable((params.sim.n, params.sim.n_controls), name="du")  # Control Trust Region
+u_bar = cp.Parameter((params.sim.n, params.sim.n_controls), name="u_bar")  # Previous SCP Control
 ```
 
 ## Scaling Definitions
@@ -104,15 +104,15 @@ def OptimalControlProblem(params: Config):
     ########################
 
     # Parameters
-    lam_prox = cp.Parameter(nonneg = True, name='lam_prox')
-    lam_cost = cp.Parameter(nonneg=True, name='lam_cost')
-    lam_vc = cp.Parameter((params.sim.n - 1, params.sim.n_states), nonneg=True, name='lam_vc')
-    lam_vb = cp.Parameter(nonneg=True, name='lam_vb')
+    lam_prox = cp.Parameter(nonneg=True, name="lam_prox")
+    lam_cost = cp.Parameter(nonneg=True, name="lam_cost")
+    lam_vc = cp.Parameter((params.sim.n - 1, params.sim.n_states), nonneg=True, name="lam_vc")
+    lam_vb = cp.Parameter(nonneg=True, name="lam_vb")
 
     # State
-    x = cp.Variable((params.sim.n, params.sim.n_states), name='x') 
-    dx = cp.Variable((params.sim.n, params.sim.n_states), name='dx') # State Trust Region
-    x_bar = cp.Parameter((params.sim.n, params.sim.n_states), name='x_bar') # Previous SCP State
+    x = cp.Variable((params.sim.n, params.sim.n_states), name="x")
+    dx = cp.Variable((params.sim.n, params.sim.n_states), name="dx")  # State Trust Region
+    x_bar = cp.Parameter((params.sim.n, params.sim.n_states), name="x_bar")  # Previous SCP State
 
     # Affine Scaling for State
     S_x = params.sim.S_x
@@ -120,9 +120,11 @@ def OptimalControlProblem(params: Config):
     c_x = params.sim.c_x
 
     # Control
-    u = cp.Variable((params.sim.n, params.sim.n_controls), name='u') 
-    du = cp.Variable((params.sim.n, params.sim.n_controls), name='du') # Control Trust Region
-    u_bar = cp.Parameter((params.sim.n, params.sim.n_controls), name='u_bar') # Previous SCP Control
+    u = cp.Variable((params.sim.n, params.sim.n_controls), name="u")
+    du = cp.Variable((params.sim.n, params.sim.n_controls), name="du")  # Control Trust Region
+    u_bar = cp.Parameter(
+        (params.sim.n, params.sim.n_controls), name="u_bar"
+    )  # Previous SCP Control
 
     # Affine Scaling for Control
     S_u = params.sim.S_u
@@ -130,11 +132,11 @@ def OptimalControlProblem(params: Config):
     c_u = params.sim.c_u
 
     # Discretized Augmented Dynamics Constraints
-    A_d = cp.Parameter((params.sim.n - 1, params.sim.n_states, params.sim.n_states), name='A_d')
-    B_d = cp.Parameter((params.sim.n - 1, params.sim.n_states, params.sim.n_controls), name='B_d')
-    C_d = cp.Parameter((params.sim.n - 1, params.sim.n_states, params.sim.n_controls), name='C_d')
-    z_d = cp.Parameter((params.sim.n - 1, params.sim.n_states), name='z_d')
-    nu  = cp.Variable((params.sim.n - 1, params.sim.n_states), name='nu') # Virtual Control
+    A_d = cp.Parameter((params.sim.n - 1, params.sim.n_states, params.sim.n_states), name="A_d")
+    B_d = cp.Parameter((params.sim.n - 1, params.sim.n_states, params.sim.n_controls), name="B_d")
+    C_d = cp.Parameter((params.sim.n - 1, params.sim.n_states, params.sim.n_controls), name="C_d")
+    z_d = cp.Parameter((params.sim.n - 1, params.sim.n_states), name="z_d")
+    nu = cp.Variable((params.sim.n - 1, params.sim.n_states), name="nu")  # Virtual Control
 
     # Linearized Nonconvex Nodal Constraints
     if params.sim.constraints_nodal:
@@ -144,10 +146,20 @@ def OptimalControlProblem(params: Config):
         nu_vb = []
         for idx_ncvx, constraint in enumerate(params.sim.constraints_nodal):
             if not constraint.convex:
-                g.append(cp.Parameter(params.sim.n, name = 'g_' + str(idx_ncvx)))
-                grad_g_x.append(cp.Parameter((params.sim.n, params.sim.n_states), name='grad_g_x_' + str(idx_ncvx)))
-                grad_g_u.append(cp.Parameter((params.sim.n, params.sim.n_controls), name='grad_g_u_' + str(idx_ncvx)))
-                nu_vb.append(cp.Variable(params.sim.n, name='nu_vb_' + str(idx_ncvx))) # Virtual Control for VB
+                g.append(cp.Parameter(params.sim.n, name="g_" + str(idx_ncvx)))
+                grad_g_x.append(
+                    cp.Parameter(
+                        (params.sim.n, params.sim.n_states), name="grad_g_x_" + str(idx_ncvx)
+                    )
+                )
+                grad_g_u.append(
+                    cp.Parameter(
+                        (params.sim.n, params.sim.n_controls), name="grad_g_u_" + str(idx_ncvx)
+                    )
+                )
+                nu_vb.append(
+                    cp.Variable(params.sim.n, name="nu_vb_" + str(idx_ncvx))
+                )  # Virtual Control for VB
 
     # Applying the affine scaling to state and control
     x_nonscaled = []
@@ -174,50 +186,90 @@ def OptimalControlProblem(params: Config):
                 constr += [constraint(x_nonscaled[node], u_nonscaled[node]) for node in nodes]
 
             elif not constraint.convex:
-                constr += [((g[idx_ncvx][node] + grad_g_x[idx_ncvx][node] @ dx[node] + grad_g_u[idx_ncvx][node] @ du[node])) == nu_vb[idx_ncvx][node] for node in nodes]
+                constr += [
+                    (
+                        g[idx_ncvx][node]
+                        + grad_g_x[idx_ncvx][node] @ dx[node]
+                        + grad_g_u[idx_ncvx][node] @ du[node]
+                    )
+                    == nu_vb[idx_ncvx][node]
+                    for node in nodes
+                ]
                 idx_ncvx += 1
 
     for i in range(params.sim.idx_x_true.start, params.sim.idx_x_true.stop):
-        if params.sim.initial_state.type[i] == 'Fix':
-            constr += [x_nonscaled[0][i] == params.sim.initial_state.value[i]]  # Initial Boundary Conditions
-        if params.sim.final_state.type[i] == 'Fix':
-            constr += [x_nonscaled[-1][i] == params.sim.final_state.value[i]]   # Final Boundary Conditions
-        if params.sim.initial_state.type[i] == 'Minimize':
+        if params.sim.initial_state.type[i] == "Fix":
+            constr += [
+                x_nonscaled[0][i] == params.sim.initial_state.value[i]
+            ]  # Initial Boundary Conditions
+        if params.sim.final_state.type[i] == "Fix":
+            constr += [
+                x_nonscaled[-1][i] == params.sim.final_state.value[i]
+            ]  # Final Boundary Conditions
+        if params.sim.initial_state.type[i] == "Minimize":
             cost += lam_cost * x_nonscaled[0][i]
-        if params.sim.final_state.type[i] == 'Minimize':
+        if params.sim.final_state.type[i] == "Minimize":
             cost += lam_cost * x_nonscaled[-1][i]
-        if params.sim.initial_state.type[i] == 'Maximize':
+        if params.sim.initial_state.type[i] == "Maximize":
             cost += lam_cost * x_nonscaled[0][i]
-        if params.sim.final_state.type[i] == 'Maximize':
+        if params.sim.final_state.type[i] == "Maximize":
             cost += lam_cost * x_nonscaled[-1][i]
 
     if params.sim._uniform_time_grid:
-        constr += [x_nonscaled[i][params.sim.idx_t] - x_nonscaled[i-1][params.sim.idx_t] == x_nonscaled[i-1][params.sim.idx_t] - x_nonscaled[i-2][params.sim.idx_t] for i in range(2, params.sim.n)] # Uniform Time Step
+        constr += [
+            x_nonscaled[i][params.sim.idx_t] - x_nonscaled[i - 1][params.sim.idx_t]
+            == x_nonscaled[i - 1][params.sim.idx_t] - x_nonscaled[i - 2][params.sim.idx_t]
+            for i in range(2, params.sim.n)
+        ]  # Uniform Time Step
 
-    constr += [0 == la.inv(S_x) @ (x_nonscaled[i] - x_bar[i] - dx[i]) for i in range(params.sim.n)] # State Error
-    constr += [0 == la.inv(S_u) @ (u_nonscaled[i] - u_bar[i] - du[i]) for i in range(params.sim.n)] # Control Error
+    constr += [
+        0 == la.inv(S_x) @ (x_nonscaled[i] - x_bar[i] - dx[i]) for i in range(params.sim.n)
+    ]  # State Error
+    constr += [
+        0 == la.inv(S_u) @ (u_nonscaled[i] - u_bar[i] - du[i]) for i in range(params.sim.n)
+    ]  # Control Error
 
-    constr += [x_nonscaled[i] == \
-                      A_d[i-1] @ x_nonscaled[i-1] \
-                    + B_d[i-1] @ u_nonscaled[i-1] \
-                    + C_d[i-1] @ u_nonscaled[i] \
-                    + z_d[i-1] \
-                    + nu[i-1] for i in range(1, params.sim.n)] # Dynamics Constraint
-    
+    constr += [
+        x_nonscaled[i]
+        == A_d[i - 1] @ x_nonscaled[i - 1]
+        + B_d[i - 1] @ u_nonscaled[i - 1]
+        + C_d[i - 1] @ u_nonscaled[i]
+        + z_d[i - 1]
+        + nu[i - 1]
+        for i in range(1, params.sim.n)
+    ]  # Dynamics Constraint
+
     constr += [u_nonscaled[i] <= params.sim.max_control for i in range(params.sim.n)]
-    constr += [u_nonscaled[i] >= params.sim.min_control for i in range(params.sim.n)] # Control Constraints
+    constr += [
+        u_nonscaled[i] >= params.sim.min_control for i in range(params.sim.n)
+    ]  # Control Constraints
 
-    constr += [x_nonscaled[i][params.sim.idx_x_true] <= params.sim.max_state[params.sim.idx_x_true] for i in range(params.sim.n)]
-    constr += [x_nonscaled[i][params.sim.idx_x_true] >= params.sim.min_state[params.sim.idx_x_true] for i in range(params.sim.n)] # State Constraints (Also implemented in CTCS but included for numerical stability)
+    constr += [
+        x_nonscaled[i][params.sim.idx_x_true] <= params.sim.max_state[params.sim.idx_x_true]
+        for i in range(params.sim.n)
+    ]
+    constr += [
+        x_nonscaled[i][params.sim.idx_x_true] >= params.sim.min_state[params.sim.idx_x_true]
+        for i in range(params.sim.n)
+    ]  # State Constraints (Also implemented in CTCS but included for numerical stability)
 
     ########
     # COSTS
     ########
-    
-    inv = block([[inv_S_x, np.zeros((S_x.shape[0], S_u.shape[1]))], [np.zeros((S_u.shape[0], S_x.shape[1])), inv_S_u]])
-    cost += sum(lam_prox * cp.sum_squares(inv @ cp.hstack((dx[i], du[i]))) for i in range(params.sim.n))  # Trust Region Cost
-    cost += sum(lam_vc * cp.sum(cp.abs(nu[i-1])) for i in range(1, params.sim.n)) # Virtual Control Slack
-    
+
+    inv = block(
+        [
+            [inv_S_x, np.zeros((S_x.shape[0], S_u.shape[1]))],
+            [np.zeros((S_u.shape[0], S_x.shape[1])), inv_S_u],
+        ]
+    )
+    cost += sum(
+        lam_prox * cp.sum_squares(inv @ cp.hstack((dx[i], du[i]))) for i in range(params.sim.n)
+    )  # Trust Region Cost
+    cost += sum(
+        lam_vc * cp.sum(cp.abs(nu[i - 1])) for i in range(1, params.sim.n)
+    )  # Virtual Control Slack
+
     idx_ncvx = 0
     if params.sim.constraints_nodal:
         for constraint in params.sim.constraints_nodal:
@@ -225,28 +277,32 @@ def OptimalControlProblem(params: Config):
                 cost += lam_vb * cp.sum(cp.pos(nu_vb[idx_ncvx]))
                 idx_ncvx += 1
 
-    for idx, nodes in zip(np.arange(params.sim.idx_y.start, params.sim.idx_y.stop), params.sim.ctcs_node_intervals):  
+    for idx, nodes in zip(
+        np.arange(params.sim.idx_y.start, params.sim.idx_y.stop), params.sim.ctcs_node_intervals
+    ):
         if nodes[0] == 0:
             start_idx = 1
         else:
             start_idx = nodes[0]
-        constr += [cp.abs(x_nonscaled[i][idx] - x_nonscaled[i-1][idx]) <= params.sim.max_state[idx] for i in range(start_idx, nodes[1])]
+        constr += [
+            cp.abs(x_nonscaled[i][idx] - x_nonscaled[i - 1][idx]) <= params.sim.max_state[idx]
+            for i in range(start_idx, nodes[1])
+        ]
         constr += [x_nonscaled[0][idx] == 0]
 
-    
     #########
     # PROBLEM
     #########
     prob = cp.Problem(cp.Minimize(cost), constr)
     if solver.cvxpygen:
         # Check to see if solver directory exists
-        if not os.path.exists('solver'):
-            cpg.generate_code(prob, solver = solver.cvx_solver, code_dir='solver', wrapper = True)
+        if not os.path.exists("solver"):
+            cpg.generate_code(prob, solver=solver.cvx_solver, code_dir="solver", wrapper=True)
         else:
             # Prompt the use to indicate if they wish to overwrite the solver directory or use the existing compiled solver
             overwrite = input("Solver directory already exists. Overwrite? (y/n): ")
-            if overwrite.lower() == 'y':
-                cpg.generate_code(prob, solver = solver.cvx_solver, code_dir='solver', wrapper = True)
+            if overwrite.lower() == "y":
+                cpg.generate_code(prob, solver=solver.cvx_solver, code_dir="solver", wrapper=True)
             else:
                 pass
     return prob

--- a/docs/UnderTheHood/batching_jit_grad.md
+++ b/docs/UnderTheHood/batching_jit_grad.md
@@ -25,9 +25,7 @@ result = problem.solve()
 result = problem.solve_jax()
 
 # Batched — standard jax.vmap, no library-specific API.
-batched = jax.vmap(problem.solve_jax, in_axes=(0, 0, None))(
-    x_initial_stack, x_final_stack, params
-)
+batched = jax.vmap(problem.solve_jax, in_axes=(0, 0, None))(x_initial_stack, x_final_stack, params)
 
 # JIT-compile once, solve forever (e.g. MPC inner loop).
 fast_solve = jax.jit(problem.solve_jax)
@@ -101,10 +99,10 @@ batched inputs agree.)
 
 ```python
 results = problem.solve_batched(
-    x_initial=x0_batch,                  # (B, n_x): rank = declared+1 -> batched
+    x_initial=x0_batch,  # (B, n_x): rank = declared+1 -> batched
     parameters={
-        "gate_center": centers,          # (B, 3) vs declared (3,)  -> batched
-        "gate_radius": 0.5,              # declared shape           -> shared
+        "gate_center": centers,  # (B, 3) vs declared (3,)  -> batched
+        "gate_radius": 0.5,  # declared shape           -> shared
     },
 )
 ```
@@ -117,7 +115,7 @@ fall back to the rank rule):
 
 ```python
 results = problem.solve_batched(
-    parameters={"weights": w},           # (B,) is also w's declared shape...
+    parameters={"weights": w},  # (B,) is also w's declared shape...
     in_axes={"parameters": {"weights": 0}},  # ...so say "batched" explicitly
 )
 
@@ -157,7 +155,7 @@ kwarg's field. Construction-only keys of the constructor dict — `autotuner`,
 
 ```python
 B = 8  # batch size. Just an int for building the arrays below — there is no
-       # B argument; solve_batched infers it from the leading-axis lengths.
+# B argument; solve_batched infers it from the leading-axis lengths.
 sweep = problem.solve_batched(algorithm={"ep_tr": jnp.logspace(-6, -3, B)})
 weights = problem.solve_batched(algorithm={"lam_prox": jnp.array([0.5, 1.0, 4.0])})
 budgets = problem.solve_batched(max_iters=jnp.array([5, 10, 20]))  # per-element caps

--- a/docs/UnderTheHood/custom_algorithms_autotuners.md
+++ b/docs/UnderTheHood/custom_algorithms_autotuners.md
@@ -183,7 +183,7 @@ the rule:
 
 ```python
 def converged(self, state):
-    return state.J_vc < state.ep_vc   # custom: virtual control alone
+    return state.J_vc < state.ep_vc  # custom: virtual control alone
 ```
 
 The default — every metric below its threshold — is algorithm-agnostic, since

--- a/docs/UnderTheHood/lowering_architecture.md
+++ b/docs/UnderTheHood/lowering_architecture.md
@@ -71,12 +71,12 @@ After preprocessing, all symbolic definitions are collected into a `SymbolicProb
 ```python
 @dataclass
 class SymbolicProblem:
-    dynamics: Expr              # Symbolic dx/dt = f(x, u)
-    states: List[State]         # All state variables (including augmented)
-    controls: List[Control]     # All control variables (including virtual)
+    dynamics: Expr  # Symbolic dx/dt = f(x, u)
+    states: List[State]  # All state variables (including augmented)
+    controls: List[Control]  # All control variables (including virtual)
     constraints: ConstraintSet  # Categorized constraints
-    parameters: dict            # User-defined parameters
-    N: int                      # Discretization nodes
+    parameters: dict  # User-defined parameters
+    N: int  # Discretization nodes
     # ... plus propagation variants
 ```
 
@@ -88,20 +88,20 @@ Lowering produces a `LoweredProblem` containing everything needed for optimizati
 @dataclass
 class LoweredProblem:
     # JAX dynamics (callable functions with Jacobians)
-    dynamics: Dynamics           # f, A=df/dx, B=df/du
-    dynamics_prop: Dynamics      # For forward propagation
+    dynamics: Dynamics  # f, A=df/dx, B=df/du
+    dynamics_prop: Dynamics  # For forward propagation
 
     # Lowered constraints (by backend)
     jax_constraints: LoweredJaxConstraints
     cvxpy_constraints: LoweredCvxpyConstraints
 
     # Unified state/control interfaces
-    x_unified: UnifiedState      # Aggregates all states into one vector
-    u_unified: UnifiedControl    # Aggregates all controls into one vector
+    x_unified: UnifiedState  # Aggregates all states into one vector
+    u_unified: UnifiedControl  # Aggregates all controls into one vector
 
     # CVXPy optimization variables
-    ocp_vars: OCPVariables       # x, u, dx, du, nu, etc.
-    cvxpy_params: dict           # User parameters as cp.Parameter
+    ocp_vars: OCPVariables  # x, u, dx, du, nu, etc.
+    cvxpy_params: dict  # User parameters as cp.Parameter
 ```
 
 ## Constraint Routing
@@ -123,9 +123,9 @@ Non-convex constraints become JAX functions with gradients:
 ```python
 @dataclass
 class LoweredJaxConstraints:
-    nodal: List[LoweredNodalConstraint]      # func, grad_g_x, grad_g_u
+    nodal: List[LoweredNodalConstraint]  # func, grad_g_x, grad_g_u
     cross_node: List[LoweredCrossNodeConstraint]  # func, grad_g_X, grad_g_U
-    ctcs: List[CTCS]                         # Handled via dynamics augmentation
+    ctcs: List[CTCS]  # Handled via dynamics augmentation
 ```
 
 ### CVXPy-Lowered Constraints

--- a/docs/UnderTheHood/vectorization_and_vmapping.md
+++ b/docs/UnderTheHood/vectorization_and_vmapping.md
@@ -80,16 +80,16 @@ The unification process (in `openscvx/symbolic/unified.py`) sorts variables (use
 For a problem with `N` decision nodes:
 
 ```python
-x_unified.shape = (n_x,)          # Sum of all state dimensions
-u_unified.shape = (n_u,)          # Sum of all control dimensions
+x_unified.shape = (n_x,)  # Sum of all state dimensions
+u_unified.shape = (n_u,)  # Sum of all control dimensions
 x_unified.guess.shape = (N, n_x)  # State trajectory
 u_unified.guess.shape = (N, n_u)  # Control trajectory
 ```
 
 **Concrete example** (brachistochrone with N=10, no CTCS constraints):
 ```python
-x_unified.shape = (4,)        # position(2) + velocity(1) + time(1)
-u_unified.shape = (2,)        # theta(1) + _time_dilation(1)
+x_unified.shape = (4,)  # position(2) + velocity(1) + time(1)
+u_unified.shape = (2,)  # theta(1) + _time_dilation(1)
 x_unified.guess.shape = (10, 4)
 u_unified.guess.shape = (10, 2)
 ```
@@ -116,9 +116,9 @@ dyn_fn = lower_to_jax(dynamics_aug)
 
 # Create Dynamics object with Jacobians
 dynamics_augmented = Dynamics(
-    f=dyn_fn,                      # State derivative function
-    A=jacfwd(dyn_fn, argnums=0),   # Jacobian df/dx
-    B=jacfwd(dyn_fn, argnums=1),   # Jacobian df/du
+    f=dyn_fn,  # State derivative function
+    A=jacfwd(dyn_fn, argnums=0),  # Jacobian df/dx
+    B=jacfwd(dyn_fn, argnums=1),  # Jacobian df/du
 )
 ```
 
@@ -158,10 +158,10 @@ constraints_nodal_fns = lower_to_jax(constraints_nodal)
 # Create LoweredNodalConstraint objects with Jacobians
 for i, fn in enumerate(constraints_nodal_fns):
     constraint = LoweredNodalConstraint(
-        func=fn,                          # Constraint function
+        func=fn,  # Constraint function
         grad_g_x=jacfwd(fn, argnums=0),  # Jacobian dg/dx
         grad_g_u=jacfwd(fn, argnums=1),  # Jacobian dg/du
-        nodes=constraints_nodal[i].nodes, # Node indices where constraint applies
+        nodes=constraints_nodal[i].nodes,  # Node indices where constraint applies
     )
 ```
 
@@ -239,18 +239,9 @@ Dynamics functions are vmapped to process all intervals in parallel (in `Problem
 
 ```python
 # Vectorize dynamics functions across decision nodes
-self.dynamics_augmented.f = jax.vmap(
-    self.dynamics_augmented.f,
-    in_axes=(0, 0, 0, None)
-)
-self.dynamics_augmented.A = jax.vmap(
-    self.dynamics_augmented.A,
-    in_axes=(0, 0, 0, None)
-)
-self.dynamics_augmented.B = jax.vmap(
-    self.dynamics_augmented.B,
-    in_axes=(0, 0, 0, None)
-)
+self.dynamics_augmented.f = jax.vmap(self.dynamics_augmented.f, in_axes=(0, 0, 0, None))
+self.dynamics_augmented.A = jax.vmap(self.dynamics_augmented.A, in_axes=(0, 0, 0, None))
+self.dynamics_augmented.B = jax.vmap(self.dynamics_augmented.B, in_axes=(0, 0, 0, None))
 ```
 
 **Dynamics Vmap Configuration: `in_axes=(0, 0, 0, None)`**
@@ -372,9 +363,9 @@ Cross-node constraints are **not vmapped** because they already operate on full 
 
 ```python
 # Each LoweredCrossNodeConstraint operates on full trajectories
-residual = constraint.func(X, U, params)      # scalar
-grad_X = constraint.grad_g_X(X, U, params)    # (N, n_x) - sparse, mostly zeros
-grad_U = constraint.grad_g_U(X, U, params)    # (N, n_u) - sparse, mostly zeros
+residual = constraint.func(X, U, params)  # scalar
+grad_X = constraint.grad_g_X(X, U, params)  # (N, n_x) - sparse, mostly zeros
+grad_U = constraint.grad_g_U(X, U, params)  # (N, n_u) - sparse, mostly zeros
 ```
 
 The Jacobians are dense arrays but exhibit sparsity patterns determined by which nodes the constraint couples.
@@ -385,23 +376,23 @@ The vmapped dynamics functions are called during discretization (in `calculate_d
 
 ```python
 # Setup batch inputs
-x = V[:, :n_x]                          # Shape: (N-1, n_x) - States at interval starts
-u = u[: x.shape[0]]                     # Shape: (N-1, n_u) - Controls (includes time dilation)
-nodes = jnp.arange(0, N-1)              # Shape: (N-1,) - Node indices
+x = V[:, :n_x]  # Shape: (N-1, n_x) - States at interval starts
+u = u[: x.shape[0]]  # Shape: (N-1, n_u) - Controls (includes time dilation)
+nodes = jnp.arange(0, N - 1)  # Shape: (N-1,) - Node indices
 
 # Extract time dilation (last control dimension)
-s = u[:, -1]                            # Shape: (N-1,) - Time dilation values
+s = u[:, -1]  # Shape: (N-1,) - Time dilation values
 
 # Call vmapped dynamics - evaluates all intervals in parallel
 # Note: dynamics receive u[:, :-1] (vehicle controls only, excluding time dilation)
 f = state_dot(x, u[:, :-1], nodes, params)  # Shape: (N-1, n_x)
-dfdx = A(x, u[:, :-1], nodes, params)       # Shape: (N-1, n_x, n_x)
-dfdu_veh = B(x, u[:, :-1], nodes, params)   # Shape: (N-1, n_x, n_u-1)
+dfdx = A(x, u[:, :-1], nodes, params)  # Shape: (N-1, n_x, n_x)
+dfdu_veh = B(x, u[:, :-1], nodes, params)  # Shape: (N-1, n_x, n_u-1)
 
 # Build full control Jacobian including time dilation
 dfdu = jnp.zeros((x.shape[0], n_x, n_u))
 dfdu = dfdu.at[:, :, :-1].set(s[:, None, None] * dfdu_veh)  # Vehicle control derivatives
-dfdu = dfdu.at[:, :, -1].set(f)                              # Time dilation derivative = f
+dfdu = dfdu.at[:, :, -1].set(f)  # Time dilation derivative = f
 ```
 
 **Why exclude time dilation from dynamics?** Time dilation is a meta-control that scales the entire dynamics (used for time-optimal problems). The actual vehicle dynamics are defined without it, and time dilation is applied as a scaling factor during discretization. This is why `n_u-1` appears in the vehicle dynamics Jacobians.

--- a/docs/UsersGuide/01_hello_world_brachistochrone.md
+++ b/docs/UsersGuide/01_hello_world_brachistochrone.md
@@ -214,12 +214,7 @@ To mark these as CTCS constraints we simply wrap them in `ox.ctcs(...)`
 # Generate box constraints for all states
 constraints = []
 for state in states:
-    constraints.extend(
-        [
-            ox.ctcs(state <= state.max),
-            ox.ctcs(state.min <= state)
-        ]
-    )
+    constraints.extend([ox.ctcs(state <= state.max), ox.ctcs(state.min <= state)])
 ```
 
 This style of constraint definition as a list should feel familiar to CVXPY users.

--- a/docs/UsersGuide/02_drone_racing_constraints.md
+++ b/docs/UsersGuide/02_drone_racing_constraints.md
@@ -97,10 +97,7 @@ As before, we enforce box constraints on states continuously:
 ```python
 constraints = []
 for state in states:
-    constraints.extend([
-        ox.ctcs(state <= state.max),
-        ox.ctcs(state.min <= state)
-    ])
+    constraints.extend([ox.ctcs(state <= state.max), ox.ctcs(state.min <= state)])
 ```
 
 With our states now in 3D it becomes clear to us why such constraints are also referred to as _path constraints_; we are enforcing the entire path to follow the constraints, not just the discrete nodes.
@@ -114,9 +111,7 @@ We use the `.at([node])` method to specify which nodes the constraint applies to
 
 ```python
 # Gate passage constraint at a specific node
-gate_constraint = (
-    ox.linalg.Norm(A_gate @ position - c_gate, ord="inf") <= 1.0
-).at([node])
+gate_constraint = (ox.linalg.Norm(A_gate @ position - c_gate, ord="inf") <= 1.0).at([node])
 ```
 
 The infinity norm $\lVert \cdot \rVert_\infty$ defines a box-shaped region, which when combined with the scaling matrix `A_gate` creates an ellipsoidal gate region.
@@ -124,9 +119,7 @@ The infinity norm $\lVert \cdot \rVert_\infty$ defines a box-shaped region, whic
 It should be noted that by default constraints are interpreted as nodal constraints, however they are applied to _all_ nodes when not otherwise noted. Writing
 
 ```python
-gate_constraint = (
-    ox.linalg.Norm(A_gate @ position - c_gate, ord="inf") <= 1.0
-)
+gate_constraint = ox.linalg.Norm(A_gate @ position - c_gate, ord="inf") <= 1.0
 ```
 
 would result in all nodes being constrained to lie within the gate.
@@ -164,9 +157,7 @@ The `.over()` method also accepts optional parameters for the penalty function t
 When a constraint is convex, we can mark it with `.convex()`:
 
 ```python
-gate_constraint = (
-    ox.linalg.Norm(A_gate @ position - c_gate, ord="inf") <= 1.0
-).convex().at([node])
+gate_constraint = (ox.linalg.Norm(A_gate @ position - c_gate, ord="inf") <= 1.0).convex().at([node])
 ```
 
 This tells OpenSCvx that no successive convexification is needed for this constraint, it is then lowered directly as a CVXPY constraint when the problem is lowered.
@@ -192,8 +183,8 @@ gate_nodes = np.arange(nodes_per_gate, n, nodes_per_gate)
 for node, center in zip(gate_nodes, gate_centers):
     A_gate_scaled = A_gate @ center  # Pre-scaled center
     gate_constraint = (
-        ox.linalg.Norm(A_gate @ position - A_gate_scaled, ord="inf") <= 1.0
-    ).convex().at([node])
+        (ox.linalg.Norm(A_gate @ position - A_gate_scaled, ord="inf") <= 1.0).convex().at([node])
+    )
     constraints.append(gate_constraint)
 ```
 
@@ -254,11 +245,7 @@ from openscvx.plotting import plot_states, plot_projections_2d
 plot_states(results, ["position", "velocity"]).show()
 
 # 2D projections colored by velocity
-plot_projections_2d(
-    results,
-    var_name="position",
-    velocity_var_name="velocity"
-).show()
+plot_projections_2d(results, var_name="position", velocity_var_name="velocity").show()
 ```
 
 For fully interactive 3D visualization with animated playback, gates, and thrust vectors, OpenSCvx integrates with [viser](https://viser.studio/). See [Tutorial 05: Visualization](05_visualization.md) for details on building rich 3D visualizations.

--- a/docs/UsersGuide/03_obstacle_avoidance_vmap.md
+++ b/docs/UsersGuide/03_obstacle_avoidance_vmap.md
@@ -159,11 +159,10 @@ attitude_normalized = attitude / q_norm
 dynamics = {
     "position": velocity,
     "velocity": (1.0 / m) * ox.spatial.QDCM(attitude_normalized) @ thrust_force
-                + np.array([0, 0, g_const]),
+    + np.array([0, 0, g_const]),
     "attitude": 0.5 * ox.spatial.SSMP(angular_velocity) @ attitude_normalized,
-    "angular_velocity": ox.linalg.Diag(1.0 / J_b) @ (
-        torque - ox.spatial.SSM(angular_velocity) @ ox.linalg.Diag(J_b) @ angular_velocity
-    ),
+    "angular_velocity": ox.linalg.Diag(1.0 / J_b)
+    @ (torque - ox.spatial.SSM(angular_velocity) @ ox.linalg.Diag(J_b) @ angular_velocity),
 }
 ```
 
@@ -225,10 +224,7 @@ constraints = []
 
 # Box constraints on states (as before)
 for state in states:
-    constraints.extend([
-        ox.ctcs(state <= state.max),
-        ox.ctcs(state.min <= state)
-    ])
+    constraints.extend([ox.ctcs(state <= state.max), ox.ctcs(state.min <= state)])
 
 # Obstacle constraints
 for center, A in zip(obstacle_centers, A_obs):
@@ -258,11 +254,11 @@ problem = ox.Problem(
     constraints=constraints,
     N=n,
     algorithm={
-        "lam_prox": 1e1,       # Trust region weight
-        "lam_cost": 1e1,       # Cost objective weight
-        "lam_vc": 1e2,         # Virtual control weight
+        "lam_prox": 1e1,  # Trust region weight
+        "lam_cost": 1e1,  # Cost objective weight
+        "lam_vc": 1e2,  # Virtual control weight
         "autotuner": ox.AugmentedLagrangian(
-            lam_cost_drop=4,     # Iteration to start relaxing cost
+            lam_cost_drop=4,  # Iteration to start relaxing cost
             lam_cost_relax=0.5,  # Cost relaxation factor
         ),
     },
@@ -292,7 +288,7 @@ Consider a 3D grid of obstacles:
 ```python
 n_obstacles = 64  # 4 x 4 x 4 grid
 obstacle_centers = np.array([...])  # Shape: (64, 3)
-obstacle_radii = np.array([...])    # Shape: (64,)
+obstacle_radii = np.array([...])  # Shape: (64,)
 ```
 
 The naive approach creates 64 separate constraints:
@@ -302,9 +298,7 @@ The naive approach creates 64 separate constraints:
 for i in range(n_obstacles):
     center = obstacle_centers[i]
     radius = obstacle_radii[i]
-    constraints.append(
-        ox.ctcs(radius <= ox.linalg.Norm(position - center))
-    )
+    constraints.append(ox.ctcs(radius <= ox.linalg.Norm(position - center)))
 ```
 
 This creates N separate constraint objects, each processed independently. For 64 obstacles this adds overhead; for 2000+ it becomes impractical.
@@ -316,7 +310,8 @@ This creates N separate constraint objects, each processed independently. For 64
 ```python
 # Approach 2: Vmap (vectorized, efficient)
 obstacle_avoidance = ox.ctcs(
-    obstacle_radii <= ox.Vmap(
+    obstacle_radii
+    <= ox.Vmap(
         lambda center: ox.linalg.Norm(position - center),
         batch=obstacle_centers,
     )

--- a/docs/UsersGuide/04_viewpoint_constraints.md
+++ b/docs/UsersGuide/04_viewpoint_constraints.md
@@ -152,11 +152,10 @@ attitude_normalized = attitude / q_norm
 dynamics = {
     "position": velocity,
     "velocity": (1.0 / m) * ox.spatial.QDCM(attitude_normalized) @ thrust_force
-                + np.array([0, 0, g_const]),
+    + np.array([0, 0, g_const]),
     "attitude": 0.5 * ox.spatial.SSMP(angular_velocity) @ attitude_normalized,
-    "angular_velocity": ox.linalg.Diag(1.0 / J_b) @ (
-        torque - ox.spatial.SSM(angular_velocity) @ ox.linalg.Diag(J_b) @ angular_velocity
-    ),
+    "angular_velocity": ox.linalg.Diag(1.0 / J_b)
+    @ (torque - ox.spatial.SSM(angular_velocity) @ ox.linalg.Diag(J_b) @ angular_velocity),
 }
 ```
 
@@ -169,25 +168,31 @@ First, we define our camera parameters and target locations:
 # Camera field-of-view parameters
 alpha_x = 6.0  # Horizontal half-angle (pi/6 radians)
 alpha_y = 6.0  # Vertical half-angle
-A_cone = np.diag([
-    1 / np.tan(np.pi / alpha_x),
-    1 / np.tan(np.pi / alpha_y),
-    0,
-])
+A_cone = np.diag(
+    [
+        1 / np.tan(np.pi / alpha_x),
+        1 / np.tan(np.pi / alpha_y),
+        0,
+    ]
+)
 c_boresight = jnp.array([0, 0, 1])  # Camera points along +z in sensor frame
-R_sensor_body = jnp.array([         # Sensor mounting rotation
-    [0, 1, 0],
-    [0, 0, 1],
-    [1, 0, 0]
-])
+R_sensor_body = jnp.array(
+    [  # Sensor mounting rotation
+        [0, 1, 0],
+        [0, 0, 1],
+        [1, 0, 0],
+    ]
+)
 
 # Generate random target positions
 n_targets = 10
 np.random.seed(0)
-target_positions = np.array([
-    [100.0 + np.random.random() * 20, -60.0 + np.random.random() * 20, 20.0]
-    for _ in range(n_targets)
-])
+target_positions = np.array(
+    [
+        [100.0 + np.random.random() * 20, -60.0 + np.random.random() * 20, 20.0]
+        for _ in range(n_targets)
+    ]
+)
 ```
 
 ### Custom Symbolic Constraint Functions
@@ -226,7 +231,8 @@ visibility = ox.ctcs(
     ox.Vmap(
         lambda target: visibility_constraint(target, position, attitude),
         batch=target_positions,
-    ) <= 0.0
+    )
+    <= 0.0
 )
 ```
 
@@ -258,10 +264,7 @@ constraints = []
 
 # Box constraints on states
 for state in states:
-    constraints.extend([
-        ox.ctcs(state <= state.max),
-        ox.ctcs(state.min <= state)
-    ])
+    constraints.extend([ox.ctcs(state <= state.max), ox.ctcs(state.min <= state)])
 
 # Visibility constraint (all targets, all time)
 constraints.append(visibility)
@@ -269,8 +272,8 @@ constraints.append(visibility)
 # Gate passage constraints (specific nodes)
 for node, center in zip(gate_nodes, gate_centers):
     gate_constraint = (
-        ox.linalg.Norm(A_gate @ position - A_gate @ center, ord="inf") <= 1.0
-    ).convex().at([node])
+        (ox.linalg.Norm(A_gate @ position - A_gate @ center, ord="inf") <= 1.0).convex().at([node])
+    )
     constraints.append(gate_constraint)
 ```
 
@@ -301,10 +304,7 @@ for k in range(n):
     # Quaternion that rotates camera_axis to point at target
     cross = np.cross(camera_axis, to_target)
     dot = np.dot(camera_axis, to_target)
-    q = np.array([
-        np.sqrt(la.norm(to_target)**2 + la.norm(camera_axis)**2) + dot,
-        *cross
-    ])
+    q = np.array([np.sqrt(la.norm(to_target) ** 2 + la.norm(camera_axis) ** 2) + dot, *cross])
     attitude_guess[k] = q / la.norm(q)
 
 attitude.guess = attitude_guess

--- a/docs/UsersGuide/05_visualization.md
+++ b/docs/UsersGuide/05_visualization.md
@@ -71,10 +71,7 @@ plot_projections_2d(results, var_name="position").show()
 
 # Color by velocity magnitude
 plot_projections_2d(
-    results,
-    var_name="position",
-    velocity_var_name="velocity",
-    cmap="viridis"
+    results, var_name="position", velocity_var_name="velocity", cmap="viridis"
 ).show()
 ```
 
@@ -223,7 +220,7 @@ from openscvx.plotting.viser import compute_velocity_colors, create_server
 pos = results.trajectory["position"]
 vel = results.trajectory["velocity"]
 thrust = results.trajectory.get("thrust_force")  # May be None
-attitude = results.trajectory.get("attitude")    # May be None for 3-DOF
+attitude = results.trajectory.get("attitude")  # May be None for 3-DOF
 traj_time = results.trajectory["time"]
 
 # Map velocity magnitude to viridis colormap
@@ -292,21 +289,14 @@ update_callbacks.append(update_trail)
 
 # Current position indicator: use attitude frame for 6-DOF, sphere for 3-DOF
 if attitude is not None:
-    _, update_attitude = add_attitude_frame(
-        server, pos, attitude,
-        axes_length=2.0
-    )
+    _, update_attitude = add_attitude_frame(server, pos, attitude, axes_length=2.0)
     update_callbacks.append(update_attitude)
 else:
     _, update_marker = add_position_marker(server, pos)
     update_callbacks.append(update_marker)
 
 # Thrust vector arrow (body-frame thrust needs attitude)
-_, update_thrust = add_thrust_vector(
-    server, pos, thrust,
-    attitude=attitude,
-    scale=0.3
-)
+_, update_thrust = add_thrust_vector(server, pos, thrust, attitude=attitude, scale=0.3)
 if update_thrust is not None:  # None if thrust data wasn't provided
     update_callbacks.append(update_thrust)
 ```
@@ -317,7 +307,9 @@ For viewplanning problems, you can add a camera viewcone and target markers:
 # Camera field-of-view cone (requires sensor parameters)
 if attitude is not None and "R_sb" in results:
     _, update_viewcone = add_viewcone(
-        server, pos, attitude,
+        server,
+        pos,
+        attitude,
         half_angle_x=np.pi / 6,  # 30 degree half-angle
         half_angle_y=np.pi / 6,
         scale=10.0,
@@ -343,10 +335,12 @@ from openscvx.plotting.viser import add_animated_vector_norm_plot
 
 # Add thrust magnitude plot with bounds and custom folder
 _, update_norm = add_animated_vector_norm_plot(
-    server, results, "thrust_force",
+    server,
+    results,
+    "thrust_force",
     title="Thrust Magnitude",
     bounds=(0.0, max_thrust),  # Show constraint bounds
-    folder_name="Control Plots"  # Organize in GUI folder
+    folder_name="Control Plots",  # Organize in GUI folder
 )
 if update_norm is not None:
     update_callbacks.append(update_norm)
@@ -362,8 +356,10 @@ Finally, connect all the update callbacks to the animation system. This adds pla
 from openscvx.plotting.viser import add_animation_controls
 
 add_animation_controls(
-    server, traj_time, update_callbacks,
-    loop=True  # Loop when animation reaches the end
+    server,
+    traj_time,
+    update_callbacks,
+    loop=True,  # Loop when animation reaches the end
 )
 ```
 
@@ -430,11 +426,13 @@ update_callbacks.append(cb)
 _, cb = add_attitude_frame(server, pos, attitude)
 update_callbacks.append(cb)
 _, cb = add_thrust_vector(server, pos, thrust, attitude=attitude, scale=0.3)
-if cb: update_callbacks.append(cb)
+if cb:
+    update_callbacks.append(cb)
 
 # 5. Embedded Plotly panels (optional)
 _, cb = add_animated_vector_norm_plot(server, results, "thrust_force")
-if cb: update_callbacks.append(cb)
+if cb:
+    update_callbacks.append(cb)
 
 # 6. Wire up controls
 add_animation_controls(server, traj_time, update_callbacks, loop=True)

--- a/docs/UsersGuide/07_lie.md
+++ b/docs/UsersGuide/07_lie.md
@@ -115,15 +115,17 @@ a3 = 0.250  # elbow -> wrist
 a4 = 0.150  # wrist -> end-effector
 
 # Screw axes [v; omega] for each joint, in the base frame at q = 0
-screw_axes = np.array([
-    [0.0,        0.0,        0.0, 0.0, 0.0, 1.0],  # J1 z at origin
-    [-d1,        0.0,        0.0, 0.0, 1.0, 0.0],  # J2 y at [0, 0, d1]
-    [0.0,       -a2,         0.0, 0.0, 0.0, 1.0],  # J3 z at [a2, 0, d1]
-    [-d1,        0.0,         a2, 0.0, 1.0, 0.0],  # J4 y at [a2, 0, d1]
-    [0.0, -(a2 + a3),         0.0, 0.0, 0.0, 1.0],  # J5 z at [a2+a3, ...]
-    [-d1,        0.0,    a2 + a3, 0.0, 1.0, 0.0],  # J6 y
-    [0.0, -(a2 + a3 + a4),    0.0, 0.0, 0.0, 1.0],  # J7 z
-])
+screw_axes = np.array(
+    [
+        [0.0, 0.0, 0.0, 0.0, 0.0, 1.0],  # J1 z at origin
+        [-d1, 0.0, 0.0, 0.0, 1.0, 0.0],  # J2 y at [0, 0, d1]
+        [0.0, -a2, 0.0, 0.0, 0.0, 1.0],  # J3 z at [a2, 0, d1]
+        [-d1, 0.0, a2, 0.0, 1.0, 0.0],  # J4 y at [a2, 0, d1]
+        [0.0, -(a2 + a3), 0.0, 0.0, 0.0, 1.0],  # J5 z at [a2+a3, ...]
+        [-d1, 0.0, a2 + a3, 0.0, 1.0, 0.0],  # J6 y
+        [0.0, -(a2 + a3 + a4), 0.0, 0.0, 0.0, 1.0],  # J7 z
+    ]
+)
 
 # End-effector pose at q = 0
 T_home = np.eye(4)
@@ -207,20 +209,20 @@ q_down = np.array([np.cos(np.pi / 4), 0.0, np.sin(np.pi / 4), 0.0])
 q_identity = np.array([1.0, 0.0, 0.0, 0.0])
 
 pre_height = 0.15
-grasp_pos     = np.array([0.35, -0.25, 0.05])
-place_pos     = np.array([0.35,  0.25, 0.05])
-home_pos      = np.array([a2 + a3 + a4 - 0.01, 0.0, d1])
+grasp_pos = np.array([0.35, -0.25, 0.05])
+place_pos = np.array([0.35, 0.25, 0.05])
+home_pos = np.array([a2 + a3 + a4 - 0.01, 0.0, d1])
 pre_grasp_pos = grasp_pos + np.array([0.0, 0.0, pre_height])
 pre_place_pos = place_pos + np.array([0.0, 0.0, pre_height])
 
-waypoint_names        = ["home", "pre_grasp", "grasp", "pre_grasp", "pre_place", "place"]
-waypoint_positions    = [home_pos, pre_grasp_pos, grasp_pos, pre_grasp_pos, pre_place_pos, place_pos]
+waypoint_names = ["home", "pre_grasp", "grasp", "pre_grasp", "pre_place", "place"]
+waypoint_positions = [home_pos, pre_grasp_pos, grasp_pos, pre_grasp_pos, pre_place_pos, place_pos]
 waypoint_orientations = [q_identity, q_down, q_down, q_down, q_down, q_down]
 
 nodes_per_segment = 2
-n_segments        = len(waypoint_positions) - 1
-n                 = nodes_per_segment * n_segments + 1   # 11 nodes total
-waypoint_nodes    = [i * nodes_per_segment for i in range(len(waypoint_positions))]
+n_segments = len(waypoint_positions) - 1
+n = nodes_per_segment * n_segments + 1  # 11 nodes total
+waypoint_nodes = [i * nodes_per_segment for i in range(len(waypoint_positions))]
 ```
 
 ### Task-Space Constraints
@@ -228,15 +230,17 @@ waypoint_nodes    = [i * nodes_per_segment for i in range(len(waypoint_positions
 Because `p_ee` and `R_ee` are symbolic, we can constrain them directly. We start with the standard box constraints on each state, then enforce a tight position tolerance at each waypoint:
 
 ```python
-states   = [angle, velocity]
+states = [angle, velocity]
 controls = [torque]
 
 constraints = []
 for state in states:
-    constraints.extend([
-        ox.ctcs(state <= state.max),
-        ox.ctcs(state.min <= state),
-    ])
+    constraints.extend(
+        [
+            ox.ctcs(state <= state.max),
+            ox.ctcs(state.min <= state),
+        ]
+    )
 
 # Keep the EE above the table everywhere
 constraints.append(ox.ctcs(p_ee[2] >= 0.0))
@@ -245,9 +249,7 @@ constraints.append(ox.ctcs(p_ee[2] >= 0.0))
 ee_tolerance = 0.01
 for name, wp, node in zip(waypoint_names, waypoint_positions, waypoint_nodes):
     wp_param = ox.Parameter(f"waypoint_{name}", shape=(3,), value=wp)
-    constraints.append(
-        (ox.linalg.Norm(p_ee - wp_param, ord=2) <= ee_tolerance).at([node])
-    )
+    constraints.append((ox.linalg.Norm(p_ee - wp_param, ord=2) <= ee_tolerance).at([node]))
 ```
 
 For orientation we use the $SO(3)$ logarithm, `ox.lie.SO3Log`, which maps a rotation matrix to its $\mathbb{R}^3$ axis–angle representation. The norm of $\log(R_{\text{des}}^\top R_{\text{ee}})$ is the geodesic angle error:
@@ -255,25 +257,21 @@ For orientation we use the $SO(3)$ logarithm, `ox.lie.SO3Log`, which maps a rota
 ```python
 # Build R_des from q_down (the desired downward gripper orientation)
 w, x, y, z = q_down
-R_des = np.array([
-    [1 - 2*(y*y + z*z), 2*(x*y - w*z),     2*(x*z + w*y)],
-    [2*(x*y + w*z),     1 - 2*(x*x + z*z), 2*(y*z - w*x)],
-    [2*(x*z - w*y),     2*(y*z + w*x),     1 - 2*(x*x + y*y)],
-])
+R_des = np.array(
+    [
+        [1 - 2 * (y * y + z * z), 2 * (x * y - w * z), 2 * (x * z + w * y)],
+        [2 * (x * y + w * z), 1 - 2 * (x * x + z * z), 2 * (y * z - w * x)],
+        [2 * (x * z - w * y), 2 * (y * z + w * x), 1 - 2 * (x * x + y * y)],
+    ]
+)
 
 ori_error = ox.lie.SO3Log(R_des.T @ R_ee)
-ori_norm  = ox.linalg.Norm(ori_error, ord=2)
+ori_norm = ox.linalg.Norm(ori_error, ord=2)
 
 # Loose tolerance for the entire task region; tight near grasp/place
-constraints.append(
-    (ori_norm <= np.deg2rad(5.0)).over((waypoint_nodes[1], waypoint_nodes[-1]))
-)
-constraints.append(
-    (ori_norm <= np.deg2rad(0.1)).over((waypoint_nodes[1], waypoint_nodes[3]))
-)
-constraints.append(
-    (ori_norm <= np.deg2rad(0.1)).over((waypoint_nodes[4], waypoint_nodes[5]))
-)
+constraints.append((ori_norm <= np.deg2rad(5.0)).over((waypoint_nodes[1], waypoint_nodes[-1])))
+constraints.append((ori_norm <= np.deg2rad(0.1)).over((waypoint_nodes[1], waypoint_nodes[3])))
+constraints.append((ori_norm <= np.deg2rad(0.1)).over((waypoint_nodes[4], waypoint_nodes[5])))
 ```
 
 These are *continuous-time* constraints: the geodesic error is bounded everywhere along the indicated trajectory segment, not just at the discrete nodes.
@@ -319,9 +317,9 @@ angle.guess = ox.init.ik_interpolation(
     angles_max=angle.max,
     sequential=True,
 )
-angle.initial   = np.clip(angle.guess[0], angle.min, angle.max)
-velocity.guess  = np.zeros((n, N_JOINTS))
-torque.guess    = np.zeros((n, N_JOINTS))
+angle.initial = np.clip(angle.guess[0], angle.min, angle.max)
+velocity.guess = np.zeros((n, N_JOINTS))
+torque.guess = np.zeros((n, N_JOINTS))
 ```
 
 The `sequential=True` flag seeds each node's IK solve from the previous node's solution, producing a coherent joint-space path. The default (`sequential=False`) solves all nodes in parallel from the same seed via `jax.vmap`, giving each node its own independent shot at finding a good local minimum.
@@ -382,16 +380,18 @@ First, lift each keypoint from its home position into the world frame using the 
 
 ```python
 keypoint_home_pos = {
-    "base":     np.array([0.0,          0.0, 0.0, 1.0]),
-    "shoulder": np.array([0.0,          0.0, d1,  1.0]),
-    "elbow":    np.array([a2,           0.0, d1,  1.0]),
-    "wrist":    np.array([a2 + a3,      0.0, d1,  1.0]),
-    "ee":       np.array([a2 + a3 + a4, 0.0, d1,  1.0]),
+    "base": np.array([0.0, 0.0, 0.0, 1.0]),
+    "shoulder": np.array([0.0, 0.0, d1, 1.0]),
+    "elbow": np.array([a2, 0.0, d1, 1.0]),
+    "wrist": np.array([a2 + a3, 0.0, d1, 1.0]),
+    "ee": np.array([a2 + a3 + a4, 0.0, d1, 1.0]),
 }
+
 
 def _keypoint_world(name):
     p_hom = joint_transforms[name] @ ox.Constant(keypoint_home_pos[name])
     return ox.Concat(p_hom[0], p_hom[1], p_hom[2])
+
 
 kp = {name: _keypoint_world(name) for name in joint_names}
 ```
@@ -400,10 +400,10 @@ Then describe each link as `(start, end, radius)`:
 
 ```python
 link_specs = [
-    ("base",     "shoulder", 0.06),
-    ("shoulder", "elbow",    0.05),
-    ("elbow",    "wrist",    0.04),
-    ("wrist",    "ee",       0.035),
+    ("base", "shoulder", 0.06),
+    ("shoulder", "elbow", 0.05),
+    ("elbow", "wrist", 0.04),
+    ("wrist", "ee", 0.035),
 ]
 ```
 
@@ -426,8 +426,7 @@ for i in range(len(link_specs)):
 
         dists = ox.Vmap(
             lambda t, pa0=pa0, pa1=pa1, pb0=pb0, pb1=pb1: ox.linalg.Norm(
-                ((1 - t[0]) * pa0 + t[0] * pa1)
-                - ((1 - t[1]) * pb0 + t[1] * pb1)
+                ((1 - t[0]) * pa0 + t[0] * pa1) - ((1 - t[1]) * pb0 + t[1] * pb1)
             ),
             batch=tt,
         )

--- a/docs/UsersGuide/08_mpcc.md
+++ b/docs/UsersGuide/08_mpcc.md
@@ -311,10 +311,12 @@ controls = [speed, angular_rate, progress_rate]
 
 constraints = []
 for state in [position, heading]:
-    constraints.extend([
-        ox.ctcs(state <= state.max),
-        ox.ctcs(state.min <= state),
-    ])
+    constraints.extend(
+        [
+            ox.ctcs(state <= state.max),
+            ox.ctcs(state.min <= state),
+        ]
+    )
 
 t = ox.Time(
     initial=0.0,
@@ -369,15 +371,15 @@ For the analytical circle we assume a constant speed along the reference and com
 ```python
 def set_initial_guess(theta_start: float = 0.0):
     ref_speed = 5.0
-    arc_guess = np.linspace(
-        theta_start, theta_start + ref_speed * horizon_duration, n_mpc
-    )
+    arc_guess = np.linspace(theta_start, theta_start + ref_speed * horizon_duration, n_mpc)
     angle_guess = arc_guess / R_circle
 
-    position.guess = np.column_stack([
-        R_circle * np.cos(angle_guess),
-        R_circle * np.sin(angle_guess),
-    ])
+    position.guess = np.column_stack(
+        [
+            R_circle * np.cos(angle_guess),
+            R_circle * np.sin(angle_guess),
+        ]
+    )
     heading.guess = (-angle_guess + np.pi / 2).reshape(-1, 1)
     progress.guess = arc_guess.reshape(-1, 1)
     lag_sum.guess = np.zeros((n_mpc, 1))
@@ -400,7 +402,7 @@ For this initial example we will simply repeat this `max_steps` times:
 problem_mpc.initialize()
 
 for step in range(max_steps):
-    problem_mpc.reset() # Clear SCP history
+    problem_mpc.reset()  # Clear SCP history
     results = problem_mpc.solve()
     results = problem_mpc.post_process()
     nodes = results.nodes
@@ -475,9 +477,7 @@ def shift_guess(nodes: dict):
     ar_last = nodes["angular_rate"][-1, 0]
     pr_last = nodes["progress_rate"][-1, 0]
 
-    ext_pos = pos_last + dt * spd_last * np.array([
-        np.sin(hdg_last), np.cos(hdg_last)
-    ])
+    ext_pos = pos_last + dt * spd_last * np.array([np.sin(hdg_last), np.cos(hdg_last)])
     ext_hdg = hdg_last + dt * ar_last
     ext_prog = nodes["progress"][-1, 0] + dt * pr_last
 
@@ -497,26 +497,22 @@ def shift_guess(nodes: dict):
     # Cost integrators: shift and re-zero to preserve the accumulated profile
     lag_offset = nodes["lag_sum"][1]
     lag_sum.guess = np.maximum(
-        np.vstack([nodes["lag_sum"][1:] - lag_offset,
-                    nodes["lag_sum"][-1:] - lag_offset]),
+        np.vstack([nodes["lag_sum"][1:] - lag_offset, nodes["lag_sum"][-1:] - lag_offset]),
         0.0,
     )
 
     contour_offset = nodes["contour_sum"][1]
     contour_sum.guess = np.maximum(
-        np.vstack([nodes["contour_sum"][1:] - contour_offset,
-                    nodes["contour_sum"][-1:] - contour_offset]),
+        np.vstack(
+            [nodes["contour_sum"][1:] - contour_offset, nodes["contour_sum"][-1:] - contour_offset]
+        ),
         0.0,
     )
 
     # Controls: shift forward, repeat last value for the new final node
     speed.guess = np.vstack([nodes["speed"][1:], nodes["speed"][-1:]])
-    angular_rate.guess = np.vstack([
-        nodes["angular_rate"][1:], nodes["angular_rate"][-1:]
-    ])
-    progress_rate.guess = np.vstack([
-        nodes["progress_rate"][1:], nodes["progress_rate"][-1:]
-    ])
+    angular_rate.guess = np.vstack([nodes["angular_rate"][1:], nodes["angular_rate"][-1:]])
+    progress_rate.guess = np.vstack([nodes["progress_rate"][1:], nodes["progress_rate"][-1:]])
 ```
 
 The wrap offsets are computed from node 1 of the previous solution (which becomes node 0 of the new problem) so the whole horizon shifts consistently.
@@ -602,23 +598,25 @@ With a discrete reference we instead interpolate the reference data arrays direc
 
 ```python
 def set_initial_guess(theta_start: float = 0.0, ref_speed: float = 5.0):
-    arc_guess = np.linspace(
-        theta_start, theta_start + ref_speed * horizon_duration, n_mpc
-    )
+    arc_guess = np.linspace(theta_start, theta_start + ref_speed * horizon_duration, n_mpc)
 
     # Position: interpolate from reference sample arrays
-    position.guess = np.column_stack([
-        np.interp(arc_guess, s_data, px_data),
-        np.interp(arc_guess, s_data, py_data),
-    ])
+    position.guess = np.column_stack(
+        [
+            np.interp(arc_guess, s_data, px_data),
+            np.interp(arc_guess, s_data, py_data),
+        ]
+    )
 
     # Heading: infer from reference segment directions
     seg_idx = np.searchsorted(s_data, arc_guess, side="right") - 1
     seg_idx = np.clip(seg_idx, 0, len(s_data) - 2)
-    seg_dp = np.column_stack([
-        px_data[seg_idx + 1] - px_data[seg_idx],
-        py_data[seg_idx + 1] - py_data[seg_idx],
-    ])
+    seg_dp = np.column_stack(
+        [
+            px_data[seg_idx + 1] - px_data[seg_idx],
+            py_data[seg_idx + 1] - py_data[seg_idx],
+        ]
+    )
     hdg_guess = np.arctan2(seg_dp[:, 0], seg_dp[:, 1])
     heading.guess = hdg_guess.reshape(-1, 1)
     heading.initial = np.array([hdg_guess[0]])
@@ -653,8 +651,8 @@ problem_traj.initialize()
 results_traj = problem_traj.solve()
 results_traj = problem_traj.post_process()
 
-ref_pos = results_traj.trajectory["position"]   # (N_dense, 3)
-ref_vel = results_traj.trajectory["velocity"]   # (N_dense, 3)
+ref_pos = results_traj.trajectory["position"]  # (N_dense, 3)
+ref_vel = results_traj.trajectory["velocity"]  # (N_dense, 3)
 ref_time = results_traj.trajectory["time"].flatten()
 ```
 
@@ -700,16 +698,20 @@ def set_initial_guess(theta_start: float = 0.0):
     t_guess = np.linspace(t_start, t_start + horizon_duration, n_mpc)
     arc_guess = np.interp(t_guess, t_data, s_data)
 
-    position.guess = np.column_stack([
-        np.interp(arc_guess, s_data, px_data),
-        np.interp(arc_guess, s_data, py_data),
-        np.interp(arc_guess, s_data, pz_data),
-    ])
-    velocity.guess = np.column_stack([
-        np.interp(arc_guess, s_data, vx_data),
-        np.interp(arc_guess, s_data, vy_data),
-        np.interp(arc_guess, s_data, vz_data),
-    ])
+    position.guess = np.column_stack(
+        [
+            np.interp(arc_guess, s_data, px_data),
+            np.interp(arc_guess, s_data, py_data),
+            np.interp(arc_guess, s_data, pz_data),
+        ]
+    )
+    velocity.guess = np.column_stack(
+        [
+            np.interp(arc_guess, s_data, vx_data),
+            np.interp(arc_guess, s_data, vy_data),
+            np.interp(arc_guess, s_data, vz_data),
+        ]
+    )
     # ... similarly for force, progress_rate
 ```
 
@@ -727,16 +729,20 @@ def shift_guess(nodes: dict):
     ext_prog = np.interp(t_last + dt_mpc, t_data, s_data)
 
     # Look up reference state at the extrapolated progress
-    ext_pos = np.array([
-        np.interp(ext_prog, s_data, px_data),
-        np.interp(ext_prog, s_data, py_data),
-        np.interp(ext_prog, s_data, pz_data),
-    ])
-    ext_vel = np.array([
-        np.interp(ext_prog, s_data, vx_data),
-        np.interp(ext_prog, s_data, vy_data),
-        np.interp(ext_prog, s_data, vz_data),
-    ])
+    ext_pos = np.array(
+        [
+            np.interp(ext_prog, s_data, px_data),
+            np.interp(ext_prog, s_data, py_data),
+            np.interp(ext_prog, s_data, pz_data),
+        ]
+    )
+    ext_vel = np.array(
+        [
+            np.interp(ext_prog, s_data, vx_data),
+            np.interp(ext_prog, s_data, vy_data),
+            np.interp(ext_prog, s_data, vz_data),
+        ]
+    )
     # ... similarly for force, progress_rate
 
     # Shift and wrap as before
@@ -762,9 +768,7 @@ Because we are now running a closed-loop controller we can include additional co
 
 ```python
 for obs_center in obstacle_centers:
-    constraints.append(
-        ox.ctcs(obstacle_radius <= ox.linalg.Norm(position - obs_center))
-    )
+    constraints.append(ox.ctcs(obstacle_radius <= ox.linalg.Norm(position - obs_center)))
 ```
 
 #### Progress-Dependent Gate Constraints
@@ -795,11 +799,13 @@ Putting all this together results in our cone constraints:
 ```python
 cone_constraints = ox.Vmap(
     lambda apex, R_gate, n_hat, s_gate, s_prev: ox.Cond(
-        ox.All([
-            progress[0] >= s_prev,
-            progress[0] <= s_gate,
-            ox.Sum(velocity * n_hat) <= 0.0,
-        ]),
+        ox.All(
+            [
+                progress[0] >= s_prev,
+                progress[0] <= s_gate,
+                ox.Sum(velocity * n_hat) <= 0.0,
+            ]
+        ),
         g_gate_cone(apex, R_gate, position),
         -1.0,  # Inactive: return feasible value
     ),
@@ -816,16 +822,14 @@ To ensure a consistent loop rate, we constrain that time at node 1 is always $t_
 ```python
 t = ox.Time(
     initial=0.0,
-    final=horizon_duration, # Still fixed!
+    final=horizon_duration,  # Still fixed!
     min=0.0,
     max=horizon_duration,
     # Note: uniform_time_grid is NOT set, allowing non-uniform spacing
 )
 
 # Pin node 1 at a fixed dt so the MPC loop rate is constant
-constraints.append(
-    (t == horizon_duration / (n_mpc - 1)).convex().at(1)
-)
+constraints.append((t == horizon_duration / (n_mpc - 1)).convex().at(1))
 ```
 
 We also shift the time and time dilation guesses identically to the other states and controls:
@@ -870,9 +874,7 @@ The obstacle avoidance constraints reference these parameters in the usual way:
 
 ```python
 for obs_center in obstacle_centers:
-    constraints.append(
-        ox.ctcs(obstacle_radius <= ox.linalg.Norm(position - obs_center))
-    )
+    constraints.append(ox.ctcs(obstacle_radius <= ox.linalg.Norm(position - obs_center)))
 ```
 
 When the user clicks and drags an obstacle in the viser 3D view, a callback updates both the parameter value and the problem's parameter store:

--- a/docs/UsersGuide/09_mjx_dynamics.md
+++ b/docs/UsersGuide/09_mjx_dynamics.md
@@ -114,8 +114,8 @@ Set initial and final values on the adapter's states like any other `ox.State`:
 ```python
 qpos.min = np.array([-3.0, -2.0 * np.pi])
 qpos.max = np.array([3.0, 2.0 * np.pi])
-qpos.initial = np.array([0.0, np.pi])   # cart at origin, pole hanging
-qpos.final = np.array([0.0, 0.0])     # upright
+qpos.initial = np.array([0.0, np.pi])  # cart at origin, pole hanging
+qpos.final = np.array([0.0, 0.0])  # upright
 
 qvel.initial = np.zeros(2)
 qvel.final = np.zeros(2)


### PR DESCRIPTION
## Summary

Ruff 0.16 (which CI installs as latest) now formats Python snippets inside fenced code blocks in Markdown files. Since main hasn't been reformatted, every open PR currently fails the lint job with these unrelated docs diffs (e.g. #579).

This PR applies `ruff format` with 0.16.1 once, so the noise disappears from unrelated PRs. Changes are formatting-only, confined to code blocks in `docs/**/*.md` — no library or example code was touched (`ruff check` and `ruff format --check` both pass clean).

Note: CI installs unpinned latest ruff (`uv pip install --system ruff` in `lint.yml`), so this can recur on future ruff releases. Pinning the version there would make lint deterministic — happy to add that here if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AT1qEbBJYHE3U39K876Wqo