### PR TITLE
Allow callable CTCS penalties built from symbolic expressions

### DIFF
--- a/docs/Foundations/constraint_reformulation.md
+++ b/docs/Foundations/constraint_reformulation.md
@@ -29,8 +29,8 @@ $$
 $$
 
 where the default penalty is the squared ReLU $\max(0, g_j)^2$ (Huber and smooth
-ReLU are also available), and $s$ is the [time-dilation](time_dilation.md)
-factor. Because the integrand is non-negative, $y$ is monotonically
+ReLU are also available, or you can [write your own](#custom-penalties)), and $s$
+is the [time-dilation](time_dilation.md) factor. Because the integrand is non-negative, $y$ is monotonically
 non-decreasing and accumulates *any* violation occurring between nodes.
 
 Enforcing $y \equiv 0$ then drives every penalty — and hence every constraint —
@@ -65,6 +65,38 @@ different intervals get separate states. The bound $y_{\max}$ is the constraint'
 `licq_max` (default $10^{-4}$); tighten it for stricter between-node enforcement.
 After solving, the achieved continuous-time violation is reported as
 `results.ctcs_violation`.
+
+## Custom penalties
+
+The built-in penalties are selected by name — `"squared_relu"` (the default),
+`"huber"`, and `"smooth_relu"` — which fixes their shape and their internal
+constants. When you want to tune those constants or shape the penalty yourself,
+pass a callable instead:
+
+```python
+# Widen Huber's quadratic region — not expressible with the string form.
+ox.ctcs(altitude >= 10, penalty=lambda r: ox.Huber(ox.PositivePart(r), delta=0.5))
+
+# Quadratic near the boundary, with a linear tail that keeps pushing far out.
+ox.ctcs(
+    speed <= v_max,
+    penalty=lambda r: ox.Square(ox.PositivePart(r)) + 0.1 * ox.PositivePart(r),
+)
+```
+
+The callable receives the canonicalized residual $g_j(x, u)$ — the constraint
+already rearranged into $g_j \le 0$ form, so `speed <= v_max` arrives as
+`speed - v_max` — and returns the expression to integrate. That result is summed
+to a scalar, so a vector-valued residual may produce a vector-valued penalty. The
+callable runs once, when the problem is built; from there its expression is
+differentiated, sparsified, and cached exactly like a built-in penalty.
+
+The body must be built from openscvx operations: `ox.PositivePart`, `ox.Square`,
+`ox.Huber` (tunable `delta`), `ox.SmoothReLU` (tunable `c`), and ordinary
+arithmetic on expressions. Reaching for `jax.numpy` instead — `jnp.maximum(r, 0)`
+— returns an array rather than an expression and is rejected when the problem is
+built: the penalty has to stay symbolic to be lowered into the augmented
+dynamics.
 
 ## Related reading
 

--- a/docs/UsersGuide/02_drone_racing_constraints.md
+++ b/docs/UsersGuide/02_drone_racing_constraints.md
@@ -138,6 +138,7 @@ obstacle_constraint = (diff.T @ diff >= safe_distance**2).over((5, 10))
 ```
 
 The `.over()` method also accepts optional parameters for the penalty function type (`penalty`), grouping index (`idx`), and whether to also check nodally (`check_nodally`).
+`penalty` takes one of the built-in names (`"squared_relu"`, `"huber"`, `"smooth_relu"`) or a callable that builds a penalty of your own from the constraint residual; see [Custom penalties](../Foundations/constraint_reformulation.md#custom-penalties).
 
 !!! note
     You can also directly instantiate `NodalConstraint` or `CTCS` objects if you prefer:

--- a/openscvx/__init__.py
+++ b/openscvx/__init__.py
@@ -60,6 +60,7 @@ from openscvx.symbolic.expr import (
     Fixed,
     Free,
     Hstack,
+    Huber,
     Index,
     Inequality,
     Inv,
@@ -76,9 +77,12 @@ from openscvx.symbolic.expr import (
     Neg,
     NodalConstraint,
     Parameter,
+    PositivePart,
     Power,
     Sin,
+    SmoothReLU,
     Sqrt,
+    Square,
     Stack,
     State,
     Sub,
@@ -185,6 +189,11 @@ __all__ = [
     "NodalConstraint",
     "CTCS",
     "ctcs",
+    # Penalty function building blocks
+    "PositivePart",
+    "Square",
+    "Huber",
+    "SmoothReLU",
     # Data parallelism
     "Vmap",
     # LaTeX rendering

--- a/openscvx/symbolic/augmentation.py
+++ b/openscvx/symbolic/augmentation.py
@@ -215,13 +215,15 @@ def separate_constraints(constraint_set: ConstraintSet, n_nodes: int) -> Constra
                     "Cross-node constraints should be specified as bare Constraint objects. "
                     f"Constraint: {c.constraint}"
                 )
-            # Validate that CTCS constraints are not equality constraints
-            # CTCS penalty functions (squared_relu, huber, smooth_relu) are designed
-            # for inequality constraints only
+            # Validate that CTCS constraints are not equality constraints: the
+            # augmented state integrates a one-sided violation penalty, which
+            # only certifies satisfaction of an inequality
             if isinstance(c.constraint, Equality):
                 raise ValueError(
                     f"CTCS constraints cannot be equality constraints. "
-                    f"CTCS uses penalty functions designed for inequality constraints. "
+                    f"A CTCS penalty measures violation of an inequality (how far the "
+                    f"residual is above zero), so it cannot detect an equality being "
+                    f"missed from below. "
                     f"For equality constraints, use nodal constraints with .convex() instead.\n"
                     f"Constraint: {c.constraint}"
                 )

--- a/openscvx/symbolic/expr/constraint.py
+++ b/openscvx/symbolic/expr/constraint.py
@@ -37,7 +37,7 @@ Example:
 
 import hashlib
 import struct
-from typing import List, Optional, Tuple, Union
+from typing import Callable, List, Optional, Tuple, Union
 
 import numpy as np
 
@@ -124,7 +124,7 @@ class Constraint(Expr):
     def over(
         self,
         interval: tuple[int, int],
-        penalty: str = "squared_relu",
+        penalty: Union[str, Callable[[Expr], "Expr"]] = "squared_relu",
         idx: Optional[int] = None,
         check_nodally: bool = False,
         licq_max: Optional[float] = None,
@@ -133,7 +133,10 @@ class Constraint(Expr):
 
         Args:
             interval: Tuple of (start, end) node indices for the continuous interval
-            penalty: Penalty function type ("squared_relu", "huber", "smooth_relu")
+            penalty: Built-in penalty name ("squared_relu", "huber", "smooth_relu")
+                or a callable that receives the constraint residual as an ``Expr``
+                and returns the penalty ``Expr``, e.g.
+                ``lambda r: ox.Huber(ox.PositivePart(r), delta=0.5)``.
             idx: Optional grouping index for multiple augmented states
             check_nodally: Whether to also enforce this constraint nodally
             licq_max: Optional upper bound on the augmented state that accumulates
@@ -611,9 +614,20 @@ class CTCS(Expr):
     - **huber**: Huber(PositivePart(lhs)) - less sensitive to outliers than squared
     - **smooth_relu**: SmoothReLU(lhs) - smooth approximation of ReLU
 
+    A penalty may also be written as a callable that receives the constraint
+    residual ``r`` (the canonical left-hand side, satisfying ``r <= 0``) as a
+    symbolic ``Expr`` and returns the penalty ``Expr``. This is how penalty
+    parameters are tuned::
+
+        ox.ctcs(altitude >= 10, penalty=lambda r: ox.Huber(ox.PositivePart(r), delta=0.5))
+
+    The callable is applied once, at problem-build time; the resulting
+    expression is summed and integrated exactly like a built-in penalty.
+
     Attributes:
         constraint: The wrapped Constraint (typically Inequality) to enforce continuously
-        penalty: Penalty function type ('squared_relu', 'huber', or 'smooth_relu')
+        penalty: Penalty function name ('squared_relu', 'huber', or 'smooth_relu')
+            or a callable ``Expr -> Expr`` applied to the constraint residual
         nodes: Optional (start, end) tuple specifying the interval for enforcement,
             or None to enforce over the entire trajectory
         idx: Optional grouping index for managing multiple augmented states.
@@ -655,7 +669,7 @@ class CTCS(Expr):
     def __init__(
         self,
         constraint: Constraint,
-        penalty: str = "squared_relu",
+        penalty: Union[str, Callable[[Expr], Expr]] = "squared_relu",
         nodes: Optional[Tuple[int, int]] = None,
         idx: Optional[int] = None,
         check_nodally: bool = False,
@@ -665,10 +679,14 @@ class CTCS(Expr):
 
         Args:
             constraint: The Constraint to enforce continuously (typically an Inequality)
-            penalty: Penalty function type. Options:
+            penalty: Penalty function name. Options:
                 - 'squared_relu': Square(PositivePart(lhs)) - default, smooth, differentiable
                 - 'huber': Huber(PositivePart(lhs)) - robust to outliers
                 - 'smooth_relu': SmoothReLU(lhs) - smooth ReLU approximation
+
+                Alternatively a callable ``Expr -> Expr`` that receives the
+                constraint residual and returns the penalty expression, e.g.
+                ``lambda r: ox.Huber(ox.PositivePart(r), delta=0.5)``.
             nodes: Optional (start, end) tuple of node indices defining the enforcement interval.
                 None means enforce over the entire trajectory. Must satisfy start < end.
                 CTCS constraints with the same nodes are automatically grouped together.
@@ -780,12 +798,16 @@ class CTCS(Expr):
     def _hash_into(self, hasher: "hashlib._Hash") -> None:
         """Hash CTCS including all its parameters.
 
+        The penalty is hashed through the expression it builds rather than
+        through its spelling, so callable and named penalties hash alike and
+        two problems agree exactly when the same penalty tree gets lowered.
+
         Args:
             hasher: A hashlib hash object to update
         """
         hasher.update(b"CTCS")
-        # Hash penalty type
-        hasher.update(self.penalty.encode())
+        # Hash the penalty by what it builds, not how it was spelled
+        self.penalty_expr()._hash_into(hasher)
         # Hash nodes interval
         if self.nodes is not None:
             hasher.update(struct.pack(">ii", self.nodes[0], self.nodes[1]))
@@ -837,9 +859,14 @@ class CTCS(Expr):
         """String representation of the CTCS constraint.
 
         Returns:
-            str: String showing constraint, penalty type, and optional parameters
+            str: String showing constraint, penalty, and optional parameters
         """
-        parts = [f"{self.constraint!r}", f"penalty={self.penalty!r}"]
+        penalty = (
+            repr(self.penalty)
+            if isinstance(self.penalty, str)
+            else getattr(self.penalty, "__name__", repr(self.penalty))
+        )
+        parts = [f"{self.constraint!r}", f"penalty={penalty}"]
         if self.nodes is not None:
             parts.append(f"nodes={self.nodes}")
         if self.idx is not None:
@@ -863,11 +890,15 @@ class CTCS(Expr):
         s_aug_i(t) = 0 for all t, we ensure all penalties in the group are zero,
         which strictly enforces all constraints in the group continuously.
 
+        A callable penalty is applied here, once, to the residual expression; the
+        result is an ordinary Expr and rides the rest of the pipeline unchanged.
+
         Returns:
             Expr: Sum of the penalty function applied to the constraint violation
 
         Raises:
-            ValueError: If an unknown penalty type is specified
+            ValueError: If an unknown penalty name is given, or if a callable
+                penalty returns something other than an Expr
 
         Note:
             This method is used internally during problem compilation to create
@@ -876,7 +907,18 @@ class CTCS(Expr):
         """
         lhs = self.constraint.lhs
 
-        if self.penalty == "squared_relu":
+        if callable(self.penalty):
+            penalty = self.penalty(lhs)
+            if not isinstance(penalty, Expr):
+                raise ValueError(
+                    f"CTCS penalty callable returned {type(penalty).__name__}, not a "
+                    f"symbolic expression. The callable receives the constraint residual "
+                    f"as an Expr and must return one built from openscvx operations, e.g. "
+                    f"lambda r: ox.Square(ox.PositivePart(r)). Computing on the residual "
+                    f"with jax.numpy or numpy will not work — the penalty is composed "
+                    f"symbolically and only lowered to JAX later."
+                )
+        elif self.penalty == "squared_relu":
             from openscvx.symbolic.expr.math import PositivePart, Square
 
             penalty = Square(PositivePart(lhs))
@@ -896,7 +938,7 @@ class CTCS(Expr):
 
 def ctcs(
     constraint: Constraint,
-    penalty: str = "squared_relu",
+    penalty: Union[str, Callable[[Expr], Expr]] = "squared_relu",
     nodes: Optional[Tuple[int, int]] = None,
     idx: Optional[int] = None,
     check_nodally: bool = False,
@@ -909,7 +951,8 @@ def ctcs(
 
     Args:
         constraint: The Constraint to enforce continuously
-        penalty: Penalty function type ('squared_relu', 'huber', or 'smooth_relu').
+        penalty: Penalty function name ('squared_relu', 'huber', or 'smooth_relu'),
+            or a callable ``Expr -> Expr`` receiving the constraint residual.
             Defaults to 'squared_relu'.
         nodes: Optional (start, end) tuple of node indices for enforcement interval.
             None enforces over entire trajectory.
@@ -942,5 +985,12 @@ def ctcs(
         Also equivalent to using .over() method on constraint:
 
             altitude_constraint = (altitude >= 10).over((0, 100), penalty="huber")
+
+        Tuning a penalty with a callable:
+
+            altitude_constraint = ctcs(
+                altitude >= 10,
+                penalty=lambda r: ox.Huber(ox.PositivePart(r), delta=0.5),
+            )
     """
     return CTCS(constraint, penalty, nodes, idx, check_nodally, licq_max)

--- a/openscvx/symbolic/expr/stl.py
+++ b/openscvx/symbolic/expr/stl.py
@@ -57,7 +57,7 @@ See also:
 """
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Callable, Optional, Tuple, Union
 
 import numpy as np
 
@@ -307,7 +307,7 @@ class STLExpr(Expr):
     def over(
         self,
         interval: "IntervalLike",
-        penalty: str = "smooth_relu",
+        penalty: Union[str, Callable[[Expr], Expr]] = "smooth_relu",
         idx: Optional[int] = None,
         check_nodally: bool = False,
         licq_max: Optional[float] = None,
@@ -321,7 +321,8 @@ class STLExpr(Expr):
                 discretization indices and produces a :class:`NodeInterval`;
                 ``"seconds"`` treats them as wall-time and produces a
                 :class:`TimeInterval` (lowering not yet implemented).
-            penalty: Penalty function type for CTCS
+            penalty: CTCS penalty function name, or a callable ``Expr -> Expr``
+                receiving the constraint residual (see :class:`CTCS`)
             idx: Optional grouping index for multiple augmented states
             check_nodally: Whether to also enforce at discrete nodes
             licq_max: Optional upper bound on the augmented state accumulating

--- a/openscvx/symbolic/expr/stljax.py
+++ b/openscvx/symbolic/expr/stljax.py
@@ -9,7 +9,7 @@ STL operators accept Constraint objects (predicates) and extract robustness
 expressions which are lowered to STLJax during compilation.
 """
 
-from typing import TYPE_CHECKING, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Callable, Optional, Tuple, Union
 
 import numpy as np
 
@@ -56,7 +56,7 @@ class STLJaxExpr(Expr):
     def over(
         self,
         interval: tuple[int, int],
-        penalty: str = "squared_relu",
+        penalty: Union[str, Callable[[Expr], Expr]] = "squared_relu",
         idx: Optional[int] = None,
         check_nodally: bool = False,
         licq_max: Optional[float] = None,
@@ -68,7 +68,8 @@ class STLJaxExpr(Expr):
 
         Args:
             interval: Tuple of (start, end) node indices for enforcement interval
-            penalty: Penalty function type for CTCS
+            penalty: CTCS penalty function name, or a callable ``Expr -> Expr``
+                receiving the constraint residual (see :class:`CTCS`)
             idx: Optional grouping index for multiple augmented states
             check_nodally: Whether to also enforce at discrete nodes
             licq_max: Optional upper bound on the augmented state accumulating

--- a/tests/symbolic/expr/test_constraint.py
+++ b/tests/symbolic/expr/test_constraint.py
@@ -1121,6 +1121,94 @@ def test_ctcs_unknown_penalty():
         ctcs_constraint.penalty_expr()
 
 
+# --- CTCS: Callable Penalties ---
+
+
+def test_ctcs_callable_penalty_builds_expected_ast():
+    """A callable penalty is applied to the residual and summed."""
+    x = Variable("x", shape=(2,))
+    constraint = x <= 1.0
+
+    ctcs_constraint = CTCS(constraint, penalty=lambda r: Square(PositivePart(r)))
+    penalty = ctcs_constraint.penalty_expr()
+
+    assert isinstance(penalty, Sum)
+    assert isinstance(penalty.operand, Square)
+    assert isinstance(penalty.operand.x, PositivePart)
+    assert penalty.operand.x.x is constraint.lhs
+
+
+def test_ctcs_callable_penalty_carries_parameters():
+    """A callable penalty can tune parameters the named penalties hardcode."""
+    x = Variable("x", shape=(2,))
+    constraint = x <= 1.0
+
+    ctcs_constraint = CTCS(constraint, penalty=lambda r: Huber(PositivePart(r), delta=0.5))
+    penalty = ctcs_constraint.penalty_expr()
+
+    assert isinstance(penalty.operand, Huber)
+    assert penalty.operand.delta == 0.5
+    # The named 'huber' penalty leaves delta at its default
+    assert CTCS(constraint, penalty="huber").penalty_expr().operand.delta != 0.5
+
+
+def test_ctcs_callable_penalty_must_return_expr():
+    """A callable penalty returning a non-Expr should say how to fix it."""
+    import jax.numpy as jnp
+
+    x = Variable("x", shape=(1,))
+    constraint = x <= 0.0
+
+    with pytest.raises(ValueError, match="must return one built from openscvx operations"):
+        CTCS(constraint, penalty=lambda r: 42.0).penalty_expr()
+
+    with pytest.raises(ValueError, match="jax.numpy or numpy will not work"):
+        CTCS(constraint, penalty=lambda r: jnp.maximum(0.0, 1.0)).penalty_expr()
+
+
+def test_ctcs_callable_penalty_rejected_at_build_time():
+    """Shape checking surfaces a bad callable penalty when the problem is built."""
+    x = State("x", (3,))
+    constraint = x <= np.ones((3,))
+
+    with pytest.raises(ValueError, match="penalty expression validation failed"):
+        ctcs(constraint, penalty=lambda r: 42.0).check_shape()
+
+
+def test_ctcs_callable_penalty_repr():
+    """CTCS repr should name a callable penalty rather than dumping its address."""
+    x = Variable("x", shape=(3,))
+    constraint = x <= 1.5
+
+    def wide_huber(r):
+        return Huber(PositivePart(r), delta=0.5)
+
+    assert repr(CTCS(constraint, penalty=wide_huber)) == (
+        "CTCS(Var('x') <= Const(1.5), penalty=wide_huber)"
+    )
+    assert repr(CTCS(constraint, penalty=lambda r: Square(r))) == (
+        "CTCS(Var('x') <= Const(1.5), penalty=<lambda>)"
+    )
+
+
+def test_ctcs_over_preserves_callable_penalty():
+    """A callable penalty survives .over() on both Constraint and CTCS."""
+    x = Variable("x", shape=(2,))
+
+    def wide_huber(r):
+        return Huber(PositivePart(r), delta=0.5)
+
+    ctcs_constraint = (x <= 1.0).over((0, 10), penalty=wide_huber)
+    assert ctcs_constraint.penalty is wide_huber
+    assert ctcs_constraint.nodes == (0, 10)
+
+    retimed = ctcs_constraint.over((10, 20))
+    assert retimed.penalty is wide_huber
+    assert retimed.nodes == (10, 20)
+
+    assert ctcs_constraint.canonicalize().penalty is wide_huber
+
+
 # --- CTCS: Shape Checking ---
 
 

--- a/tests/symbolic/test_augmentation.py
+++ b/tests/symbolic/test_augmentation.py
@@ -582,6 +582,29 @@ def test_inequality_constraint_penalty_activation():
                 )
 
 
+def test_callable_penalty_matches_hand_built_expression():
+    """A callable penalty lowers to the same values as the expression it builds."""
+    limit = 1.0
+    x = jnp.array([-2.0, 0.0, 1.0, 1.5, 4.0])
+
+    state = State("x", (5,))
+    state._slice = slice(0, 5)
+
+    constraint = state - limit <= 0
+
+    ctcs_constraint = CTCS(constraint, penalty=lambda r: Huber(PositivePart(r), delta=0.5))
+    from_callable = lower_to_jax(ctcs_constraint.penalty_expr())(x, None, None, None)
+
+    hand_built = lower_to_jax(Sum(Huber(PositivePart(constraint.lhs), delta=0.5)))(
+        x, None, None, None
+    )
+
+    assert jnp.allclose(from_callable, hand_built)
+    # And it is genuinely a different penalty from the built-in huber
+    built_in = lower_to_jax(CTCS(constraint, penalty="huber").penalty_expr())(x, None, None, None)
+    assert not jnp.allclose(from_callable, built_in)
+
+
 def test_reverse_inequality_constraint_penalty():
     """Test penalties for x >= limit (satisfied when x >= limit)."""
     # Constraint: x >= 2.0, equivalent to 2.0 <= x
@@ -1552,9 +1575,12 @@ def test_ctcs_equality_rejected():
     with pytest.raises(ValueError) as exc_info:
         separate_constraints(constraint_set, n_nodes=n_nodes)
 
-    # Check error message is helpful
+    # Check error message is helpful: it names the cause and the alternative,
+    # without enumerating penalty names (penalties may be user-defined)
     msg = str(exc_info.value)
     assert "CTCS constraints cannot be equality" in msg
+    assert "violation of an inequality" in msg
+    assert ".convex()" in msg
 
 
 def test_nonconvex_inequality_still_accepted():

--- a/tests/symbolic/test_hashing.py
+++ b/tests/symbolic/test_hashing.py
@@ -22,7 +22,7 @@ from openscvx.symbolic.expr import (
 )
 from openscvx.symbolic.expr.constraint import CTCS
 from openscvx.symbolic.expr.linalg import Norm
-from openscvx.symbolic.expr.math import Cos, Huber, Sin, SmoothReLU
+from openscvx.symbolic.expr.math import Cos, Huber, PositivePart, Sin, SmoothReLU, Square
 from openscvx.symbolic.hashing import hash_symbolic_problem
 
 
@@ -528,8 +528,8 @@ def test_ctcs_same_params():
     y = State("y", (2,))
     y._slice = slice(0, 2)
 
-    ctcs1 = CTCS(x <= 5, penalty="l2")
-    ctcs2 = CTCS(y <= 5, penalty="l2")
+    ctcs1 = CTCS(x <= 5, penalty="huber")
+    ctcs2 = CTCS(y <= 5, penalty="huber")
 
     assert hash_expr(ctcs1) == hash_expr(ctcs2)
 
@@ -539,10 +539,48 @@ def test_ctcs_different_penalty():
     x = State("x", (2,))
     x._slice = slice(0, 2)
 
-    ctcs_l2 = CTCS(x <= 5, penalty="l2")
-    ctcs_l1 = CTCS(x <= 5, penalty="l1")
+    ctcs_squared = CTCS(x <= 5, penalty="squared_relu")
+    ctcs_huber = CTCS(x <= 5, penalty="huber")
 
-    assert hash_expr(ctcs_l2) != hash_expr(ctcs_l1)
+    assert hash_expr(ctcs_squared) != hash_expr(ctcs_huber)
+
+
+def test_ctcs_same_callable_penalty():
+    """CTCS with the same callable penalty should hash the same."""
+    x = State("x", (2,))
+    x._slice = slice(0, 2)
+
+    y = State("y", (2,))
+    y._slice = slice(0, 2)
+
+    ctcs1 = CTCS(x <= 5, penalty=lambda r: Huber(PositivePart(r), delta=0.5))
+    ctcs2 = CTCS(y <= 5, penalty=lambda r: Huber(PositivePart(r), delta=0.5))
+
+    assert hash_expr(ctcs1) == hash_expr(ctcs2)
+
+
+def test_ctcs_different_callable_penalty():
+    """CTCS callable penalties that build different trees should hash differently."""
+    x = State("x", (2,))
+    x._slice = slice(0, 2)
+
+    ctcs_wide = CTCS(x <= 5, penalty=lambda r: Huber(PositivePart(r), delta=0.5))
+    ctcs_narrow = CTCS(x <= 5, penalty=lambda r: Huber(PositivePart(r), delta=0.1))
+    ctcs_squared = CTCS(x <= 5, penalty=lambda r: Square(PositivePart(r)))
+
+    assert hash_expr(ctcs_wide) != hash_expr(ctcs_narrow)
+    assert hash_expr(ctcs_wide) != hash_expr(ctcs_squared)
+
+
+def test_ctcs_callable_penalty_matches_equivalent_name():
+    """A callable that rebuilds a named penalty hashes like the named penalty."""
+    x = State("x", (2,))
+    x._slice = slice(0, 2)
+
+    ctcs_named = CTCS(x <= 5, penalty="squared_relu")
+    ctcs_callable = CTCS(x <= 5, penalty=lambda r: Square(PositivePart(r)))
+
+    assert hash_expr(ctcs_named) == hash_expr(ctcs_callable)
 
 
 def test_ctcs_with_nodes():
@@ -932,9 +970,9 @@ def test_problem_ctcs_constraint_order_invariant():
 
         # Create CTCS constraints in the specified order
         constraints_map = {
-            "ctcs_norm": CTCS(Norm(x) <= 3.0, penalty="l2"),
-            "ctcs_x0": CTCS(x[0] >= -1.0, penalty="l1"),
-            "ctcs_x1": CTCS(x[1] <= 2.0, penalty="l2"),
+            "ctcs_norm": CTCS(Norm(x) <= 3.0, penalty="squared_relu"),
+            "ctcs_x0": CTCS(x[0] >= -1.0, penalty="huber"),
+            "ctcs_x1": CTCS(x[1] <= 2.0, penalty="squared_relu"),
         }
         ordered_constraints = [constraints_map[name] for name in constraint_order]
 


### PR DESCRIPTION
Closes #420. First of a three-PR stack for the symbolic-layer ancillary-function family (#476); followed by the symbolic-guesses and with-jacobian PRs.

## What

`penalty` on `ox.ctcs` / `CTCS` / `constraint.over()` (and the STL `.over()` variants) now also accepts a callable `(residual: Expr) -> Expr`, applied once at problem-build time to the constraint's canonical residual:

```python
ox.ctcs(altitude >= 10, penalty=lambda r: ox.Huber(ox.PositivePart(r), delta=0.5))
```

The composed expression rides augmentation, autodiff, sparsity, and hashing exactly like the built-in penalties. This also makes `Huber`'s `delta` and `SmoothReLU`'s `c` tunable, which the string form never allowed. The string presets are unchanged and remain the default.

## Notes

- CTCS hashing now hashes the **built penalty expression** rather than the penalty's spelling, so a callable that rebuilds `Square(PositivePart(r))` hashes identically to `penalty="squared_relu"`. String-penalty hash values change (compile-cache invalidation only).
- Penalty building blocks (`PositivePart`, `Square`, `Huber`, `SmoothReLU`) are now exported at the `ox.` top level.
- Fixes a latent test bug: `test_hashing.py` used invalid penalty names (`"l2"`, `"l1"`) that only passed because hashing never built the AST.
- A callable returning a non-Expr (e.g. `jnp.maximum(r, 0)`) raises a build-time teaching error.
- Deliberately untouched: the byof penalty registry (`square`/`l1`/`huber`, divergent Huber default and formula) and the YAML string dialect.

## Testing

`tests/symbolic/` + expert/loader sweeps green (1716 at time of authoring); new tests cover the callable AST composition, parameter tuning, non-Expr rejection, repr, `.over()` round-trip, numeric equivalence against hand-built expressions, and hash equivalence of string vs. callable spellings. End-to-end brachistochrone with two callable penalties converges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5WX9YVDJr8qmZd8z3DM1V