### PR TITLE
Loosen Cinterp no-recompile test atol to float32 resolution

### DIFF
--- a/tests/symbolic/expr/test_math.py
+++ b/tests/symbolic/expr/test_math.py
@@ -3611,8 +3611,10 @@ def test_cinterp_symbolic_coeffs_update_between_evals_no_recompile():
     result_a = fn(None, None, None, {"c": _reverse_coeffs(cs_a)})
     result_b = fn(None, None, None, {"c": _reverse_coeffs(cs_b)})
 
-    assert jnp.allclose(result_a, cs_a(query))
-    assert jnp.allclose(result_b, cs_b(query))
+    # float32 evaluation cannot pin the fp_b endpoint (exactly 0) tighter than
+    # ~1 ulp of the O(1) coefficients, so the default atol=1e-8 is unattainable.
+    assert jnp.allclose(result_a, cs_a(query), atol=1e-6)
+    assert jnp.allclose(result_b, cs_b(query), atol=1e-6)
     assert not jnp.allclose(result_a, result_b)
 
 


### PR DESCRIPTION
Fixes the ubuntu CI failures first seen on #582 (`test_cinterp_symbolic_coeffs_update_between_evals_no_recompile`, from #578).

The test compares a float32 JAX evaluation against a float64 scipy `PchipInterpolator` reference whose final sample is exactly `0.0`. A float32 spline evaluation from O(1) coefficients cannot land closer to zero than ~1 ulp (`1.19e-7`), so `jnp.allclose`'s default `atol=1e-8` only passed when XLA's instruction ordering happened to cancel the roundoff. #582 adds an unrelated test file, which shifted pytest-xdist scheduling on ubuntu runners and flipped the outcome — main passed the identical workflow two minutes before #582's run failed, ruling out dependency drift. Every other sample agrees to ~7 significant digits.

Test-only change: `atol=1e-6` (float32-appropriate) on the two reference comparisons, with a comment explaining why. The `not allclose(result_a, result_b)` assert compares O(1)-different curves and is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5WX9YVDJr8qmZd8z3DM1V