### PR TITLE
Add Expr.with_jacobian for user-supplied Jacobian overrides

### DIFF
--- a/docs/Foundations/discretization.md
+++ b/docs/Foundations/discretization.md
@@ -91,4 +91,41 @@ def dVdt(self, tau: float, V: jnp.ndarray, u_cur: np.ndarray, u_next: np.ndarray
     )
     return dVdt.flatten()
 ```
-    
+
+## Supplying your own Jacobian
+
+The state and control Jacobians above (`dfdx`, `dfdu`) come from automatic
+differentiation of the dynamics you wrote. Occasionally the exact Jacobian is
+not the one you want: a drag law, a contact model, or a lookup table can be
+smooth enough to integrate while its true derivative makes the convex
+subproblem badly conditioned, so the trust region collapses and the SCP loop
+crawls. The standard remedy is to linearize with a deliberately simplified
+(inexact) Jacobian.
+
+`Expr.with_jacobian` applies that remedy to a single term:
+
+``` py
+drag = -0.5 * rho * ox.Norm(vel) * vel
+J_drag = -0.5 * rho * ox.Norm(vel) * np.eye(3)   # drops the d||v||/dv term
+
+dynamics = {"pos": vel, "vel": thrust / m + drag.with_jacobian({vel: J_drag})}
+```
+
+The keys are the `State` or `Control` objects the derivative is taken with
+respect to, and each value is an expression (or constant array) of shape
+`(*term.shape, *variable.shape)`. Directions you do not name are still
+differentiated automatically, so the example above hands over `∂/∂vel` while
+`∂/∂thrust` still comes from autodiff.
+
+The *value* of the term is untouched — only the search direction changes — so a
+converged trajectory still satisfies the original nonlinear dynamics; the
+defect and the propagated solution are computed with the term as written. An
+inexact Jacobian trades linearization accuracy (and hence convergence rate) for
+conditioning, so reach for it when a term is a known source of stiffness, not
+as a default.
+
+The override lives inside the lowered JAX function, so every downstream
+derivative picks it up: the discretizer's `A`/`B`, nonconvex constraint
+linearization, and the sparsity pattern used for coloring. It has no meaning
+inside a constraint that is handed to the convex solver as written, and lowering
+one there raises.

--- a/docs/Foundations/discretization.md
+++ b/docs/Foundations/discretization.md
@@ -106,7 +106,7 @@ crawls. The standard remedy is to linearize with a deliberately simplified
 
 ``` py
 drag = -0.5 * rho * ox.Norm(vel) * vel
-J_drag = -0.5 * rho * ox.Norm(vel) * np.eye(3)   # drops the d||v||/dv term
+J_drag = -0.5 * rho * ox.Norm(vel) * np.eye(3)  # drops the d||v||/dv term
 
 dynamics = {"pos": vel, "vel": thrust / m + drag.with_jacobian({vel: J_drag})}
 ```

--- a/openscvx/symbolic/expr/__init__.py
+++ b/openscvx/symbolic/expr/__init__.py
@@ -33,6 +33,11 @@ Module Organization:
         Array manipulation operations including `Index`, `Concat`, `Stack`, `Hstack`,
         and `Vstack` for indexing, slicing, and combining arrays.
 
+    User-Supplied Jacobians (autodiff.py):
+        `WithJacobian`, built by `Expr.with_jacobian`, replaces a subexpression's
+        derivative with respect to chosen variables — the inexact-Jacobian knob for
+        SCP conditioning.
+
     Constraints (constraint.py):
         Constraint types including `Constraint`, `Equality`, `Inequality`,
         `NodalConstraint`, and `CTCS` (Continuous-Time Constraint Satisfaction).
@@ -79,6 +84,9 @@ from .arithmetic import Add, Div, MatMul, Mul, Neg, Power, Sub
 
 # Array operations
 from .array import Block, Concat, Hstack, Index, Stack, Vstack
+
+# User-supplied Jacobians
+from .autodiff import WithJacobian
 
 # Specialized constraints
 from .constraint import (
@@ -258,4 +266,6 @@ __all__ = [
     "ctcs",
     # Vmap
     "Vmap",
+    # User-supplied Jacobians
+    "WithJacobian",
 ]

--- a/openscvx/symbolic/expr/autodiff.py
+++ b/openscvx/symbolic/expr/autodiff.py
@@ -1,0 +1,159 @@
+"""User-supplied Jacobians for a subexpression.
+
+Successive convexification linearizes the dynamics and constraints at every
+iteration, so the *Jacobian* — not the value — is what shapes each convex
+subproblem. Occasionally the exact Jacobian is the wrong one to hand the
+solver: an aerodynamic drag term, a contact model, or a lookup table can be
+smooth enough to integrate but stiff enough that its true derivative wrecks the
+conditioning of the subproblem. The standard remedy is a deliberately
+simplified (inexact) Jacobian — the trajectory still converges to a solution of
+the *nonlinear* problem, because the value used for the defect is untouched;
+only the search direction changes.
+
+:class:`WithJacobian` is that remedy, written at sub-expression granularity::
+
+    drag = -0.5 * rho * ox.Norm(vel) * vel
+    accel = thrust / m + drag.with_jacobian({vel: J_drag})
+
+The node wraps a subexpression and carries an override Jacobian per variable.
+Lowering to JAX emits a :func:`jax.custom_jvp` rule around the wrapped
+subexpression, so every downstream differentiation — the discretizer's
+``jacfwd``, constraint linearization, sparse coloring — sees the user's
+Jacobian in the overridden directions and autodiff everywhere else, with no
+further special-casing. The primal value is always the wrapped expression
+itself.
+"""
+
+import hashlib
+from typing import Dict, List, Tuple
+
+import numpy as np
+
+from .expr import Expr, to_expr
+from .variable import Variable
+
+
+def _without_unit_axes(shape: Tuple[int, ...]) -> Tuple[int, ...]:
+    """Drop length-1 axes, the way :class:`Constant` squeezes a wrapped array."""
+    return tuple(d for d in shape if d != 1)
+
+
+class WithJacobian(Expr):
+    """A subexpression whose derivative w.r.t. chosen variables is user-supplied.
+
+    Construct this through :meth:`Expr.with_jacobian` rather than directly. The
+    node evaluates exactly like the expression it wraps; only differentiation
+    differs, and only in the overridden directions (see the module docstring for
+    the motivation).
+
+    Attributes:
+        expr: The wrapped expression, and the node's value.
+        overrides: ``(variable, jacobian)`` pairs in the order given, each
+            Jacobian shaped ``(*expr.shape, *variable.shape)``.
+    """
+
+    def __init__(self, expr: Expr, jacobians: Dict[Variable, Expr]):
+        """Wrap ``expr`` with an override Jacobian per variable.
+
+        Args:
+            expr: Expression whose derivative is being overridden.
+            jacobians: Map from a ``State`` or ``Control`` to the Jacobian of
+                ``expr`` with respect to it. Values are coerced with
+                :func:`to_expr`, so constant matrices are accepted.
+
+        Raises:
+            TypeError: If a key is not a decision variable.
+            ValueError: If no Jacobian is given.
+        """
+        if not jacobians:
+            raise ValueError(
+                "with_jacobian needs at least one {variable: jacobian} entry; an empty "
+                "mapping would wrap the expression without changing anything."
+            )
+        self.expr = to_expr(expr)
+        overrides = []
+        for var, jac in jacobians.items():
+            if not isinstance(var, Variable):
+                raise TypeError(
+                    f"with_jacobian keys must be the State or Control the derivative is "
+                    f"taken with respect to, got {type(var).__name__}. Write "
+                    f"`expr.with_jacobian({{vel: J_vel}})` with `vel` the variable itself."
+                )
+            overrides.append((var, to_expr(jac)))
+        self.overrides: List[Tuple[Variable, Expr]] = overrides
+
+    def children(self) -> List[Expr]:
+        """Return the wrapped expression followed by each override Jacobian.
+
+        The overridden variables are not children: they identify *directions*,
+        not operands, and appear as leaves inside the Jacobian expressions only
+        if the user put them there.
+        """
+        return [self.expr, *(jac for _, jac in self.overrides)]
+
+    def canonicalize(self) -> Expr:
+        """Canonicalize the wrapped expression and every override Jacobian."""
+        return WithJacobian(
+            self.expr.canonicalize(),
+            {var: jac.canonicalize() for var, jac in self.overrides},
+        )
+
+    def check_shape(self) -> Tuple[int, ...]:
+        """Return the wrapped expression's shape, validating each Jacobian.
+
+        A Jacobian must be shaped ``(*expr.shape, *var.shape)``. Unit axes are
+        ignored in the comparison: a constant is squeezed when it is wrapped, so
+        an honest ``(3, 1)`` Jacobian arrives as ``(3,)``. The JAX lowering
+        reshapes it back before contracting.
+
+        Returns:
+            The shape of the wrapped expression — the wrapper is value-transparent.
+
+        Raises:
+            ValueError: If a Jacobian's shape is not ``(*expr.shape, *var.shape)``.
+        """
+        shape = self.expr.check_shape()
+        for var, jac in self.overrides:
+            expected = (*shape, *var.shape)
+            got = jac.check_shape()
+            if _without_unit_axes(got) != _without_unit_axes(expected):
+                raise ValueError(
+                    f"Jacobian for {var.__class__.__name__} '{var.name}' has shape {got}, "
+                    f"expected {expected}: the derivative of an expression of shape "
+                    f"{shape} with respect to a variable of shape {var.shape}."
+                )
+        return shape
+
+    def sparsity(self, n_x: int, n_u: int) -> Tuple[np.ndarray, np.ndarray]:
+        """Conservative pattern: the children's, widened to the overridden columns.
+
+        The default union over children is not enough here. A user Jacobian may
+        be a constant (no dependence of its own) yet still couple outputs to
+        every entry of the overridden variable, so those columns are marked
+        dense on top of the children's pattern.
+        """
+        from .control import Control
+
+        S_x, S_u = super().sparsity(n_x, n_u)
+        for var, _ in self.overrides:
+            if var._slice is None:
+                continue
+            S = S_u if isinstance(var, Control) else S_x
+            S[:, var._slice] = True
+        return S_x, S_u
+
+    def _hash_into(self, hasher: "hashlib._Hash") -> None:
+        """Hash the wrapper, the wrapped expression, and each override in order.
+
+        Args:
+            hasher: A hashlib hash object to update
+        """
+        hasher.update(b"WithJacobian")
+        self.expr._hash_into(hasher)
+        for var, jac in self.overrides:
+            var._hash_into(hasher)
+            jac._hash_into(hasher)
+
+    def __repr__(self) -> str:
+        vars_ = ", ".join(var.name for var, _ in self.overrides)
+        return f"{self.expr!r}.with_jacobian({{{vars_}}})"

--- a/openscvx/symbolic/expr/expr.py
+++ b/openscvx/symbolic/expr/expr.py
@@ -308,6 +308,47 @@ class Expr:
         """
         return NodeReference(self, k)
 
+    def with_jacobian(self, jacobians: dict) -> "Expr":
+        """Override this expression's derivative w.r.t. chosen variables.
+
+        Successive convexification linearizes at every iteration, so the Jacobian
+        of a term — not its value — is what conditions the convex subproblem. A
+        deliberately simplified (inexact) Jacobian is a standard remedy for a term
+        that is smooth enough to integrate but whose true derivative makes the
+        subproblem badly conditioned. The value of the expression is untouched, so
+        the converged trajectory still satisfies the original nonlinear problem;
+        only the search direction changes.
+
+        Directions that are not overridden are still differentiated automatically,
+        so a single term can hand-specify its state Jacobian and let the control
+        Jacobian fall out of autodiff.
+
+        Args:
+            jacobians: Map from a ``State`` or ``Control`` to the Jacobian of this
+                expression with respect to it, shaped ``(*self.shape, *var.shape)``
+                (a variable of shape ``(n,)`` and a scalar expression give shape
+                ``(n,)``). Constant matrices are accepted alongside expressions.
+
+        Returns:
+            Expr: A ``WithJacobian`` node wrapping this expression.
+
+        Example:
+            Damp the drag Jacobian without changing the drag force:
+
+                drag = -0.5 * rho * ox.Norm(vel) * vel
+                J_drag = -0.5 * rho * ox.Norm(vel) * np.eye(3)  # drops the d|v|/dv term
+
+                dynamics = {"vel": thrust / m + drag.with_jacobian({vel: J_drag})}
+
+        Note:
+            The override applies on the JAX path — dynamics linearization and
+            constraint linearization. Inside a constraint lowered to CVXPy the
+            wrapper has no meaning and raises.
+        """
+        from .autodiff import WithJacobian
+
+        return WithJacobian(self, jacobians)
+
     def children(self) -> List["Expr"]:
         """Return the child expressions of this node.
 

--- a/openscvx/symbolic/expr/variable.py
+++ b/openscvx/symbolic/expr/variable.py
@@ -58,6 +58,12 @@ class Variable(Leaf):
     def __repr__(self) -> str:
         return f"Var({self.name!r})"
 
+    # ``Expr.__eq__`` builds an Equality constraint rather than comparing, which
+    # makes Python drop the inherited ``__hash__``. Variables are identities, not
+    # values, so restore hashing by identity: it lets a variable key a dict, as in
+    # ``expr.with_jacobian({vel: J_vel})``.
+    __hash__ = object.__hash__
+
     def _hash_into(self, hasher: "hashlib._Hash") -> None:
         """Hash Variable using its slice (canonical position, name-invariant).
 

--- a/openscvx/symbolic/lowerers/cvxpy/__init__.py
+++ b/openscvx/symbolic/lowerers/cvxpy/__init__.py
@@ -22,6 +22,7 @@ Example::
 from openscvx.symbolic.lowerers.cvxpy import (
     arithmetic,  # noqa: F401
     array,  # noqa: F401
+    autodiff,  # noqa: F401
     constraint,  # noqa: F401
     control,  # noqa: F401
     expr,  # noqa: F401

--- a/openscvx/symbolic/lowerers/cvxpy/autodiff.py
+++ b/openscvx/symbolic/lowerers/cvxpy/autodiff.py
@@ -1,0 +1,36 @@
+"""CVXPy visitors for user-supplied Jacobians.
+
+Visitors: WithJacobian
+
+A ``WithJacobian`` override reshapes a *linearization*, and linearization happens
+on the JAX path. The convex subproblem sees convex constraints verbatim, with no
+derivative taken, so the wrapper has nothing to act on here and raises
+``NotImplementedError`` — the same treatment ``CTCS`` gets for being a
+JAX-side construct.
+"""
+
+import cvxpy as cp
+
+from openscvx.symbolic.expr.autodiff import WithJacobian
+from openscvx.symbolic.lowerers.cvxpy._registry import visitor  # noqa: F401
+
+
+@visitor(WithJacobian)
+def _visit_with_jacobian(lowerer, node: WithJacobian) -> cp.Expression:
+    """Raise NotImplementedError for a Jacobian override inside a convex constraint.
+
+    Args:
+        node: WithJacobian expression node
+
+    Raises:
+        NotImplementedError: Always — see the module docstring.
+    """
+    raise NotImplementedError(
+        "`.with_jacobian(...)` overrides the derivative used when a nonconvex "
+        "expression is linearized, which only happens on the JAX path (dynamics and "
+        "nonconvex constraints). This expression was lowered to CVXPy as part of a "
+        "convex constraint, which is passed to the solver as written and never "
+        "differentiated, so the override has no meaning here. Apply "
+        "`.with_jacobian(...)` to the nonconvex term instead, or drop it from this "
+        "constraint."
+    )

--- a/openscvx/symbolic/lowerers/jax/__init__.py
+++ b/openscvx/symbolic/lowerers/jax/__init__.py
@@ -23,6 +23,7 @@ Example::
 from openscvx.symbolic.lowerers.jax import (
     arithmetic,  # noqa: F401
     array,  # noqa: F401
+    autodiff,  # noqa: F401
     constraint,  # noqa: F401
     control,  # noqa: F401
     expr,  # noqa: F401

--- a/openscvx/symbolic/lowerers/jax/autodiff.py
+++ b/openscvx/symbolic/lowerers/jax/autodiff.py
@@ -1,0 +1,82 @@
+"""JAX visitors for user-supplied Jacobians.
+
+Visitors: WithJacobian
+
+Lowers a ``WithJacobian`` node to its wrapped subexpression wrapped in a
+:func:`jax.custom_jvp` rule. The rule zeroes the tangent of every overridden
+variable before differentiating the inner function, then adds ``J @ dvar`` for
+each override — so overridden directions come from the user's Jacobian and all
+others from autodiff. Because the override lives inside the lowered function,
+every downstream differentiation (the discretizer's ``jacfwd``, constraint
+linearization, sparse coloring) picks it up with no further plumbing.
+
+Unlike the ``Vmap`` and ``Cond`` visitors, this one does not pause the value
+memo: the nested ``jax.jvp`` trace receives its own ``(x, u)`` tracers rather
+than reusing the captured outer ones, and the memo is keyed on all four
+arguments, so a value cached in one trace can never be handed to a caller in
+another.
+"""
+
+import jax
+import jax.numpy as jnp
+
+from openscvx.symbolic.expr.autodiff import WithJacobian
+from openscvx.symbolic.expr.control import Control
+from openscvx.symbolic.lowerers.jax._registry import visitor  # noqa: F401
+
+
+@visitor(WithJacobian)
+def _visit_with_jacobian(lowerer, node: WithJacobian):
+    """Lower a user-Jacobian override to a ``jax.custom_jvp``-wrapped function.
+
+    Args:
+        node: WithJacobian expression node
+
+    Returns:
+        Function (x, u, node, params) -> value of the wrapped expression, whose
+        derivative w.r.t. each overridden variable is the user's Jacobian.
+
+    Raises:
+        ValueError: If an overridden variable has no slice assigned (unification
+            not run).
+    """
+    inner = lowerer.lower(node.expr)
+    out_shape = node.expr.check_shape()
+    overrides = []
+    for var, jac in node.overrides:
+        if var._slice is None:
+            raise ValueError(f"{var.__class__.__name__} {var.name!r} has no slice assigned")
+        # Squeezed constants come back as e.g. () for a (1, 1) Jacobian, so the
+        # declared shape is restored before contracting with the tangent.
+        jac_shape = (*out_shape, *var.shape)
+        overrides.append((var._slice, isinstance(var, Control), lowerer.lower(jac), jac_shape))
+    overrides = tuple(overrides)
+
+    def with_jacobian_fn(x, u, node_idx, params):
+        def inner_xu(x_, u_):
+            return inner(x_, u_, node_idx, params)
+
+        f = jax.custom_jvp(inner_xu)
+
+        @f.defjvp
+        def _jvp(primals, tangents):
+            x_, u_ = primals
+            dx, du = tangents
+            # Autodiff supplies the non-overridden directions: blank the
+            # overridden slices so their contribution comes only from below.
+            dx_free, du_free = dx, du
+            for sl, is_control, _, _ in overrides:
+                if is_control:
+                    du_free = du_free.at[sl].set(0.0)
+                else:
+                    dx_free = dx_free.at[sl].set(0.0)
+            out, tangent = jax.jvp(inner_xu, (x_, u_), (dx_free, du_free))
+            for sl, is_control, jac_fn, jac_shape in overrides:
+                J = jnp.reshape(jac_fn(x_, u_, node_idx, params), jac_shape)
+                dvar = du[sl] if is_control else dx[sl]
+                tangent = tangent + jnp.tensordot(J, dvar, axes=1)
+            return out, tangent
+
+        return f(x, u)
+
+    return with_jacobian_fn

--- a/openscvx/symbolic/lowerers/latex/__init__.py
+++ b/openscvx/symbolic/lowerers/latex/__init__.py
@@ -27,6 +27,7 @@ Example::
 from openscvx.symbolic.lowerers.latex import (
     arithmetic,  # noqa: F401
     array,  # noqa: F401
+    autodiff,  # noqa: F401
     constraint,  # noqa: F401
     control,  # noqa: F401
     expr,  # noqa: F401

--- a/openscvx/symbolic/lowerers/latex/autodiff.py
+++ b/openscvx/symbolic/lowerers/latex/autodiff.py
@@ -1,0 +1,17 @@
+"""LaTeX visitors for user-supplied Jacobians.
+
+Visitors: WithJacobian
+
+A Jacobian override changes how a term is differentiated, not what it equals, so
+the rendered formulation shows the wrapped expression alone — the same choice the
+``CTCS`` visitor makes in rendering the constraint it stands for.
+"""
+
+from openscvx.symbolic.expr.autodiff import WithJacobian
+from openscvx.symbolic.lowerers.latex._registry import visitor
+
+
+@visitor(WithJacobian)
+def _visit_with_jacobian(lowerer, node: WithJacobian):
+    """Render the wrapped expression; the override is invisible in the math."""
+    return lowerer.lower(node.expr)

--- a/tests/symbolic/expr/test_autodiff.py
+++ b/tests/symbolic/expr/test_autodiff.py
@@ -1,0 +1,450 @@
+"""Tests for user-supplied Jacobians (``Expr.with_jacobian``).
+
+``WithJacobian`` wraps a subexpression and replaces its derivative with respect
+to chosen variables, leaving the value and all other directions untouched. The
+override is emitted as a ``jax.custom_jvp`` rule inside the lowered function, so
+every downstream differentiation — constraint linearization, the discretizer's
+Jacobians — sees it without further plumbing.
+
+Sections:
+1. Node mechanics (children, canonicalize, shapes, hashing, sparsity)
+2. JAX lowering semantics (value, full and partial overrides, composition)
+3. Problem integration (dynamics Jacobians and a solve)
+4. Other backends (CVXPy, LaTeX)
+"""
+
+import hashlib
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from openscvx.symbolic.expr import Constant, Control, Norm, State, Sum
+from openscvx.symbolic.expr.autodiff import WithJacobian
+from openscvx.symbolic.expr.time import Time
+from openscvx.symbolic.lower import lower_to_jax, to_latex
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _sliced_state(name, n, start):
+    x = State(name, shape=(n,))
+    x._slice = slice(start, start + n)
+    return x
+
+
+def _sliced_control(name, n, start):
+    u = Control(name, shape=(n,))
+    u._slice = slice(start, start + n)
+    return u
+
+
+def _hash(expr) -> bytes:
+    hasher = hashlib.sha256()
+    expr._hash_into(hasher)
+    return hasher.digest()
+
+
+# =============================================================================
+# Node Mechanics
+# =============================================================================
+
+
+def test_children_are_the_expression_then_each_jacobian():
+    """Overridden variables are directions, not operands: only exprs are children."""
+    x = _sliced_state("x", 2, 0)
+    u = _sliced_control("u", 2, 0)
+    jac_x, jac_u = Constant(np.eye(2)), Constant(np.zeros((2, 2)))
+
+    node = (x * u).with_jacobian({x: jac_x, u: jac_u})
+
+    assert isinstance(node, WithJacobian)
+    assert node.children() == [node.expr, jac_x, jac_u]
+    assert [var for var, _ in node.overrides] == [x, u]
+
+
+def test_non_variable_key_raises_teaching_error():
+    x = _sliced_state("x", 2, 0)
+
+    with pytest.raises(TypeError) as excinfo:
+        (x * x).with_jacobian({"x": np.eye(2)})
+
+    assert "State or Control" in str(excinfo.value)
+
+
+def test_empty_override_raises_rather_than_wrapping_silently():
+    x = _sliced_state("x", 2, 0)
+
+    with pytest.raises(ValueError) as excinfo:
+        (x * x).with_jacobian({})
+
+    assert "at least one" in str(excinfo.value)
+
+
+def test_jacobians_are_coerced_to_expressions():
+    """A constant matrix is a legal Jacobian and arrives as a Constant."""
+    x = _sliced_state("x", 2, 0)
+
+    node = Sum(x).with_jacobian({x: np.array([1.0, 0.0])})
+
+    ((_, jac),) = node.overrides
+    assert isinstance(jac, Constant)
+
+
+def test_canonicalize_preserves_the_overrides():
+    x = _sliced_state("x", 2, 0)
+    node = (x * x).with_jacobian({x: 1.0 * Constant(np.eye(2))})
+
+    canon = node.canonicalize()
+
+    assert isinstance(canon, WithJacobian)
+    assert [var for var, _ in canon.overrides] == [x]
+    # Both the body and the Jacobian are canonicalized: the identity factor folds.
+    assert isinstance(canon.overrides[0][1], Constant)
+    assert canon.check_shape() == (2,)
+
+
+def test_check_shape_is_the_wrapped_shape():
+    x = _sliced_state("x", 3, 0)
+
+    assert (x * x).with_jacobian({x: np.eye(3)}).check_shape() == (3,)
+    assert Sum(x).with_jacobian({x: np.zeros(3)}).check_shape() == ()
+
+
+def test_check_shape_rejects_a_scalar_jacobian_of_wrong_length():
+    x = _sliced_state("x", 3, 0)
+    node = Sum(x).with_jacobian({x: np.zeros(2)})
+
+    with pytest.raises(ValueError) as excinfo:
+        node.check_shape()
+
+    msg = str(excinfo.value)
+    assert "'x'" in msg and "(2,)" in msg and "(3,)" in msg
+
+
+def test_check_shape_rejects_a_vector_jacobian_of_wrong_shape():
+    x = _sliced_state("x", 3, 0)
+    node = (x * x).with_jacobian({x: np.zeros((3, 2))})
+
+    with pytest.raises(ValueError) as excinfo:
+        node.check_shape()
+
+    assert "(3, 2)" in str(excinfo.value) and "(3, 3)" in str(excinfo.value)
+
+
+def test_hash_is_stable_across_equivalent_overrides():
+    x = _sliced_state("x", 2, 0)
+    y = _sliced_state("y", 2, 0)  # same slice: hashing is name-invariant
+
+    assert _hash(Sum(x).with_jacobian({x: np.zeros(2)})) == _hash(
+        Sum(y).with_jacobian({y: np.zeros(2)})
+    )
+
+
+def test_hash_distinguishes_different_jacobians_and_the_bare_expression():
+    x = _sliced_state("x", 2, 0)
+    body = Sum(x)
+
+    zeros = _hash(body.with_jacobian({x: np.zeros(2)}))
+    ones = _hash(body.with_jacobian({x: np.ones(2)}))
+
+    assert zeros != ones
+    assert zeros != _hash(body)
+
+
+def test_hash_distinguishes_the_overridden_variable():
+    """Same Jacobian, different direction, different problem."""
+    x = _sliced_state("x", 2, 0)
+    u = _sliced_control("u", 2, 0)
+    body = Sum(x) + Sum(u)
+
+    assert _hash(body.with_jacobian({x: np.zeros(2)})) != _hash(
+        body.with_jacobian({u: np.zeros(2)})
+    )
+
+
+def test_repr_shows_the_overridden_variables():
+    x = _sliced_state("x", 2, 0)
+
+    assert "with_jacobian({x})" in repr(Sum(x).with_jacobian({x: np.zeros(2)}))
+
+
+def test_sparsity_marks_the_overridden_columns_dense():
+    """A constant Jacobian carries no dependence of its own but still couples."""
+    x = _sliced_state("x", 3, 0)
+    u = _sliced_control("u", 2, 0)
+    body = Sum(x[0:1]) + Sum(u)
+
+    S_x, S_u = body.with_jacobian({x: np.ones(3)}).sparsity(3, 2)
+
+    assert S_x.all()  # widened from column 0 alone to the whole `x` slice
+    assert S_u.all()  # inherited from the body
+
+
+# =============================================================================
+# JAX Lowering Semantics
+# =============================================================================
+
+
+def test_value_is_unchanged_by_the_wrapper():
+    x = _sliced_state("x", 3, 0)
+    u = _sliced_control("u", 2, 0)
+    body = Sum(x * x) + Sum(u)
+
+    plain, wrapped = lower_to_jax([body, body.with_jacobian({x: np.zeros(3)})])
+    xv, uv = jnp.array([1.0, 2.0, 3.0]), jnp.array([0.5, -1.5])
+
+    assert plain(xv, uv, 0, {}) == wrapped(xv, uv, 0, {})
+
+
+def test_zero_jacobian_replaces_autodiff():
+    x = _sliced_state("x", 3, 0)
+    body = Sum(x * x)  # autodiff would give 2x
+
+    (fn,) = lower_to_jax([body.with_jacobian({x: np.zeros(3)})])
+    grad = jax.jacfwd(fn, argnums=0)(jnp.array([1.0, 2.0, 3.0]), jnp.zeros(0), 0, {})
+
+    np.testing.assert_allclose(grad, np.zeros(3))
+
+
+def test_wrong_jacobian_comes_back_exactly():
+    """Nothing reconciles the override with the truth — the user's value is used."""
+    x = _sliced_state("x", 3, 0)
+    wrong = np.array([7.0, -1.0, 0.5])
+
+    (fn,) = lower_to_jax([Sum(x * x).with_jacobian({x: wrong})])
+    grad = jax.jacfwd(fn, argnums=0)(jnp.array([1.0, 2.0, 3.0]), jnp.zeros(0), 0, {})
+
+    np.testing.assert_allclose(grad, wrong)
+
+
+def test_partial_override_leaves_other_directions_to_autodiff():
+    pos = _sliced_state("pos", 2, 0)
+    vel = _sliced_state("vel", 2, 2)
+    acc = _sliced_control("acc", 2, 0)
+    body = Sum(pos * pos) + Sum(vel * vel) + Sum(acc * acc)
+
+    (fn,) = lower_to_jax([body.with_jacobian({vel: np.zeros(2)})])
+    xv = jnp.array([1.0, 2.0, 3.0, 4.0])
+    uv = jnp.array([5.0, 6.0])
+
+    grad_x = jax.jacfwd(fn, argnums=0)(xv, uv, 0, {})
+    grad_u = jax.jacfwd(fn, argnums=1)(xv, uv, 0, {})
+
+    np.testing.assert_allclose(grad_x, [2.0, 4.0, 0.0, 0.0])  # pos autodiff, vel overridden
+    np.testing.assert_allclose(grad_u, [10.0, 12.0])
+
+
+def test_control_override_leaves_the_state_direction_to_autodiff():
+    x = _sliced_state("x", 2, 0)
+    u = _sliced_control("u", 2, 0)
+    body = Sum(x * x) + Sum(u * u)
+
+    (fn,) = lower_to_jax([body.with_jacobian({u: np.array([1.0, 1.0])})])
+    xv, uv = jnp.array([1.0, 2.0]), jnp.array([3.0, 4.0])
+
+    np.testing.assert_allclose(jax.jacfwd(fn, argnums=0)(xv, uv, 0, {}), [2.0, 4.0])
+    np.testing.assert_allclose(jax.jacfwd(fn, argnums=1)(xv, uv, 0, {}), [1.0, 1.0])
+
+
+def test_vector_valued_override_uses_the_full_matrix():
+    x = _sliced_state("x", 2, 0)
+    J = np.array([[1.0, 0.0], [0.0, 0.0]])  # true Jacobian would be diag(2x)
+
+    (fn,) = lower_to_jax([(x * x).with_jacobian({x: J})])
+    out = jax.jacfwd(fn, argnums=0)(jnp.array([1.0, 2.0]), jnp.zeros(0), 0, {})
+
+    assert out.shape == (2, 2)
+    np.testing.assert_allclose(out, J)
+
+
+def test_expression_valued_jacobian_is_evaluated_at_the_linearization_point():
+    """The override is an expression, so it tracks the state it is evaluated at."""
+    x = _sliced_state("x", 2, 0)
+    # Half the true Jacobian of sum(x^2): a damped search direction.
+    (fn,) = lower_to_jax([Sum(x * x).with_jacobian({x: x})])
+
+    for xv in (jnp.array([1.0, 2.0]), jnp.array([-3.0, 0.5])):
+        grad = jax.jacfwd(fn, argnums=0)(xv, jnp.zeros(0), 0, {})
+        np.testing.assert_allclose(grad, np.asarray(xv))
+
+
+def test_override_deep_inside_an_expression_chains_correctly():
+    x = _sliced_state("x", 2, 0)
+    u = _sliced_control("u", 1, 0)
+    J = np.array([[1.0, 0.0], [0.0, 0.0]])
+    body = Norm((x * x).with_jacobian({x: J})) + Sum(u)
+
+    (fn,) = lower_to_jax([body])
+    xv, uv = jnp.array([1.0, 2.0]), jnp.array([3.0])
+    grad = jax.jacfwd(fn, argnums=0)(xv, uv, 0, {})
+
+    # d/dx ||w||, w = x*x  ==>  (w / ||w||) @ J, with the true dw/dx replaced by J.
+    w = np.array([1.0, 4.0])
+    np.testing.assert_allclose(grad, (w / np.linalg.norm(w)) @ J, rtol=1e-6)
+    np.testing.assert_allclose(jax.jacfwd(fn, argnums=1)(xv, uv, 0, {}), [1.0])
+
+
+def test_shared_subexpression_between_body_and_jacobian_lowers_once():
+    """Body and override may share nodes; the nested JVP trace must not leak."""
+    x = _sliced_state("x", 2, 0)
+    shared = Sum(x * x)
+    body = shared + 1.0
+
+    (fn,) = lower_to_jax([body.with_jacobian({x: shared * np.array([1.0, 0.0])})])
+    xv = jnp.array([1.0, 2.0])
+
+    np.testing.assert_allclose(fn(xv, jnp.zeros(0), 0, {}), 6.0)
+    np.testing.assert_allclose(jax.jacfwd(fn, argnums=0)(xv, jnp.zeros(0), 0, {}), [5.0, 0.0])
+
+
+def test_batched_jacobian_matches_the_constraint_lowering_pattern():
+    """`_lower_jax_constraints` vmaps jacfwd over the node axis; overrides survive."""
+    x = _sliced_state("x", 2, 0)
+    u = _sliced_control("u", 1, 0)
+    body = Sum(x * x) + Sum(u * u)
+
+    (fn,) = lower_to_jax([body.with_jacobian({x: np.zeros(2)})])
+    X = jnp.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+    U = jnp.array([[1.0], [2.0], [3.0]])
+
+    grad_x = jax.vmap(jax.jacfwd(fn, argnums=0), in_axes=(0, 0, None, None))(X, U, 0, {})
+    grad_u = jax.vmap(jax.jacfwd(fn, argnums=1), in_axes=(0, 0, None, None))(X, U, 0, {})
+
+    np.testing.assert_allclose(grad_x, np.zeros((3, 2)))
+    np.testing.assert_allclose(grad_u, 2.0 * np.asarray(U))
+
+
+def test_jit_traces_the_override():
+    x = _sliced_state("x", 2, 0)
+    (fn,) = lower_to_jax([Sum(x * x).with_jacobian({x: np.zeros(2)})])
+
+    jitted = jax.jit(jax.jacfwd(fn, argnums=0), static_argnums=(2,))
+    np.testing.assert_allclose(jitted(jnp.array([1.0, 2.0]), jnp.zeros(0), 0, {}), [0.0, 0.0])
+
+
+def test_time_override_behaves_like_a_state_override():
+    t = Time(initial=0.0, final=1.0, min=0.0, max=2.0)
+    t._slice = slice(0, 1)
+
+    (fn,) = lower_to_jax([Sum(t * t).with_jacobian({t: np.array([3.0])})])
+    grad = jax.jacfwd(fn, argnums=0)(jnp.array([2.0]), jnp.zeros(0), 0, {})
+
+    np.testing.assert_allclose(grad, [3.0])
+
+
+def test_lowering_without_a_slice_raises():
+    x = State("x", shape=(2,))
+
+    with pytest.raises(ValueError) as excinfo:
+        lower_to_jax([Sum(x).with_jacobian({x: np.zeros(2)})])
+
+    assert "slice" in str(excinfo.value)
+
+
+# =============================================================================
+# Problem Integration
+# =============================================================================
+
+
+def _drag_problem(N, override):
+    """1-D double integrator with a quadratic drag term on the velocity dynamics.
+
+    ``override`` selects whether the drag term carries a (zeroed) Jacobian
+    override, so the two builds differ only in how they linearize.
+    """
+    import openscvx as ox
+
+    pos = State("pos", shape=(1,))
+    pos.min, pos.max = np.array([-10.0]), np.array([10.0])
+    pos.initial, pos.final = np.array([0.0]), np.array([1.0])
+
+    vel = State("vel", shape=(1,))
+    vel.min, vel.max = np.array([-5.0]), np.array([5.0])
+    vel.initial, vel.final = np.array([0.0]), np.array([0.0])
+
+    accel = Control("accel", shape=(1,))
+    accel.min, accel.max = np.array([-2.0]), np.array([2.0])
+    accel.guess = np.zeros((N, 1))
+
+    drag = -0.1 * vel * vel
+    if override:
+        drag = drag.with_jacobian({vel: np.zeros((1, 1))})
+
+    problem = ox.Problem(
+        dynamics={"pos": vel, "vel": accel + drag},
+        states=[pos, vel],
+        controls=[accel],
+        constraints=[],
+        N=N,
+        time=Time(initial=0.0, final=2.0, min=0.0, max=4.0),
+        algorithm={"k_max": 2},
+    )
+    problem.settings.dev.printing = False
+    problem.initialize()
+    return problem, vel
+
+
+def test_dynamics_jacobian_reflects_the_override():
+    """The state Jacobian the discretizer builds (`jacfwd(dynamics.f, 0)`) is overridden."""
+    plain, vel = _drag_problem(6, override=False)
+    wrapped, vel_w = _drag_problem(6, override=True)
+
+    x = jnp.zeros(plain._lowered.x_unified.initial.shape[0]).at[vel._slice].set(3.0)
+    # Unit controls, so the time-dilation factor multiplying f is 1 and the
+    # Jacobian entries are the bare partials.
+    u = jnp.ones(plain._lowered.u_unified.guess.shape[1])
+
+    A_plain = jax.jacfwd(plain._lowered.dynamics.f, argnums=0)(x, u, 0, {})
+    A_wrapped = jax.jacfwd(wrapped._lowered.dynamics.f, argnums=0)(x, u, 0, {})
+
+    vel_row, vel_col = vel._slice.start, vel._slice.start
+    # d(vel_dot)/d(vel) is -0.2 * vel = -0.6 exactly, and 0 once overridden.
+    np.testing.assert_allclose(A_plain[vel_row, vel_col], -0.6, rtol=1e-6)
+    np.testing.assert_allclose(A_wrapped[vel_row, vel_col], 0.0, atol=1e-12)
+    # Nothing else moves: the two Jacobians agree away from the overridden entry.
+    delta = np.asarray(A_wrapped) - np.asarray(A_plain)
+    delta[vel_row, vel_col] = 0.0
+    np.testing.assert_allclose(delta, 0.0, atol=1e-12)
+    assert vel_w._slice == vel._slice
+
+    jax.clear_caches()
+
+
+def test_problem_with_an_overridden_jacobian_solves():
+    problem, _ = _drag_problem(6, override=True)
+
+    problem.solve()
+
+    assert problem.state.x.shape[0] == 6
+    jax.clear_caches()
+
+
+# =============================================================================
+# Other Backends
+# =============================================================================
+
+
+def test_cvxpy_lowering_raises_a_teaching_error():
+    import cvxpy as cp
+
+    from openscvx.symbolic.lowerers.cvxpy import lower_to_cvxpy
+
+    x = _sliced_state("x", 2, 0)
+    constraint = Sum(x).with_jacobian({x: np.zeros(2)}) <= 1.0
+
+    with pytest.raises(NotImplementedError) as excinfo:
+        lower_to_cvxpy(constraint, {"x": cp.Variable(2)})
+
+    msg = str(excinfo.value)
+    assert "with_jacobian" in msg and "CVXPy" in msg
+
+
+def test_latex_renders_the_wrapped_expression_unchanged():
+    x = _sliced_state("x", 2, 0)
+    body = Sum(x * x)
+
+    assert to_latex(body.with_jacobian({x: np.zeros(2)})) == to_latex(body)


### PR DESCRIPTION
Closes #518. Last in the #476 stack — **based on #582** (which is based on #581); review those first.

## What

```python
drag = -0.5 * rho * ox.linalg.Norm(vel) * vel
dynamics = {"vel": thrust / m + drag.with_jacobian({vel: J_simplified}), ...}
```

`expr.with_jacobian({var: J_expr})` wraps a subexpression in a `WithJacobian` node: the wrapped term's derivative w.r.t. each overridden variable comes from the user's Jacobian expression, while every non-overridden direction still autodiffs. Motivating use: deliberately simplified/inexact Jacobians for SCP conditioning, at sub-expression granularity. Same fluent idiom as `.over()`/`.at()`/`.convex()`.

## How

The JAX lowering emits a `jax.custom_jvp` rule inside the lowered function (zero the overridden tangent slices, `jax.jvp` the inner expression, add `J @ dvar` per override), so the discretizer's `jacfwd`, constraint linearization, and sparse coloring pick the override up with no further plumbing — verified down to the A-matrix entry in tests. Overrides are visible in the tree: they hash structurally, survive canonicalization, and shape-check at build time. CVXPy lowering rejects the wrapper with a teaching error; LaTeX renders the wrapped expression unchanged.

## Notes for review

- `Variable.__hash__ = object.__hash__` is restored (with a comment): `Expr.__eq__` builds an `Equality`, which had made States/Controls unhashable — identity hashing is required for `{vel: J}` dict keys and matches variables-as-identities semantics.
- `WithJacobian.sparsity()` is overridden: the children-union default is **not** a conservative superset here (a constant Jacobian has empty sparsity of its own yet couples the whole output to the overridden variable), so the override ORs the variable's columns into all output rows.
- `check_shape` compares with unit axes dropped and the visitor reshapes lowered Jacobians, accommodating `Constant`'s squeeze-on-construction.
- No string/YAML dialect for this node.

## Testing

30 new tests (`tests/symbolic/expr/test_autodiff.py`): node mechanics, exact-override and partial-override gradients (incl. vector/tensordot path), composition inside larger expressions (chain rule through the override), vmap compatibility, discretizer-level A-matrix comparison, an end-to-end solve, and the CVXPy teaching error. Full symbolic + discretization sweeps green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5WX9YVDJr8qmZd8z3DM1V